### PR TITLE
feat: add token schema definitions for regulated money, land, and art

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -3,3 +3,18 @@
 This folder contains the schemas 'recommended' for representing different type of assets in the digital way.
 
 If your digital asset is not found here, feel free to open a PR to add it.
+
+## Available Schemas
+
+| Schema | Token Type | Fungibility | Description |
+| ------ | ---------- | ----------- | ----------- |
+| [regulated-money.yaml](./regulated-money.yaml) | Regulated Money | Fungible | Fiat currency issued by regulated financial institutions (e.g., CBDC, tokenized bank deposits) |
+| [land.yaml](./land.yaml) | Land | Non-Fungible | Tokenized land parcels backed by government land records |
+| [art.yaml](./art.yaml) | Art | Non-Fungible (Self-Attested) | Self-tokenized artwork with optional third-party attestations |
+
+## Schema Design Principles
+
+- **Consistent structure**: All token schemas share common fields (`token_id`, `token_type`, `fungible`, `issuer`, `holder_id`, `status`, `allowed_verbs`)
+- **Finternet verbs**: The `allowed_verbs` field maps to Finternet operations (`transfer`, `pledge`, `lease`, `nominate`, etc.)
+- **DID-based identity**: Issuers and holders are identified using decentralized identifiers (DIDs)
+- **OpenAPI 3.0.3**: All schemas follow the OpenAPI specification for interoperability

--- a/schemas/art.yaml
+++ b/schemas/art.yaml
@@ -1,0 +1,314 @@
+openapi: "3.0.3"
+info:
+  title: "Art Token - Self-Attested Token Schema"
+  description: |
+    Schema definition for a tokenized art asset on the Finternet.
+    Art tokens represent self-attested, self-tokenized assets where the creator or
+    owner initiates tokenization without requiring a regulated institution.
+
+    This covers physical artworks (paintings, sculptures) and digital art that
+    are tokenized for provenance tracking, transfer, and potential use as collateral.
+  version: "0.1.0"
+
+components:
+  schemas:
+    ArtToken:
+      type: object
+      description: |
+        A self-attested token representing an artwork.
+        Unlike regulated tokens, art tokens are created by the asset owner themselves,
+        with optional third-party attestations for authenticity.
+      required:
+        - token_id
+        - token_type
+        - art_info
+        - creator
+        - holder_id
+        - status
+      properties:
+        token_id:
+          type: string
+          format: uuid
+          description: "Unique identifier for this art token"
+          example: "a3bb189e-8bf9-3888-9912-ace4e6543002"
+        token_type:
+          type: string
+          enum:
+            - art
+          description: "Type identifier for this token category"
+        fungible:
+          type: boolean
+          default: false
+          description: "Indicates this is a non-fungible token - always false for art"
+        self_attested:
+          type: boolean
+          default: true
+          description: "Indicates this token was self-attested by the creator/owner"
+        art_info:
+          $ref: "#/components/schemas/ArtInfo"
+        creator:
+          $ref: "#/components/schemas/ArtCreator"
+        holder_id:
+          type: string
+          description: "DID or account address of the current token holder"
+          example: "did:finternet:holder:collector-001"
+        issuer:
+          $ref: "#/components/schemas/ArtIssuer"
+        valuation:
+          $ref: "#/components/schemas/ArtValuation"
+        provenance:
+          type: array
+          description: "Chain of custody / ownership history"
+          items:
+            $ref: "#/components/schemas/ProvenanceRecord"
+        attestations:
+          type: array
+          description: "Third-party attestations of authenticity or appraisal"
+          items:
+            $ref: "#/components/schemas/Attestation"
+        status:
+          type: string
+          enum:
+            - active
+            - pledged
+            - transferred
+            - burned
+            - disputed
+          description: "Current lifecycle status of the art token"
+        allowed_verbs:
+          type: array
+          description: "Permitted operations on this token"
+          items:
+            type: string
+            enum:
+              - transfer
+              - pledge
+              - lease
+              - burn
+          example:
+            - transfer
+            - pledge
+        metadata:
+          $ref: "#/components/schemas/ArtTokenMetadata"
+        created_at:
+          type: string
+          format: date-time
+          description: "Timestamp of token creation"
+        updated_at:
+          type: string
+          format: date-time
+          description: "Timestamp of last state change"
+
+    ArtInfo:
+      type: object
+      description: "Details about the artwork"
+      required:
+        - title
+        - medium
+      properties:
+        title:
+          type: string
+          description: "Title of the artwork"
+          example: "Sunset Over the Ganges"
+        description:
+          type: string
+          description: "Detailed description of the artwork"
+        medium:
+          type: string
+          enum:
+            - painting
+            - sculpture
+            - digital
+            - photography
+            - mixed_media
+            - print
+            - textile
+            - ceramic
+          description: "Art medium or form"
+        dimensions:
+          type: object
+          description: "Physical dimensions of the artwork"
+          properties:
+            height:
+              type: number
+              format: double
+              description: "Height in centimeters"
+            width:
+              type: number
+              format: double
+              description: "Width in centimeters"
+            depth:
+              type: number
+              format: double
+              description: "Depth in centimeters (for sculptures)"
+            unit:
+              type: string
+              enum:
+                - cm
+                - inches
+              default: cm
+        year_created:
+          type: integer
+          description: "Year the artwork was created"
+          example: 2024
+        edition:
+          type: object
+          description: "Edition details (for prints or limited editions)"
+          properties:
+            edition_number:
+              type: integer
+              description: "This item's edition number"
+            total_editions:
+              type: integer
+              description: "Total number of editions"
+        image_hash:
+          type: string
+          description: "SHA-256 hash of the artwork's primary image for integrity verification"
+        image_url:
+          type: string
+          format: uri
+          description: "URL to a digital image of the artwork"
+
+    ArtCreator:
+      type: object
+      description: "The artist or creator of the artwork"
+      required:
+        - creator_id
+        - name
+      properties:
+        creator_id:
+          type: string
+          description: "DID or identifier of the creator"
+          example: "did:finternet:creator:artist-001"
+        name:
+          type: string
+          description: "Name of the artist"
+          example: "Ravi Varma"
+        nationality:
+          type: string
+          description: "ISO 3166-1 alpha-2 country code"
+          pattern: "^[A-Z]{2}$"
+          example: "IN"
+
+    ArtIssuer:
+      type: object
+      description: |
+        For self-attested tokens, the issuer is the creator or current owner themselves.
+        No regulated institution is required.
+      properties:
+        issuer_id:
+          type: string
+          description: "DID of the self-attesting owner (same as creator or holder)"
+          example: "did:finternet:holder:collector-001"
+        name:
+          type: string
+          description: "Name of the person self-attesting"
+        type:
+          type: string
+          enum:
+            - self_attested
+            - gallery
+            - auction_house
+          description: "Type of issuer"
+          default: self_attested
+
+    ArtValuation:
+      type: object
+      description: "Valuation details for the artwork"
+      properties:
+        estimated_value:
+          type: string
+          description: "Estimated market value"
+          example: "250000.00"
+        currency_code:
+          type: string
+          description: "ISO 4217 currency code"
+          pattern: "^[A-Z]{3}$"
+          example: "INR"
+        valuation_date:
+          type: string
+          format: date
+        appraiser:
+          type: string
+          description: "Entity that performed the appraisal (if any)"
+        insurance_value:
+          type: string
+          description: "Insured value (if applicable)"
+
+    ProvenanceRecord:
+      type: object
+      description: "A record in the artwork's chain of custody"
+      properties:
+        event_type:
+          type: string
+          enum:
+            - created
+            - sold
+            - gifted
+            - inherited
+            - auctioned
+            - restored
+          description: "Type of provenance event"
+        from_holder:
+          type: string
+          description: "Previous holder (DID or name)"
+        to_holder:
+          type: string
+          description: "New holder (DID or name)"
+        date:
+          type: string
+          format: date
+          description: "Date of the event"
+        transaction_ref:
+          type: string
+          description: "Reference to the on-ledger transaction"
+        notes:
+          type: string
+          description: "Additional notes about this event"
+
+    Attestation:
+      type: object
+      description: "A third-party attestation of authenticity, condition, or appraisal"
+      properties:
+        attestation_id:
+          type: string
+          description: "Unique identifier for this attestation"
+        type:
+          type: string
+          enum:
+            - authenticity
+            - appraisal
+            - condition_report
+            - provenance_verification
+          description: "Type of attestation"
+        attester_id:
+          type: string
+          description: "DID of the attesting entity"
+        attester_name:
+          type: string
+          description: "Name of the attesting entity"
+          example: "National Gallery of Modern Art"
+        date:
+          type: string
+          format: date
+        signature:
+          type: string
+          description: "Digital signature of the attestation"
+        document_hash:
+          type: string
+          description: "SHA-256 hash of the attestation document"
+
+    ArtTokenMetadata:
+      type: object
+      description: "Additional metadata for the art token"
+      properties:
+        ledger_id:
+          type: string
+          description: "Identifier of the ledger where this token is recorded"
+        proof_anchor:
+          type: string
+          description: "Reference to the on-chain proof of this token's state"
+        version:
+          type: integer
+          description: "Version number for optimistic concurrency control"
+          minimum: 1

--- a/schemas/land.yaml
+++ b/schemas/land.yaml
@@ -1,0 +1,339 @@
+openapi: "3.0.3"
+info:
+  title: "Land Token - Non-Fungible Token Schema"
+  description: |
+    Schema definition for a tokenized land asset on the Finternet.
+    Land is a non-fungible asset - each parcel is unique with distinct geographic,
+    legal, and valuation properties. Tokenizing land on the Finternet enables
+    use cases like pledging land to obtain commercial loans, transferring ownership,
+    and cross-jurisdictional property management.
+  version: "0.1.0"
+
+components:
+  schemas:
+    LandToken:
+      type: object
+      description: |
+        A non-fungible token representing a land parcel or property.
+        Each token is unique and maps to a specific real-world land record.
+      required:
+        - token_id
+        - token_type
+        - parcel_info
+        - ownership
+        - issuer
+        - status
+      properties:
+        token_id:
+          type: string
+          format: uuid
+          description: "Unique identifier for this land token"
+          example: "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+        token_type:
+          type: string
+          enum:
+            - land
+          description: "Type identifier for this token category"
+        fungible:
+          type: boolean
+          default: false
+          description: "Indicates this is a non-fungible token - always false for land"
+        parcel_info:
+          $ref: "#/components/schemas/ParcelInfo"
+        ownership:
+          $ref: "#/components/schemas/OwnershipInfo"
+        issuer:
+          $ref: "#/components/schemas/LandIssuer"
+        valuation:
+          $ref: "#/components/schemas/ValuationInfo"
+        encumbrances:
+          type: array
+          description: "Existing encumbrances or liens on the property"
+          items:
+            $ref: "#/components/schemas/Encumbrance"
+        status:
+          type: string
+          enum:
+            - active
+            - pledged
+            - disputed
+            - transferred
+            - frozen
+          description: "Current lifecycle status of the land token"
+        allowed_verbs:
+          type: array
+          description: "Permitted operations on this token"
+          items:
+            type: string
+            enum:
+              - transfer
+              - pledge
+              - lease
+              - nominate
+              - subdivide
+              - merge
+          example:
+            - transfer
+            - pledge
+            - lease
+        legal_documents:
+          type: array
+          description: "References to legal documents backing this token"
+          items:
+            $ref: "#/components/schemas/DocumentReference"
+        metadata:
+          $ref: "#/components/schemas/LandTokenMetadata"
+        created_at:
+          type: string
+          format: date-time
+          description: "Timestamp of token creation (tokenization date)"
+        updated_at:
+          type: string
+          format: date-time
+          description: "Timestamp of last state change"
+
+    ParcelInfo:
+      type: object
+      description: "Geographic and identification details of the land parcel"
+      required:
+        - parcel_id
+        - area
+        - area_unit
+        - location
+      properties:
+        parcel_id:
+          type: string
+          description: "Official land record / survey number"
+          example: "SY-142/3A"
+        area:
+          type: number
+          format: double
+          description: "Total area of the parcel"
+          example: 2.5
+        area_unit:
+          type: string
+          enum:
+            - sq_meters
+            - sq_feet
+            - acres
+            - hectares
+          description: "Unit of measurement for the area"
+        location:
+          $ref: "#/components/schemas/Location"
+        land_use:
+          type: string
+          enum:
+            - residential
+            - commercial
+            - agricultural
+            - industrial
+            - mixed_use
+          description: "Designated land use classification"
+        boundaries:
+          type: string
+          description: "GeoJSON string representing the parcel boundaries"
+
+    Location:
+      type: object
+      description: "Geographic location details"
+      required:
+        - country
+      properties:
+        country:
+          type: string
+          description: "ISO 3166-1 alpha-2 country code"
+          pattern: "^[A-Z]{2}$"
+          example: "IN"
+        state:
+          type: string
+          description: "State or province"
+          example: "Karnataka"
+        district:
+          type: string
+          description: "District or county"
+          example: "Bengaluru Urban"
+        sub_district:
+          type: string
+          description: "Sub-district or taluk"
+        village:
+          type: string
+          description: "Village or locality"
+        pin_code:
+          type: string
+          description: "Postal / ZIP code"
+          example: "560001"
+        latitude:
+          type: number
+          format: double
+          description: "Latitude coordinate"
+          example: 12.9716
+        longitude:
+          type: number
+          format: double
+          description: "Longitude coordinate"
+          example: 77.5946
+
+    OwnershipInfo:
+      type: object
+      description: "Ownership details of the land"
+      required:
+        - holder_id
+        - ownership_type
+      properties:
+        holder_id:
+          type: string
+          description: "DID or account address of the current owner"
+          example: "did:finternet:holder:land-owner-001"
+        ownership_type:
+          type: string
+          enum:
+            - freehold
+            - leasehold
+            - joint
+            - government
+          description: "Type of ownership"
+        co_owners:
+          type: array
+          description: "List of co-owners if jointly held"
+          items:
+            type: object
+            properties:
+              holder_id:
+                type: string
+              share_percentage:
+                type: number
+                format: double
+                minimum: 0
+                maximum: 100
+        acquisition_date:
+          type: string
+          format: date
+          description: "Date the current owner acquired the property"
+
+    LandIssuer:
+      type: object
+      description: "The authority that tokenized this land record"
+      required:
+        - issuer_id
+        - name
+        - type
+      properties:
+        issuer_id:
+          type: string
+          description: "DID or identifier of the issuing authority"
+          example: "did:finternet:issuer:karnataka-land-registry"
+        name:
+          type: string
+          description: "Name of the issuing authority"
+          example: "Karnataka Land Records Authority"
+        type:
+          type: string
+          enum:
+            - government_registry
+            - land_authority
+            - revenue_department
+          description: "Type of issuing authority"
+        jurisdiction:
+          type: string
+          description: "ISO 3166-1 alpha-2 country code"
+          example: "IN"
+
+    ValuationInfo:
+      type: object
+      description: "Valuation details for the land"
+      properties:
+        market_value:
+          type: string
+          description: "Estimated market value"
+          example: "5000000.00"
+        guidance_value:
+          type: string
+          description: "Government guidance / circle rate value"
+          example: "3500000.00"
+        currency_code:
+          type: string
+          description: "ISO 4217 currency code for the valuation"
+          pattern: "^[A-Z]{3}$"
+          example: "INR"
+        valuation_date:
+          type: string
+          format: date
+          description: "Date of the last valuation"
+        valuator:
+          type: string
+          description: "Entity that performed the valuation"
+
+    Encumbrance:
+      type: object
+      description: "An existing encumbrance, lien, or charge on the property"
+      properties:
+        encumbrance_id:
+          type: string
+          description: "Unique identifier for this encumbrance"
+        type:
+          type: string
+          enum:
+            - mortgage
+            - lien
+            - easement
+            - lease
+            - court_order
+          description: "Type of encumbrance"
+        beneficiary:
+          type: string
+          description: "Entity holding the encumbrance"
+        amount:
+          type: string
+          description: "Amount involved (if applicable)"
+        start_date:
+          type: string
+          format: date
+        end_date:
+          type: string
+          format: date
+
+    DocumentReference:
+      type: object
+      description: "Reference to a legal document"
+      properties:
+        document_id:
+          type: string
+          description: "Unique document identifier"
+        document_type:
+          type: string
+          enum:
+            - title_deed
+            - sale_deed
+            - mutation_record
+            - encumbrance_certificate
+            - survey_map
+            - tax_receipt
+          description: "Type of legal document"
+        document_hash:
+          type: string
+          description: "SHA-256 hash of the document for integrity verification"
+        issued_by:
+          type: string
+          description: "Authority that issued the document"
+        issued_date:
+          type: string
+          format: date
+
+    LandTokenMetadata:
+      type: object
+      description: "Additional metadata for the land token"
+      properties:
+        ledger_id:
+          type: string
+          description: "Identifier of the ledger where this token is recorded"
+        proof_anchor:
+          type: string
+          description: "Reference to the on-chain proof of this token's state"
+        source_record_url:
+          type: string
+          format: uri
+          description: "URL to the original land record in the government registry"
+        version:
+          type: integer
+          description: "Version number for optimistic concurrency control"
+          minimum: 1

--- a/schemas/regulated-money.yaml
+++ b/schemas/regulated-money.yaml
@@ -1,0 +1,169 @@
+openapi: "3.0.3"
+info:
+  title: "Regulated Money - Fungible Token Schema"
+  description: |
+    Schema definition for a regulated money token on the Finternet.
+    Regulated money represents fiat currency issued by a regulated financial institution
+    (e.g., central bank digital currency, commercial bank money) and tokenized for use
+    on the Finternet unified ledger.
+
+    This is a fungible token - each unit is interchangeable with any other unit of the
+    same currency and denomination.
+  version: "0.1.0"
+
+components:
+  schemas:
+    RegulatedMoney:
+      type: object
+      description: |
+        A fungible token representing regulated money (e.g., digital rupee, tokenized bank deposit).
+        Follows the Finternet asset model with additional properties specific to regulated currencies.
+      required:
+        - token_id
+        - token_type
+        - currency_code
+        - amount
+        - issuer
+        - holder_id
+        - status
+      properties:
+        token_id:
+          type: string
+          format: uuid
+          description: "Unique identifier for this token instance"
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        token_type:
+          type: string
+          enum:
+            - regulated_money
+          description: "Type identifier for this token category"
+        fungible:
+          type: boolean
+          default: true
+          description: "Indicates this is a fungible token - always true for regulated money"
+        currency_code:
+          type: string
+          description: "ISO 4217 currency code"
+          pattern: "^[A-Z]{3}$"
+          example: "INR"
+        amount:
+          type: string
+          description: "Token amount represented as a string to avoid floating-point precision issues"
+          pattern: "^[0-9]+(\\.[0-9]{1,18})?$"
+          example: "1000.50"
+        denomination:
+          type: string
+          description: "Smallest unit of the currency (e.g., paise for INR, cents for USD)"
+          example: "paise"
+        issuer:
+          $ref: "#/components/schemas/RegulatedIssuer"
+        holder_id:
+          type: string
+          description: "DID or account address of the current token holder"
+          example: "did:finternet:holder:abc123"
+        status:
+          type: string
+          enum:
+            - active
+            - frozen
+            - redeemed
+            - expired
+          description: "Current lifecycle status of the token"
+        allowed_verbs:
+          type: array
+          description: "Permitted operations on this token"
+          items:
+            type: string
+            enum:
+              - transfer
+              - pledge
+              - redeem
+              - freeze
+              - unfreeze
+          example:
+            - transfer
+            - pledge
+            - redeem
+        regulatory_info:
+          $ref: "#/components/schemas/RegulatoryInfo"
+        metadata:
+          $ref: "#/components/schemas/TokenMetadata"
+        created_at:
+          type: string
+          format: date-time
+          description: "Timestamp of token issuance"
+        updated_at:
+          type: string
+          format: date-time
+          description: "Timestamp of last state change"
+
+    RegulatedIssuer:
+      type: object
+      description: "The regulated institution that issued this money token"
+      required:
+        - issuer_id
+        - name
+        - type
+      properties:
+        issuer_id:
+          type: string
+          description: "DID or identifier of the issuing institution"
+          example: "did:finternet:issuer:rbi-001"
+        name:
+          type: string
+          description: "Name of the issuing institution"
+          example: "Reserve Bank of India"
+        type:
+          type: string
+          enum:
+            - central_bank
+            - commercial_bank
+            - payment_bank
+            - nbfc
+          description: "Type of regulated institution"
+        jurisdiction:
+          type: string
+          description: "ISO 3166-1 alpha-2 country code of the regulatory jurisdiction"
+          pattern: "^[A-Z]{2}$"
+          example: "IN"
+        license_id:
+          type: string
+          description: "Regulatory license or registration identifier"
+
+    RegulatoryInfo:
+      type: object
+      description: "Regulatory compliance metadata"
+      properties:
+        regulation_type:
+          type: string
+          description: "Applicable regulatory framework"
+          example: "RBI Digital Currency Guidelines"
+        aml_verified:
+          type: boolean
+          description: "Whether AML checks have been completed"
+        kyc_level:
+          type: string
+          enum:
+            - none
+            - basic
+            - full
+          description: "KYC verification level of the holder"
+        daily_transaction_limit:
+          type: string
+          description: "Maximum daily transaction amount"
+          example: "200000.00"
+
+    TokenMetadata:
+      type: object
+      description: "Additional metadata for the token"
+      properties:
+        ledger_id:
+          type: string
+          description: "Identifier of the ledger where this token is recorded"
+        proof_anchor:
+          type: string
+          description: "Reference to the on-chain proof of this token's state"
+        version:
+          type: integer
+          description: "Version number for optimistic concurrency control"
+          minimum: 1


### PR DESCRIPTION
## Summary
Addresses #4 — adds three token schema definitions as requested:

- **Regulated Money** (`schemas/regulated-money.yaml`) — Fungible token for fiat currency issued by regulated institutions (central banks, commercial banks). Includes regulatory compliance metadata, KYC levels, and transaction limits.
- **Land** (`schemas/land.yaml`) — Non-fungible token for land parcels. Includes geographic info, ownership details, encumbrances, valuation, and legal document references. Supports the "pledge land for commercial loan" use case from the roadmap.
- **Art** (`schemas/art.yaml`) — Self-attested non-fungible token for artwork. Includes provenance chain, optional third-party attestations, and creator metadata.

## Design Decisions
- All schemas share consistent common fields (`token_id`, `token_type`, `fungible`, `issuer`, `holder_id`, `status`, `allowed_verbs`) aligned with the existing `Asset` and `AssetType` models in `api/application-interfaces.yaml`
- `allowed_verbs` map to Finternet operations (transfer, pledge, lease, nominate) as described in the README
- DID-based identity for issuers and holders
- OpenAPI 3.0.3 format for consistency with existing specs
- Updated `schemas/README.md` with a table of available schemas

## Checklist
- [x] Regulated Money — fungible token schema
- [x] Land — non-fungible token schema
- [x] Art — self-attested token schema
- [x] Updated schemas/README.md