### PR TITLE
Sync OpenAPI reference with current units-api

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-schema.finternetlab.io

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+schema.finternetlab.io

--- a/api/README.md
+++ b/api/README.md
@@ -13,6 +13,10 @@ OpenAPI specifications for the Finternet Developer Platform.
 | `key-management-interfaces.yaml` | Cryptographic key lifecycle management |
 | `token-interfaces.yaml` | Token lifecycle, transactions, and token classes |
 | `token-class-config-interfaces.yaml` | Mapping between a token class and its token program (hooks, overrides) |
+| `token-program-interfaces.yaml` | Token program registry |
+| `scopes-interfaces.yaml` | RBAC scope catalogue and scope-approval requests |
+| `terms-interfaces.yaml` | Terms of service and consent |
+| `workflows-interfaces.yaml` | Durable (Restate) workflow execution and status |
 | `adapter-interface.yaml` | Chain adapter interface |
 
 ## API Design
@@ -27,13 +31,13 @@ All APIs follow a consistent **envelope pattern** for protocol-agnostic communic
     "version": "1.0",
     "ts": "2025-01-04T10:00:00Z",
     "msgId": "unique-message-id",
-    "developerToken": "dev_pk_...",
+    "developerToken": "fnt_...",
     "authorization": "Bearer user_jwt..."
   },
   "payload": { },
   "signature": {
-    "type": "JsonWebSignature2020",
-    "jws": "..."
+    "key_id": "0f8fad5b-d9cb-469f-a165-70867728950e",
+    "jws": "base64-ed25519-signature-over-jcs(payload)"
   }
 }
 ```
@@ -68,4 +72,4 @@ Token operations are asynchronous:
 2. **Poll** — `POST /v1/transaction/status` → check status
 3. **Complete** — `POST /v1/transaction/get` for full details
 
-Status progression: `submitted → pending → executing → completed/failed/rolled_back`
+The base transaction `status` starts at `pending`; `POST /v1/transaction/status` returns it along with lifecycle timestamps (`submitted`, `started`, `completed`, `finalized`, `failed`). Federated transactions expose an extended lifecycle (`prepared`, `committing`, `committed`, …) via `POST /v1/transactions/status`.

--- a/api/accounts-interfaces.yaml
+++ b/api/accounts-interfaces.yaml
@@ -306,7 +306,7 @@ paths:
         - "Account"
       summary: "User login (OTP or SSO)"
       description: |
-        Three request shapes, selectable above:
+        Three payload shapes, selectable under `payload` below:
 
         * **Send OTP**: `username` only. Delivers a one-time code.
         * **Verify OTP**: `username` and `otp`. Returns a session token.
@@ -319,10 +319,7 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
-                - $ref: '#/components/schemas/ApiRequest_LoginSendOTP'
-                - $ref: '#/components/schemas/ApiRequest_LoginVerifyOTP'
-                - $ref: '#/components/schemas/ApiRequest_LoginSSO'
+              $ref: '#/components/schemas/ApiRequest_LoginRequest'
             examples:
               InitiateOTPMobile:
                 summary: "Send OTP (mobile)"
@@ -976,9 +973,15 @@ components:
     ApiRequest_RegistrationRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/RegistrationRequest' } } } ] }
     ApiRequest_UpdateAccountRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/UpdateAccountRequest' } } } ] }
     ApiRequest_AvailabilityCheckRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/AvailabilityCheckRequest' } } } ] }
-    ApiRequest_LoginSendOTP: { title: "Send OTP", allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/LoginSendOTPRequest' } } } ] }
-    ApiRequest_LoginVerifyOTP: { title: "Verify OTP", allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/LoginVerifyOTPRequest' } } } ] }
-    ApiRequest_LoginSSO: { title: "SSO login", allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/LoginSSORequest' } } } ] }
+    ApiRequest_LoginRequest:
+      allOf:
+        - $ref: '#/components/schemas/RequestContext'
+        - properties:
+            payload:
+              oneOf:
+                - $ref: '#/components/schemas/LoginSendOTPRequest'
+                - $ref: '#/components/schemas/LoginVerifyOTPRequest'
+                - $ref: '#/components/schemas/LoginSSORequest'
     ApiRequest_ResolveRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/ResolveRequest' } } } ] }
     ApiRequest_OTPVerifyRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/OTPVerifyRequest' } } } ] }
     ApiRequest_DecryptPIIRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/DecryptPIIRequest' } } } ] }

--- a/api/accounts-interfaces.yaml
+++ b/api/accounts-interfaces.yaml
@@ -765,9 +765,9 @@ paths:
       summary: "Register an additional public key for the calling account"
       description: |
         Register a key reference for the authenticated account in the unified
-        `key_references` store. Supply `chainId` plus **exactly one** of
-        `publicKey` (standard keys) or `walletAddress` (the MetaMask/EVM exception,
-        used when only the on-chain wallet address is available, not the raw key).
+        `key_references` store. Supply `type` plus **exactly one** of
+        `publicKey` (hex- or base58-encoded key) or `address` (the MetaMask/EVM
+        exception, used when only the on-chain wallet address is available).
       security:
         - developerToken: []
         - developerSignature: []
@@ -786,9 +786,11 @@ paths:
                 developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
-                chainId: "eip155:1"
+                type: "ed25519"
                 publicKey: "3f8a1c9d2b7e0f4a6c5d8e9b0a1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c"
+                name: "Ledger Nano"
                 isPrimary: false
+                isDefault: false
       responses:
         '201':
           description: "Key registered in the unified key_references store."
@@ -807,7 +809,7 @@ paths:
       summary: "Remove a public key from the calling account"
       description: |
         Revoke a key reference from the account's unified `key_references` store,
-        identified by its `id`. The primary key (the one initially provisioned
+        identified by its `id` or `address`. The primary key (the one initially provisioned
         at registration) cannot be removed via this endpoint.
       security:
         - developerToken: []
@@ -836,7 +838,7 @@ paths:
       summary: "Get a single public key for the calling account"
       description: |
         Fetch a single key reference from the account's unified `key_references`
-        store, identified by its `id`.
+        store, identified by its `id` or `address`.
       security:
         - developerToken: []
         - developerSignature: []
@@ -863,8 +865,8 @@ paths:
       summary: "List/search public keys for an account"
       description: |
         Returns the key references bound to the calling account from the unified
-        `key_references` store, optionally filtered by `filters.chainId`/`filters.isPrimary`
-        and paginated with `limit`/`offset`.
+        `key_references` store, optionally filtered by `type`/`status` and paginated
+        with `limit`/`offset`.
       security:
         - developerToken: []
         - developerSignature: []
@@ -883,7 +885,8 @@ paths:
                 developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
-                filters: { chainId: "eip155:1", isPrimary: true }
+                type: "ed25519"
+                status: "active"
                 pagination: { limit: 20, offset: 0 }
       responses:
         '200':
@@ -932,9 +935,9 @@ components:
             - $ref: '#/components/schemas/ErrorPayload'
     Signature:
       type: object
-      required: [key_id, jws]
+      required: [keyId, jws]
       properties:
-        key_id: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
+        keyId: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
         jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object." }
     ErrorPayload:
       type: object
@@ -992,52 +995,64 @@ components:
     # --- Account Keys (unified key_references store) ---
     KeyRegistrationEntry:
       type: object
-      required: [id, chainId, address, isPrimary, createdAt, updatedAt]
+      required: [id, type, address, isPrimary, isDefault, status, createdAt, updatedAt]
       description: "A key reference from the account's unified `key_references` store."
       properties:
         id: { type: string, format: uuid }
-        chainId: { type: string, example: "eip155:1", description: "Chain the key/address belongs to." }
-        publicKey: { type: string, nullable: true, example: "3f8a1c9d...", description: "Hex-encoded raw public key. Null when only a wallet address was registered." }
+        name: { type: string, nullable: true, description: "Human-readable label; null for unnamed rows." }
+        type: { type: string, example: "ed25519", description: "Key type/algorithm." }
+        publicKeyHex: { type: string, nullable: true, example: "3f8a1c9d...", description: "Hex-encoded raw public key. Null for address-only (EVM) rows." }
         address: { type: string, example: "0xAbC1230000000000000000000000000000000000" }
         isPrimary: { type: boolean, example: true }
+        isDefault: { type: boolean, example: false }
+        did: { type: string, nullable: true, example: "did:key:z...", description: "Null for address-only rows (no pubkey → no DID)." }
+        status: { type: string, example: "active" }
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
     RegisterKeyRequest:
       type: object
-      required: [chainId]
+      required: [type]
       additionalProperties: false
       description: |
-        Supply `chainId` plus **exactly one** of `publicKey` (standard keys) or
-        `walletAddress` (the MetaMask/EVM exception, used when only the on-chain
+        Supply `type` plus **exactly one** of `publicKey` (hex- or base58-encoded
+        key) or `address` (the MetaMask/EVM exception, used when only the on-chain
         wallet address is available, not the raw public key).
-      anyOf:
+      oneOf:
         - required: [publicKey]
-        - required: [walletAddress]
+        - required: [address]
       properties:
-        chainId: { type: string, example: "eip155:1", description: "Chain the key/address belongs to." }
-        publicKey: { type: string, description: "Hex-encoded raw public key. Supply for standard keys." }
-        walletAddress: { type: string, description: "On-chain wallet address. MetaMask/EVM exception, used when the raw public key is unavailable." }
+        type: { type: string, enum: [ed25519, secp256k1], example: "ed25519", description: "Key type/algorithm." }
+        publicKey: { type: string, description: "Hex- or base58-encoded public key (auto-detected). Supply for standard keys." }
+        address: { type: string, description: "On-chain wallet address. MetaMask/EVM exception, used when the raw public key is unavailable." }
+        name: { type: string, description: "Human-readable label for the key." }
         isPrimary: { type: boolean }
+        isDefault: { type: boolean }
     RemoveKeyRequest:
       type: object
-      required: [id]
       additionalProperties: false
+      description: "Identify the key by **exactly one** of `id` (the key_references UUID) or `address` (the canonical family address)."
+      oneOf:
+        - required: [id]
+        - required: [address]
       properties:
-        id: { type: string, format: uuid, description: "ID of the key reference to remove." }
+        id: { type: string, format: uuid, description: "Key reference UUID." }
+        address: { type: string, minLength: 1, description: "Canonical family address." }
     GetKeyRequest:
       type: object
-      required: [id]
       additionalProperties: false
+      description: "Identify the key by **exactly one** of `id` or `address`."
+      oneOf:
+        - required: [id]
+        - required: [address]
       properties:
-        id: { type: string, format: uuid, description: "ID of the key reference to fetch." }
+        id: { type: string, format: uuid, description: "Key reference UUID." }
+        address: { type: string, minLength: 1, description: "Canonical family address." }
     SearchKeysRequest:
       type: object
+      additionalProperties: false
       properties:
-        filters:
-          type: object
-          properties:
-            chainId: { type: string, description: "Filter by chain." }
-            isPrimary: { type: boolean, description: "Filter by primary flag." }
+        type: { type: string, enum: [ed25519, secp256k1], description: "Filter by key type/algorithm." }
+        status: { type: string, description: "Filter by key status." }
         pagination:
           type: object
           properties:

--- a/api/accounts-interfaces.yaml
+++ b/api/accounts-interfaces.yaml
@@ -68,10 +68,9 @@ paths:
         - "Account"
       summary: "Register a new account"
       description: |
-        Create a new account. The email or mobile is taken from the token in
-        `context.authorization`, so it is not accepted in the payload.
-
-        Requires a user session token in `context.authorization`.
+        Create a new account. Requires the JWT returned by `/v1/account/login` in
+        `context.authorization`; the email or mobile is taken from it and is not accepted
+        in the payload.
       requestBody:
         required: true
         content:
@@ -428,7 +427,7 @@ paths:
       tags:
         - "Account"
       summary: "User logout"
-      description: "Invalidate the user's current session token. Requires a user session token in `context.authorization`."
+      description: "Invalidate the user's current session token, supplied in `context.authorization`."
       requestBody:
         required: true
         content:

--- a/api/accounts-interfaces.yaml
+++ b/api/accounts-interfaces.yaml
@@ -10,12 +10,12 @@ info:
 
     ### Authentication
 
-    * `context.developerToken`: the calling application's developer token. Required on
+    * `context.developerToken`: the developer token of the calling application. Required on
       every endpoint.
-    * `context.authorization`: the end user's session token. Required by the endpoints
-      that act on a signed-in user; each operation states when it is needed.
-    * `signature` (top level): the end user's JWS, for operations that must be
-      cryptographically signed by the user.
+    * `context.authorization`: the end user's session token. Required on the endpoints that
+      act on a signed-in user; each operation states when it is needed.
+    * `signature` (top level): the end user's JWS over the payload, for operations that must
+      be signed by the user.
 
     ### RBAC Scopes
 
@@ -70,8 +70,8 @@ paths:
       description: |
         Create a new account. The email or mobile is taken from the token in
         `context.authorization`, so it is not accepted in the payload.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -87,7 +87,7 @@ paths:
                     version: "v1"
                     ts: "2025-09-08T12:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     address: "alice"
@@ -101,7 +101,7 @@ paths:
                     version: "v1"
                     ts: "2025-09-08T12:01:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     address: "acmecorp"
@@ -175,9 +175,9 @@ paths:
         Update the profile of the signed-in user. The account is taken from the session
         token. `action` selects the step: `initiate` starts the update, the `verify_*`
         actions confirm a new contact with a one-time code, and `cancel` stops an update
-        that is in progress. Requires a user session token.
-      security:
-        - developerToken: []
+        that is in progress.
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -193,7 +193,7 @@ paths:
                     version: "v1"
                     ts: "2025-09-09T10:00:00Z"
                     msgId: "d1e2f3a4-b5c6-7890-1234-567890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer <End_User_JWT_Token>"
                   payload:
                     action: "initiate"
@@ -209,7 +209,7 @@ paths:
                     version: "v1"
                     ts: "2025-09-09T10:02:00Z"
                     msgId: "d3e4f5a6-b7c8-9012-3456-7890abcdef12"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer <End_User_JWT_Token>"
                   payload:
                     action: "verify_new_email"
@@ -225,7 +225,7 @@ paths:
                     version: "v1"
                     ts: "2025-09-09T10:05:00Z"
                     msgId: "d2e3f4a5-b6c7-8901-2345-67890abcdef1"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer <End_User_JWT_Token>"
                   payload:
                     action: "cancel"
@@ -268,8 +268,6 @@ paths:
       description: |
         Check whether an address is free to register. An address already registered on
         another federated instance is reported as unavailable.
-      security:
-        - developerToken: []
       requestBody:
         required: true
         content:
@@ -282,7 +280,7 @@ paths:
                 version: "v1"
                 ts: "2025-09-08T11:00:00Z"
                 msgId: "e1f2a3b4-c5d6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
               payload:
                 address: "newuser"
       responses:
@@ -314,8 +312,6 @@ paths:
           and `otp` to receive a session token.
         * **SSO**: send `username` and `authToken`, a JWT signed by your own backend, to
           receive a session token without a code.
-      security:
-        - developerToken: []
       requestBody:
         required: true
         content:
@@ -331,7 +327,7 @@ paths:
                     version: "v1"
                     ts: "2025-09-09T09:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     username: "+919876543210"
               InitiateOTPEmail:
@@ -342,7 +338,7 @@ paths:
                     version: "v1"
                     ts: "2025-09-09T09:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     username: "alice@example.com"
               VerifyOTP:
@@ -353,7 +349,7 @@ paths:
                     version: "v1"
                     ts: "2025-09-09T09:00:30Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     username: "alice@example.com"
                     otp: "1234"
@@ -365,7 +361,7 @@ paths:
                     version: "v1"
                     ts: "2025-09-09T09:00:00Z"
                     msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef23"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     username: "alice@example.com"
                     authToken: "eyJhbGciOiJFZERTQSJ9..."
@@ -430,9 +426,7 @@ paths:
       tags:
         - "Account"
       summary: "User logout"
-      description: "Invalidate the user's current session token. Requires a user session token."
-      security:
-        - developerToken: []
+      description: "Invalidate the user's current session token. Requires a user session token in `context.authorization`."
       requestBody:
         required: true
         content:
@@ -445,7 +439,7 @@ paths:
                 version: "v1"
                 ts: "2025-09-09T10:30:00Z"
                 msgId: "c1d2e3f4-a5b6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload: {}
       responses:
@@ -458,15 +452,12 @@ paths:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
 
-
   /v1/account/get:
     post:
       tags:
         - "Account"
       summary: "Get current account profile"
-      description: "Return the profile of the signed-in user. Requires a user session token."
-      security:
-        - developerToken: []
+      description: "Return the profile of the signed-in user. Requires a user session token in `context.authorization`."
       requestBody:
         required: true
         content:
@@ -479,7 +470,7 @@ paths:
                 version: "v1"
                 ts: "2025-09-09T09:05:00Z"
                 msgId: "e1f2a3b4-c5d6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload: {}
       responses:
@@ -499,10 +490,9 @@ paths:
       summary: "Generate an OTP for the signed-in user"
       description: |
         Send a one-time code to the signed-in user's registered email or mobile. The
-        payload is empty; the recipient is resolved from the session. Requires a user
-        session token.
-      security:
-        - developerToken: []
+        payload is empty; the recipient is resolved from the session.
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -515,7 +505,7 @@ paths:
                 version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "aa11bb22-cc33-dd44-ee55-ff6677889900"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload: {}
       responses:
@@ -555,9 +545,9 @@ paths:
         - "Account"
       summary: "Verify an OTP for the signed-in user"
       description: |
-        Verify a code sent to the signed-in user. Requires a user session token.
-      security:
-        - developerToken: []
+        Verify a code sent to the signed-in user.
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -570,7 +560,7 @@ paths:
                 version: "v1"
                 ts: "2026-04-07T10:01:00Z"
                 msgId: "bb22cc33-dd44-ee55-ff66-778899001122"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 code: "123456"
@@ -612,9 +602,9 @@ paths:
       description: |
         Decrypt one of the encrypted values on the caller's own profile (a `pii.*_encrypted`
         value from `/v1/account/get`). A ciphertext belonging to any other account is
-        refused. Requires a user session token.
-      security:
-        - developerToken: []
+        refused.
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -627,7 +617,7 @@ paths:
                 version: "v1"
                 ts: "2026-04-07T10:02:00Z"
                 msgId: "cc33dd44-ee55-ff66-7788-990011223344"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 ciphertext: "<pii.email_encrypted value from /v1/account/get>"
@@ -677,7 +667,7 @@ paths:
   #               version: "v1"
   #               ts: "2025-09-09T09:06:00Z"
   #               msgId: "e2f3a4b5-c6d7-8901-2345-67890abcdef"
-  #               developerToken: "fnt_..."
+  #               developerToken: "c2Et..."
   #               authorization: "Bearer eyJ..."
   #             payload:
   #               email: "bob.smith@example.com"
@@ -699,8 +689,6 @@ paths:
         - "Address"
       summary: "Resolve an address"
       description: "Resolve an address to its DID."
-      security:
-        - developerToken: []
       requestBody:
         required: true
         content:
@@ -713,7 +701,7 @@ paths:
                 version: "v1"
                 ts: "2025-09-09T11:05:00Z"
                 msgId: "f1a2b3c4-d5e6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
               payload:
                 address: "alice"
       responses:
@@ -736,7 +724,6 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
 
-
   # -------------------- Account Keys --------------------
 
   /v1/account/keys/register:
@@ -745,9 +732,9 @@ paths:
       summary: "Register an additional public key for the account"
       description: |
         Register a public key for the signed-in user. Supply `type` plus exactly one of
-        `publicKey` or `address`. Requires a user session token.
-      security:
-        - developerToken: []
+        `publicKey` or `address`.
+
+        Requires a user session token in `context.authorization`.
       x-scopes: [keys:create]
       requestBody:
         required: true
@@ -760,7 +747,7 @@ paths:
                 version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "11111111-2222-3333-4444-555555555555"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 type: "ed25519"
@@ -786,10 +773,9 @@ paths:
       summary: "Remove a public key from the account"
       description: |
         Remove one of the signed-in user's keys, identified by its `id` or `address`. The
-        default key cannot be removed; make another key the default first. Requires a user
-        session token.
-      security:
-        - developerToken: []
+        default key cannot be removed; make another key the default first.
+
+        Requires a user session token in `context.authorization`.
       x-scopes: [keys:manage]
       requestBody:
         required: true
@@ -802,7 +788,7 @@ paths:
                 version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "33333333-4444-5555-6666-777777777777"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 id: "0f8fad5b-d9cb-469f-a165-70867728950e"
@@ -824,9 +810,9 @@ paths:
       summary: "Get a single public key for the account"
       description: |
         Return one of the signed-in user's keys, identified by its `id` or `address`.
-        Requires a user session token.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
+       
       x-scopes: [keys:view]
       requestBody:
         required: true
@@ -839,7 +825,7 @@ paths:
                 version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "44444444-5555-6666-7777-888888888888"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 id: "0f8fad5b-d9cb-469f-a165-70867728950e"
@@ -860,9 +846,9 @@ paths:
       summary: "List the account's public keys"
       description: |
         List the signed-in user's keys. Optionally filter by `type` and `status`, and page
-        the results with `pagination`. Requires a user session token.
-      security:
-        - developerToken: []
+        the results with `pagination`.
+
+        Requires a user session token in `context.authorization`.
       x-scopes: [keys:view]
       requestBody:
         required: true
@@ -875,7 +861,7 @@ paths:
                 version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "22222222-3333-4444-5555-666666666666"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 type: "ed25519"
@@ -891,7 +877,6 @@ paths:
         '403': { $ref: '#/components/responses/ForbiddenError' }
         '429': { $ref: '#/components/responses/RateLimitedError' }
 
-
 # ===============================================================
 #   COMPONENTS
 # ===============================================================
@@ -902,14 +887,13 @@ components:
     # --- API Envelope Schemas ---
     Context:
       type: object
-      required: [id, version, ts, msgId]
+      required: [id, version, ts, msgId, developerToken]
       properties:
         id: { type: string, example: "api.account.create" }
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        transactionId: { type: string, format: uuid, nullable: true, description: "ID for asynchronous operations." }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End user's session token." }
     ResponseContext:
       type: object
@@ -949,6 +933,26 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/Signature'
+    UserContext:
+      type: object
+      required: [id, version, ts, msgId, developerToken, authorization]
+      properties:
+        id: { type: string, example: "api.account.create" }
+        version: { type: string, example: "v1" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
+        authorization: { type: string, example: "Bearer eyJ...", description: "End user's session token." }
+    UserRequestContext:
+      type: object
+      required: [context, payload]
+      properties:
+        context: { $ref: '#/components/schemas/UserContext' }
+        payload: { type: object }
+        signature:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Signature'
     ApiResponse:
       type: object
       required: [context, response]
@@ -963,15 +967,14 @@ components:
         response: { type: object, description: "Always empty on error.", example: {} }
 
     # --- Specific Request Envelopes ---
-    ApiRequest_Empty: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { type: object } } } ] }
-    ApiRequest_RegistrationRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/RegistrationRequest' } } } ] }
-    ApiRequest_UpdateAccountRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/UpdateAccountRequest' } } } ] }
+    ApiRequest_Empty: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { type: object } } } ] }
+    ApiRequest_RegistrationRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/RegistrationRequest' } } } ] }
+    ApiRequest_UpdateAccountRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/UpdateAccountRequest' } } } ] }
     ApiRequest_AvailabilityCheckRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/AvailabilityCheckRequest' } } } ] }
     ApiRequest_LoginRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/LoginRequest' } } } ] }
     ApiRequest_ResolveRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/ResolveRequest' } } } ] }
-    ApiRequest_OTPVerifyRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/OTPVerifyRequest' } } } ] }
-    ApiRequest_DecryptPIIRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/DecryptPIIRequest' } } } ] }
-
+    ApiRequest_OTPVerifyRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/OTPVerifyRequest' } } } ] }
+    ApiRequest_DecryptPIIRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/DecryptPIIRequest' } } } ] }
 
     # --- Specific Response Envelopes ---
     ApiResponse_RegistrationSuccess: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/CreateAccountResponse' } } } ] }
@@ -1063,10 +1066,10 @@ components:
             limit: { type: integer }
             offset: { type: integer }
 
-    ApiRequest_RegisterKeyRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/RegisterKeyRequest' } } } ] }
-    ApiRequest_RemoveKeyRequest:   { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/RemoveKeyRequest' } } } ] }
-    ApiRequest_GetKeyRequest:      { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/GetKeyRequest' } } } ] }
-    ApiRequest_SearchKeysRequest:  { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/SearchKeysRequest' } } } ] }
+    ApiRequest_RegisterKeyRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/RegisterKeyRequest' } } } ] }
+    ApiRequest_RemoveKeyRequest:   { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/RemoveKeyRequest' } } } ] }
+    ApiRequest_GetKeyRequest:      { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/GetKeyRequest' } } } ] }
+    ApiRequest_SearchKeysRequest:  { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/SearchKeysRequest' } } } ] }
 
     ApiResponse_AccountKeyInfo: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/KeyRegistrationEntry' } } } ] }
     ApiResponse_AccountKeyList: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/AccountKeyList' } } } ] }
@@ -1294,11 +1297,3 @@ components:
           example:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
-
-  # -------------------- Security --------------------
-  securitySchemes:
-    developerToken:
-      type: http
-      scheme: bearer
-      bearerFormat: "JWT or Opaque"
-      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."

--- a/api/accounts-interfaces.yaml
+++ b/api/accounts-interfaces.yaml
@@ -12,8 +12,6 @@ info:
 
     * `context.developerToken`: the calling application's developer token. Required on
       every endpoint.
-    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
-      `Signature` header.
     * `context.authorization`: the end user's session token. Required by the endpoints
       that act on a signed-in user; each operation states when it is needed.
     * `signature` (top level): the end user's JWS, for operations that must be
@@ -74,7 +72,6 @@ paths:
         `context.authorization`, so it is not accepted in the payload.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -181,7 +178,6 @@ paths:
         that is in progress. Requires a user session token.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -274,7 +270,6 @@ paths:
         another federated instance is reported as unavailable.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -321,7 +316,6 @@ paths:
           receive a session token without a code.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -439,7 +433,6 @@ paths:
       description: "Invalidate the user's current session token. Requires a user session token."
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -474,7 +467,6 @@ paths:
       description: "Return the profile of the signed-in user. Requires a user session token."
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -511,7 +503,6 @@ paths:
         session token.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -567,7 +558,6 @@ paths:
         Verify a code sent to the signed-in user. Requires a user session token.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -625,7 +615,6 @@ paths:
         refused. Requires a user session token.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -712,7 +701,6 @@ paths:
       description: "Resolve an address to its DID."
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -760,7 +748,6 @@ paths:
         `publicKey` or `address`. Requires a user session token.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [keys:create]
       requestBody:
         required: true
@@ -803,7 +790,6 @@ paths:
         session token.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [keys:manage]
       requestBody:
         required: true
@@ -841,7 +827,6 @@ paths:
         Requires a user session token.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [keys:view]
       requestBody:
         required: true
@@ -878,7 +863,6 @@ paths:
         the results with `pagination`. Requires a user session token.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [keys:view]
       requestBody:
         required: true
@@ -925,8 +909,7 @@ components:
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true, description: "ID for asynchronous operations." }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "The calling application's developer token." }
-        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "Signature over the request (RFC 9421)." }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End user's session token." }
     ResponseContext:
       type: object
@@ -1318,15 +1301,4 @@ components:
       type: http
       scheme: bearer
       bearerFormat: "JWT or Opaque"
-      description: "Token identifying the calling application, sent as `context.developerToken`."
-
-    developerSignature:
-      type: apiKey
-      in: header
-      name: Signature
-      description: |
-        Optional request signature (RFC 9421) for message integrity and non-repudiation,
-        sent in the `Signature` header.
-
-        Format:
-        Signature keyId="...",algorithm="...",created="...",expires="...",headers="...",signature="..."
+      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."

--- a/api/accounts-interfaces.yaml
+++ b/api/accounts-interfaces.yaml
@@ -328,7 +328,7 @@ paths:
         Login with one of two flows (see `LoginRequest` for details):
 
         - **OTP** (default): step 1 sends OTP, step 2 verifies and returns JWT.
-        - **SSO** (`ssoLogin: true`): bypasses OTP; caller's app backend owns final JWT signing.
+        - **SSO** (`authToken`): bypasses OTP; the app backend supplies a signed authToken.
 
         Password-based login was removed in release 2026.04.07. Requires developer auth.
       security:
@@ -376,7 +376,7 @@ paths:
                     username: "alice@example.com"
                     otp: "1234"
               SSOLogin:
-                summary: "SSO: bypass OTP — app backend owns final JWT"
+                summary: "SSO: bypass OTP with a BFF-signed authToken"
                 value:
                   context:
                     id: "api.account.login"
@@ -386,7 +386,7 @@ paths:
                     developerToken: "fnt_..."
                   payload:
                     username: "alice@example.com"
-                    ssoLogin: true
+                    authToken: "eyJhbGciOiJFZERTQSJ9..."
       responses:
         '200':
           description: |
@@ -765,8 +765,8 @@ paths:
       summary: "Register an additional public key for the calling account"
       description: |
         Register a key reference for the authenticated account in the unified
-        `key_references` store. Supply `type` plus **exactly one** of
-        `public_key_hex` (standard keys) or `address` (the MetaMask/EVM exception,
+        `key_references` store. Supply `chainId` plus **exactly one** of
+        `publicKey` (standard keys) or `walletAddress` (the MetaMask/EVM exception,
         used when only the on-chain wallet address is available, not the raw key).
       security:
         - developerToken: []
@@ -786,11 +786,9 @@ paths:
                 developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
-                type: "ed25519"
-                public_key_hex: "3f8a1c9d2b7e0f4a6c5d8e9b0a1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c"
-                name: "Ledger Nano"
-                is_primary: false
-                is_default: false
+                chainId: "eip155:1"
+                publicKey: "3f8a1c9d2b7e0f4a6c5d8e9b0a1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c"
+                isPrimary: false
       responses:
         '201':
           description: "Key registered in the unified key_references store."
@@ -809,7 +807,7 @@ paths:
       summary: "Remove a public key from the calling account"
       description: |
         Revoke a key reference from the account's unified `key_references` store,
-        identified by its `address`. The primary key (the one initially provisioned
+        identified by its `id`. The primary key (the one initially provisioned
         at registration) cannot be removed via this endpoint.
       security:
         - developerToken: []
@@ -838,7 +836,7 @@ paths:
       summary: "Get a single public key for the calling account"
       description: |
         Fetch a single key reference from the account's unified `key_references`
-        store, identified by its `address`.
+        store, identified by its `id`.
       security:
         - developerToken: []
         - developerSignature: []
@@ -865,8 +863,8 @@ paths:
       summary: "List/search public keys for an account"
       description: |
         Returns the key references bound to the calling account from the unified
-        `key_references` store, optionally filtered by `type`/`status` and paginated
-        with `limit`/`offset`.
+        `key_references` store, optionally filtered by `filters.chainId`/`filters.isPrimary`
+        and paginated with `limit`/`offset`.
       security:
         - developerToken: []
         - developerSignature: []
@@ -885,8 +883,7 @@ paths:
                 developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
-                type: "ed25519"
-                status: "active"
+                filters: { chainId: "eip155:1", isPrimary: true }
                 pagination: { limit: 20, offset: 0 }
       responses:
         '200':
@@ -995,49 +992,52 @@ components:
     # --- Account Keys (unified key_references store) ---
     KeyRegistrationEntry:
       type: object
-      required: [id, type, address, isPrimary, isDefault, status, createdAt, updatedAt]
+      required: [id, chainId, address, isPrimary, createdAt, updatedAt]
       description: "A key reference from the account's unified `key_references` store."
       properties:
-        id: { type: string }
-        name: { type: string, nullable: true }
-        type: { type: string, example: "ed25519", description: "Key type/algorithm." }
-        publicKeyHex: { type: string, nullable: true, example: "3f8a1c9d...", description: "Hex-encoded raw public key. Null when only a wallet address was registered." }
+        id: { type: string, format: uuid }
+        chainId: { type: string, example: "eip155:1", description: "Chain the key/address belongs to." }
+        publicKey: { type: string, nullable: true, example: "3f8a1c9d...", description: "Hex-encoded raw public key. Null when only a wallet address was registered." }
         address: { type: string, example: "0xAbC1230000000000000000000000000000000000" }
         isPrimary: { type: boolean, example: true }
-        isDefault: { type: boolean, example: false }
-        did: { type: string, nullable: true, example: "did:key:z..." }
-        status: { type: string, example: "active" }
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
     RegisterKeyRequest:
       type: object
-      required: [type]
+      required: [chainId]
+      additionalProperties: false
       description: |
-        Supply `type` plus **exactly one** of `public_key_hex` (standard keys) or
-        `address` (the MetaMask/EVM exception, used when only the on-chain wallet
-        address is available, not the raw public key).
+        Supply `chainId` plus **exactly one** of `publicKey` (standard keys) or
+        `walletAddress` (the MetaMask/EVM exception, used when only the on-chain
+        wallet address is available, not the raw public key).
+      anyOf:
+        - required: [publicKey]
+        - required: [walletAddress]
       properties:
-        type: { type: string, example: "ed25519", description: "Key type/algorithm (e.g. ed25519)." }
-        public_key_hex: { type: string, description: "Hex-encoded raw public key. Supply for standard keys." }
-        address: { type: string, description: "On-chain wallet address. MetaMask/EVM exception, used when the raw public key is unavailable." }
-        name: { type: string, description: "Human-readable label for the key." }
-        is_primary: { type: boolean }
-        is_default: { type: boolean }
+        chainId: { type: string, example: "eip155:1", description: "Chain the key/address belongs to." }
+        publicKey: { type: string, description: "Hex-encoded raw public key. Supply for standard keys." }
+        walletAddress: { type: string, description: "On-chain wallet address. MetaMask/EVM exception, used when the raw public key is unavailable." }
+        isPrimary: { type: boolean }
     RemoveKeyRequest:
       type: object
-      required: [address]
+      required: [id]
+      additionalProperties: false
       properties:
-        address: { type: string, description: "Address of the key reference to remove." }
+        id: { type: string, format: uuid, description: "ID of the key reference to remove." }
     GetKeyRequest:
       type: object
-      required: [address]
+      required: [id]
+      additionalProperties: false
       properties:
-        address: { type: string, description: "Address of the key reference to fetch." }
+        id: { type: string, format: uuid, description: "ID of the key reference to fetch." }
     SearchKeysRequest:
       type: object
       properties:
-        type: { type: string, description: "Filter by key type/algorithm." }
-        status: { type: string, description: "Filter by key status." }
+        filters:
+          type: object
+          properties:
+            chainId: { type: string, description: "Filter by chain." }
+            isPrimary: { type: boolean, description: "Filter by primary flag." }
         pagination:
           type: object
           properties:
@@ -1122,22 +1122,22 @@ components:
       description: |
         Login payload. Two supported flows:
 
-        1. **OTP login** — omit `ssoLogin` (or set false). Send request without `otp` to
+        1. **OTP login** — omit `authToken`. Send request without `otp` to
            receive an OTP on the registered email/mobile. Send again with `otp` populated
            to receive a JWT access token.
 
-        2. **SSO login** — set `ssoLogin: true`. UNITS does not call the OTP service. The
-           caller is expected to obtain a Keycloak token via its own identity provider
-           (Google, Microsoft, etc.) and the **application backend** signs and returns
-           the final JWT to the end user. On the first SSO call for a brand-new user,
-           UNITS returns HTTP 404 — the app backend is responsible for driving the
+        2. **SSO login** — supply `authToken` (a BFF-signed Ed25519 JWT). UNITS does not
+           call the OTP service; it verifies the BFF's signature. The app backend/BFF
+           verifies the external IdP (NextAuth — Google, Microsoft, etc.), signs the
+           authToken, and returns the final session JWT to the end user. On the first SSO
+           call for a brand-new user, UNITS returns HTTP 404 — the app backend drives the
            registration flow before issuing a JWT.
 
         Password-based login has been removed as of release 2026.04.07.
       properties:
         username: { type: string, example: "alice", description: "Finternet address, email, or mobile number" }
         otp: { type: string, example: "1234", nullable: true, description: "One-time password for verification. Only used for OTP flow." }
-        ssoLogin: { type: boolean, default: false, description: "Set true to select the SSO (external IdP) flow and bypass OTP." }
+        authToken: { type: string, minLength: 1, description: "BFF-signed Ed25519 authToken JWT. Supply (instead of otp) to complete an SSO login without OTP; UNITS verifies the BFF key." }
     AvailabilityResponse:
       type: object
       properties:

--- a/api/accounts-interfaces.yaml
+++ b/api/accounts-interfaces.yaml
@@ -59,13 +59,13 @@ info:
     | `POST /v1/account/login` | *(public — OTP/SSO bootstrap)* |
     | `POST /v1/account/logout` | *(public)* |
     | `POST /v1/address/checkAvailability` | *(public)* |
-    | `POST /v1/address/resolve` | `addresses:view` |
-    | `POST /v1/account/keys/register` | `keys:manage` |
+    | `POST /v1/address/resolve` | `accounts:view` |
+    | `POST /v1/account/keys/register` | `keys:create` |
     | `POST /v1/account/keys/remove` | `keys:manage` |
     | `POST /v1/account/keys/get` | `keys:view` |
     | `POST /v1/account/keys/search` | `keys:view` |
 
-    Calls failing the scope check return `403 PERMISSION_DENIED`.
+    Calls failing the scope check return `403 FORBIDDEN`.
 
     ### Rate limiting
 
@@ -156,7 +156,7 @@ paths:
                 response:
                   accountId: "018f2c3d-4e5f-7890-abcd-1234567890ab"
                   did: "did:key:z..."
-                  status: "COMMITTED"
+                  status: "active"
         '400':
           description: "Bad request, such as a missing required field."
           content:
@@ -765,7 +765,7 @@ paths:
       security:
         - developerToken: []
         - developerSignature: []
-      x-scopes: [keys:manage]
+      x-scopes: [keys:create]
       requestBody:
         required: true
         content:
@@ -1092,7 +1092,7 @@ components:
         txnId: { type: string, description: "Deprecated — no longer populated; registration completes synchronously." }
         accountId: { type: string, example: "018f2c3d-4e5f-7890-abcd-1234567890ab" }
         did: { type: string, example: "did:key:z..." }
-        status: { type: string, example: "COMMITTED" }
+        status: { type: string, example: "active" }
     AvailabilityCheckRequest:
       type: object
       required: [address]
@@ -1243,7 +1243,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "AUTHENTICATION_FAILED", message: "Token invalid or expired." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     UnauthorizedDeveloperError:
       description: "Developer authentication failed (HTTP 401)."
@@ -1251,7 +1251,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "DEVELOPER_AUTH_FAILED", message: "Invalid developer token." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Invalid developer token." } }
             response: {}
     ForbiddenError:
       description: "Forbidden. Insufficient permissions."
@@ -1259,7 +1259,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "PERMISSION_DENIED", message: "Insufficient permissions to perform this action." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -1275,7 +1275,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "Invalid request parameters." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     ConflictError:
       description: "Conflict with existing resource."
@@ -1283,7 +1283,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RESOURCE_CONFLICT", message: "An account with this identifier already exists." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "CONFLICT", message: "An account with this identifier already exists." } }
             response: {}
     RateLimitedError:
       description: |
@@ -1296,7 +1296,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
 
   # -------------------- Security --------------------

--- a/api/accounts-interfaces.yaml
+++ b/api/accounts-interfaces.yaml
@@ -279,7 +279,10 @@ paths:
       tags:
         - "Address"
       summary: "Check address availability"
-      description: "Checks if a given human-readable address is available for registration."
+      description: |
+        Checks if a given human-readable address is available for registration.
+        Availability now consults the **federation registry**: an address already
+        registered at another federated instance is reported as unavailable.
       security:
         - developerToken: []
         - developerSignature: []
@@ -760,8 +763,10 @@ paths:
       tags: [Account Keys]
       summary: "Register an additional public key for the calling account"
       description: |
-        Register an additional public key (or wallet address) for the authenticated
-        account on a given chain. Supply the raw `publicKey` and/or the `walletAddress`.
+        Register a key reference for the authenticated account in the unified
+        `key_references` store. Supply `type` plus **exactly one** of
+        `public_key_hex` (standard keys) or `address` (the MetaMask/EVM exception,
+        used when only the on-chain wallet address is available, not the raw key).
       security:
         - developerToken: []
         - developerSignature: []
@@ -780,12 +785,14 @@ paths:
                 developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
-                chainId: "eip155:1"
-                publicKey: "0x04a1b2c3d4e5f6..."
-                isPrimary: true
+                type: "ed25519"
+                public_key_hex: "3f8a1c9d2b7e0f4a6c5d8e9b0a1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c"
+                name: "Ledger Nano"
+                is_primary: false
+                is_default: false
       responses:
         '201':
-          description: "Key registered."
+          description: "Key registered in the unified key_references store."
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiResponse_AccountKeyInfo' }
@@ -800,7 +807,8 @@ paths:
       tags: [Account Keys]
       summary: "Remove a public key from the calling account"
       description: |
-        Revoke an account-bound public key. The primary key (the one initially provisioned
+        Revoke a key reference from the account's unified `key_references` store,
+        identified by its `address`. The primary key (the one initially provisioned
         at registration) cannot be removed via this endpoint.
       security:
         - developerToken: []
@@ -827,6 +835,9 @@ paths:
     post:
       tags: [Account Keys]
       summary: "Get a single public key for the calling account"
+      description: |
+        Fetch a single key reference from the account's unified `key_references`
+        store, identified by its `address`.
       security:
         - developerToken: []
         - developerSignature: []
@@ -852,8 +863,9 @@ paths:
       tags: [Account Keys]
       summary: "List/search public keys for an account"
       description: |
-        Returns the keys bound to the calling account, optionally filtered by
-        `chainId`/`isPrimary` and paginated with `limit`/`offset`.
+        Returns the key references bound to the calling account from the unified
+        `key_references` store, optionally filtered by `type`/`status` and paginated
+        with `limit`/`offset`.
       security:
         - developerToken: []
         - developerSignature: []
@@ -872,9 +884,8 @@ paths:
                 developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
-                filters:
-                  chainId: "eip155:1"
-                  isPrimary: true
+                type: "ed25519"
+                status: "active"
                 pagination: { limit: 20, offset: 0 }
       responses:
         '200':
@@ -980,48 +991,52 @@ components:
 
     ApiResponse_Success: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { type: object, properties: { message: { type: string, example: "Signout successful" } } } } } ] }
 
-    # --- Account Keys (Public Key Registry) ---
-    PublicKeyRegistryEntry:
+    # --- Account Keys (unified key_references store) ---
+    KeyRegistrationEntry:
       type: object
-      required: [id, chainId, address, isPrimary, createdAt, updatedAt]
+      required: [id, type, address, isPrimary, isDefault, status, createdAt, updatedAt]
+      description: "A key reference from the account's unified `key_references` store."
       properties:
-        id: { type: string, format: uuid }
-        chainId: { type: string, example: "eip155:1", description: "Chain identifier the key is registered against." }
-        publicKey: { type: string, example: "0x04a1b2c3d4e5f6...", description: "Raw chain-specific public key. Omitted when only a wallet address was registered." }
-        address: { type: string, example: "0xAbC1230000000000000000000000000000000000", description: "On-chain wallet address derived from / supplied with the key." }
+        id: { type: string }
+        name: { type: string, nullable: true }
+        type: { type: string, example: "ed25519", description: "Key type/algorithm." }
+        publicKeyHex: { type: string, nullable: true, example: "3f8a1c9d...", description: "Hex-encoded raw public key. Null when only a wallet address was registered." }
+        address: { type: string, example: "0xAbC1230000000000000000000000000000000000" }
         isPrimary: { type: boolean, example: true }
+        isDefault: { type: boolean, example: false }
+        did: { type: string, nullable: true, example: "did:key:z..." }
+        status: { type: string, example: "active" }
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
     RegisterKeyRequest:
       type: object
-      required: [chainId]
-      description: "At least one of `publicKey` or `walletAddress` must be supplied."
+      required: [type]
+      description: |
+        Supply `type` plus **exactly one** of `public_key_hex` (standard keys) or
+        `address` (the MetaMask/EVM exception, used when only the on-chain wallet
+        address is available, not the raw public key).
       properties:
-        chainId: { type: string, minLength: 1, example: "eip155:1", description: "Chain identifier." }
-        publicKey: { type: string, minLength: 10, description: "Raw chain-specific public key (e.g. secp256k1 for EVM)." }
-        walletAddress: { type: string, minLength: 1, description: "On-chain address; used when the raw key is unavailable." }
-        isPrimary: { type: boolean }
-      anyOf:
-        - required: [publicKey]
-        - required: [walletAddress]
+        type: { type: string, example: "ed25519", description: "Key type/algorithm (e.g. ed25519)." }
+        public_key_hex: { type: string, description: "Hex-encoded raw public key. Supply for standard keys." }
+        address: { type: string, description: "On-chain wallet address. MetaMask/EVM exception, used when the raw public key is unavailable." }
+        name: { type: string, description: "Human-readable label for the key." }
+        is_primary: { type: boolean }
+        is_default: { type: boolean }
     RemoveKeyRequest:
       type: object
-      required: [id]
+      required: [address]
       properties:
-        id: { type: string, format: uuid }
+        address: { type: string, description: "Address of the key reference to remove." }
     GetKeyRequest:
       type: object
-      required: [id]
+      required: [address]
       properties:
-        id: { type: string, format: uuid }
+        address: { type: string, description: "Address of the key reference to fetch." }
     SearchKeysRequest:
       type: object
       properties:
-        filters:
-          type: object
-          properties:
-            chainId: { type: string }
-            isPrimary: { type: boolean }
+        type: { type: string, description: "Filter by key type/algorithm." }
+        status: { type: string, description: "Filter by key status." }
         pagination:
           type: object
           properties:
@@ -1033,7 +1048,7 @@ components:
       properties:
         keys:
           type: array
-          items: { $ref: '#/components/schemas/PublicKeyRegistryEntry' }
+          items: { $ref: '#/components/schemas/KeyRegistrationEntry' }
         pagination:
           type: object
           properties:
@@ -1046,7 +1061,7 @@ components:
     ApiRequest_GetKeyRequest:      { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/GetKeyRequest' } } } ] }
     ApiRequest_SearchKeysRequest:  { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/SearchKeysRequest' } } } ] }
 
-    ApiResponse_AccountKeyInfo: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/PublicKeyRegistryEntry' } } } ] }
+    ApiResponse_AccountKeyInfo: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/KeyRegistrationEntry' } } } ] }
     ApiResponse_AccountKeyList: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/AccountKeyList' } } } ] }
 
     # --- Core Data Schemas (Payloads) ---

--- a/api/accounts-interfaces.yaml
+++ b/api/accounts-interfaces.yaml
@@ -19,14 +19,31 @@ info:
     * `signature` (top level): the end user's JWS, for operations that must be
       cryptographically signed by the user.
 
-    Each endpoint requires the scope listed under `x-scopes`; calls without it return
-    `403`.
+    ### RBAC Scopes
+
+    | Endpoint | Required scope |
+    |----------|----------------|
+    | `POST /v1/account/create` | `accounts:create` |
+    | `POST /v1/account/update` | `accounts:manage` |
+    | `POST /v1/account/get` | `accounts:view` |
+    | `POST /v1/account/otp/generate` | *(scope resolved from apiID; requires user auth)* |
+    | `POST /v1/account/otp/verify` | *(scope resolved from apiID; requires user auth)* |
+    | `POST /v1/account/pii/decrypt` | *(scope resolved from apiID; requires user auth)* |
+    | `POST /v1/account/login` | *(public: OTP/SSO bootstrap)* |
+    | `POST /v1/account/logout` | *(public)* |
+    | `POST /v1/address/checkAvailability` | *(public)* |
+    | `POST /v1/address/resolve` | `accounts:view` |
+    | `POST /v1/account/keys/register` | `keys:create` |
+    | `POST /v1/account/keys/remove` | `keys:manage` |
+    | `POST /v1/account/keys/get` | `keys:view` |
+    | `POST /v1/account/keys/search` | `keys:view` |
+
+    Calls failing the scope check return `403 FORBIDDEN`.
 
     ### Rate limiting
 
-    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
-    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
-    the tier assigned to the calling client.
+    All endpoints are protected by a scope-tier sliding-window rate limiter; on
+    breach the response is `429 Too Many Requests` with a `Retry-After` header.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -58,7 +75,6 @@ paths:
       security:
         - developerToken: []
         - developerSignature: []
-      x-scopes: [accounts:create]
       requestBody:
         required: true
         content:
@@ -112,11 +128,46 @@ paths:
                   accessToken: "eyJ..."
                   tokenType: "Bearer"
                   expiresIn: 3600
-        '400': { $ref: '#/components/responses/BadRequestError' }
-        '401': { $ref: '#/components/responses/UnauthorizedError' }
-        '403': { $ref: '#/components/responses/ForbiddenError' }
-        '409': { $ref: '#/components/responses/ConflictError' }
-        '429': { $ref: '#/components/responses/RateLimitedError' }
+        '400':
+          description: "Bad request, such as a missing required field."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+              examples:
+                MissingField:
+                  summary: "Missing Required Field"
+                  value:
+                    context:
+                      id: "api.account.create"
+                      version: "v1"
+                      ts: "2025-09-08T12:00:00Z"
+                      msgId: "a1b2c3d4..."
+                      status: "failed"
+                      error:
+                        code: "BAD_REQUEST"
+                        message: "Field 'name' is required."
+                    response: {}
+        '409':
+          description: "Conflict, an identifier is already in use."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+              examples:
+                IdentifierTaken:
+                  summary: "Address Taken"
+                  value:
+                    context:
+                      id: "api.account.create"
+                      version: "v1"
+                      ts: "2025-09-08T12:00:00Z"
+                      msgId: "a1b2c3d4..."
+                      status: "failed"
+                      error:
+                        code: "IDENTIFIER_TAKEN"
+                        message: "The address 'alice' is already in use."
+                    response: {}
 
   /v1/account/update:
     post:
@@ -131,7 +182,6 @@ paths:
       security:
         - developerToken: []
         - developerSignature: []
-      x-scopes: [accounts:manage]
       requestBody:
         required: true
         content:
@@ -211,10 +261,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
-        '400': { $ref: '#/components/responses/BadRequestError' }
-        '401': { $ref: '#/components/responses/UnauthorizedError' }
-        '403': { $ref: '#/components/responses/ForbiddenError' }
-        '429': { $ref: '#/components/responses/RateLimitedError' }
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
 
   /v1/address/checkAvailability:
     post:
@@ -227,7 +275,6 @@ paths:
       security:
         - developerToken: []
         - developerSignature: []
-      x-scopes: [accounts:view]
       requestBody:
         required: true
         content:
@@ -259,10 +306,6 @@ paths:
                   status: "successful"
                 response:
                   available: true
-        '400': { $ref: '#/components/responses/BadRequestError' }
-        '401': { $ref: '#/components/responses/UnauthorizedError' }
-        '403': { $ref: '#/components/responses/ForbiddenError' }
-        '429': { $ref: '#/components/responses/RateLimitedError' }
 
   /v1/account/login:
     post:
@@ -279,7 +322,6 @@ paths:
       security:
         - developerToken: []
         - developerSignature: []
-      x-scopes: [accounts:manage]
       requestBody:
         required: true
         content:
@@ -384,15 +426,10 @@ paths:
                       tokenType: "Bearer"
                       expiresIn: 3600
                       isExisting: false
-        '400': { $ref: '#/components/responses/BadRequestError' }
-        '401': { $ref: '#/components/responses/UnauthorizedError' }
-        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '401':
+          $ref: '#/components/responses/UnauthorizedError' # Catches both dev auth and user auth failures
         '404':
           description: "No account is registered for `username`. Returned on the OTP flow only."
-          content:
-            application/json:
-              schema: { $ref: '#/components/schemas/ApiError' }
-        '429': { $ref: '#/components/responses/RateLimitedError' }
 
   /v1/account/logout:
     post:
@@ -403,7 +440,6 @@ paths:
       security:
         - developerToken: []
         - developerSignature: []
-      x-scopes: [accounts:view]
       requestBody:
         required: true
         content:
@@ -426,9 +462,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse_Success'
-        '401': { $ref: '#/components/responses/UnauthorizedError' }
-        '403': { $ref: '#/components/responses/ForbiddenError' }
-        '429': { $ref: '#/components/responses/RateLimitedError' }
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
 
 
   /v1/account/get:
@@ -440,7 +475,6 @@ paths:
       security:
         - developerToken: []
         - developerSignature: []
-      x-scopes: [accounts:view]
       requestBody:
         required: true
         content:
@@ -463,9 +497,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse_AccountProfile'
-        '401': { $ref: '#/components/responses/UnauthorizedError' }
-        '403': { $ref: '#/components/responses/ForbiddenError' }
-        '429': { $ref: '#/components/responses/RateLimitedError' }
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
 
   /v1/account/otp/generate:
     post:
@@ -479,7 +512,6 @@ paths:
       security:
         - developerToken: []
         - developerSignature: []
-      x-scopes: [accounts:manage]
       requestBody:
         required: true
         content:
@@ -517,13 +549,14 @@ paths:
                     to: "alice@example.com"
                     channel: "email"
         '400':
-          description: "The account has no email or mobile on record."
+          description: "No contact information available for the account."
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
-        '401': { $ref: '#/components/responses/UnauthorizedError' }
-        '403': { $ref: '#/components/responses/ForbiddenError' }
-        '429': { $ref: '#/components/responses/RateLimitedError' }
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/account/otp/verify:
     post:
@@ -535,7 +568,6 @@ paths:
       security:
         - developerToken: []
         - developerSignature: []
-      x-scopes: [accounts:manage]
       requestBody:
         required: true
         content:
@@ -572,14 +604,15 @@ paths:
                   data:
                     status: "verified"
                     valid: true
-        '400': { $ref: '#/components/responses/BadRequestError' }
+        '400':
+          $ref: '#/components/responses/BadRequestError'
         '401':
-          description: "Authentication failed, or the code is not valid."
+          description: "Unauthorized, or the OTP is invalid."
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
-        '403': { $ref: '#/components/responses/ForbiddenError' }
-        '429': { $ref: '#/components/responses/RateLimitedError' }
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/account/pii/decrypt:
     post:
@@ -593,7 +626,6 @@ paths:
       security:
         - developerToken: []
         - developerSignature: []
-      x-scopes: [accounts:manage]
       requestBody:
         required: true
         content:
@@ -626,10 +658,51 @@ paths:
                   status: "successful"
                 response:
                   plaintext: "alice@example.com"
-        '400': { $ref: '#/components/responses/BadRequestError' }
-        '401': { $ref: '#/components/responses/UnauthorizedError' }
-        '403': { $ref: '#/components/responses/ForbiddenError' }
-        '429': { $ref: '#/components/responses/RateLimitedError' }
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+
+  # /v1/account/lookup:
+  #   post:
+  #     tags:
+  #       - "Account"
+  #     summary: "Lookup account by PII"
+  #     description: "Securely looks up an account profile using private info like email or phone. Requires Developer + User auth."
+  #     security:
+  #       - developerToken: []
+  #       - developerSignature: []
+  #     requestBody:
+  #       required: true
+  #       content:
+  #         application/json:
+  #           schema:
+  #             $ref: '#/components/schemas/ApiRequest_LookupRequest'
+  #           example:
+  #             context:
+  #               id: "api.account.lookup"
+  #               version: "v1"
+  #               ts: "2025-09-09T09:06:00Z"
+  #               msgId: "e2f3a4b5-c6d7-8901-2345-67890abcdef"
+  #               developerToken: "fnt_..."
+  #               authorization: "Bearer eyJ..."
+  #             payload:
+  #               email: "bob.smith@example.com"
+  #     responses:
+  #       '200':
+  #         description: "Account profile retrieved successfully."
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: '#/components/schemas/ApiResponse_AccountProfile'
+  #       '401':
+  #         $ref: '#/components/responses/UnauthorizedError'
+  #       '404':
+  #         $ref: '#/components/responses/NotFoundError'
 
   /v1/address/resolve:
     post:
@@ -640,7 +713,6 @@ paths:
       security:
         - developerToken: []
         - developerSignature: []
-      x-scopes: [accounts:view]
       requestBody:
         required: true
         content:
@@ -673,11 +745,8 @@ paths:
                 response:
                   address: "alice"
                   did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
-        '400': { $ref: '#/components/responses/BadRequestError' }
-        '401': { $ref: '#/components/responses/UnauthorizedError' }
-        '403': { $ref: '#/components/responses/ForbiddenError' }
-        '404': { $ref: '#/components/responses/NotFoundError' }
-        '429': { $ref: '#/components/responses/RateLimitedError' }
+        '404':
+          $ref: '#/components/responses/NotFoundError'
 
 
   # -------------------- Account Keys --------------------
@@ -761,14 +830,6 @@ paths:
         '401': { $ref: '#/components/responses/UnauthorizedError' }
         '403': { $ref: '#/components/responses/ForbiddenError' }
         '404': { $ref: '#/components/responses/NotFoundError' }
-        '409':
-          description: "The key is the account's default key."
-          content:
-            application/json:
-              schema: { $ref: '#/components/schemas/ApiError' }
-              example:
-                context: { id: "api.account.keys.remove", version: "v1", ts: "...", msgId: "...", status: "failed", error: { code: "CONFLICT", message: "cannot remove the default key; set another key as default first" } }
-                response: {}
         '429': { $ref: '#/components/responses/RateLimitedError' }
 
   /v1/account/keys/get:
@@ -803,7 +864,6 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiResponse_AccountKeyInfo' }
-        '400': { $ref: '#/components/responses/BadRequestError' }
         '401': { $ref: '#/components/responses/UnauthorizedError' }
         '403': { $ref: '#/components/responses/ForbiddenError' }
         '404': { $ref: '#/components/responses/NotFoundError' }
@@ -843,7 +903,6 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiResponse_AccountKeyList' }
-        '400': { $ref: '#/components/responses/BadRequestError' }
         '401': { $ref: '#/components/responses/UnauthorizedError' }
         '403': { $ref: '#/components/responses/ForbiddenError' }
         '429': { $ref: '#/components/responses/RateLimitedError' }
@@ -1192,20 +1251,28 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
+      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
+            response: {}
+    UnauthorizedDeveloperError:
+      description: "Developer authentication failed (HTTP 401)."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Invalid developer token." } }
             response: {}
     ForbiddenError:
-      description: "The caller does not have the scope required by this endpoint."
+      description: "Forbidden. Insufficient permissions."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope: accounts:view" } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -1213,7 +1280,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "The requested resource was not found." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "The requested resource was not found." } }
             response: {}
     BadRequestError:
       description: "Invalid request."
@@ -1221,18 +1288,20 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     ConflictError:
-      description: "The address is already registered."
+      description: "Conflict with existing resource."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "RESOURCE_ALREADY_EXISTS", message: "This address is already registered in the federation; sign in instead" } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "CONFLICT", message: "An account with this identifier already exists." } }
             response: {}
     RateLimitedError:
-      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }
@@ -1240,7 +1309,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
 
   # -------------------- Security --------------------

--- a/api/accounts-interfaces.yaml
+++ b/api/accounts-interfaces.yaml
@@ -2,75 +2,31 @@ openapi: 3.0.4
 info:
   title: "Finternet API - Account & Address Service"
   description: |
-    The official API specification for the Finternet Account and Address (Identifier) services.
+    API specification for account, address and account-key management in UNITS.
 
-    ### Protocol-Agnostic Envelope
-    All API interactions use a standard JSON envelope.
+    All endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
+    On failure `context.status` is `failed`, `context.error` carries a `code` and a
+    `message`, and `response` is empty.
 
-    **Request Envelope:**
-    ```json
-    {
-      "context": { ... },
-      "payload": { ... },
-      "signature": { ... } // Optional
-    }
-    ```
+    ### Authentication
 
-    **Response Envelope (Success):**
-    ```json
-    {
-      "context": { ..., "status": "successful" },
-      "response": { ... }
-    }
-    ```
+    * `context.developerToken`: the calling application's developer token. Required on
+      every endpoint.
+    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
+      `Signature` header.
+    * `context.authorization`: the end user's session token. Required by the endpoints
+      that act on a signed-in user; each operation states when it is needed.
+    * `signature` (top level): the end user's JWS, for operations that must be
+      cryptographically signed by the user.
 
-    **Response Envelope (Error):**
-    ```json
-    {
-      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." },
-      "response": {} // Empty on error
-    }
-    ```
-    (Error details are in the context.error object)
-
-    ### Authentication and Authorization
-    This API uses a two-level authorization model contained within the `context`:
-
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
-        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
-
-    2.  **User-Level (End-User) Authorization:**
-        * `context.authorization`: The end-user's JWT session token (for session-based calls).
-        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
-
-    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
-
-    ### RBAC Scopes
-
-    | Endpoint | Required scope |
-    |----------|----------------|
-    | `POST /v1/account/create` | `accounts:create` |
-    | `POST /v1/account/update` | `accounts:manage` |
-    | `POST /v1/account/get` | `accounts:view` |
-    | `POST /v1/account/otp/generate` | *(scope resolved from apiID; requires user auth)* |
-    | `POST /v1/account/otp/verify` | *(scope resolved from apiID; requires user auth)* |
-    | `POST /v1/account/pii/decrypt` | *(scope resolved from apiID; requires user auth)* |
-    | `POST /v1/account/login` | *(public — OTP/SSO bootstrap)* |
-    | `POST /v1/account/logout` | *(public)* |
-    | `POST /v1/address/checkAvailability` | *(public)* |
-    | `POST /v1/address/resolve` | `accounts:view` |
-    | `POST /v1/account/keys/register` | `keys:create` |
-    | `POST /v1/account/keys/remove` | `keys:manage` |
-    | `POST /v1/account/keys/get` | `keys:view` |
-    | `POST /v1/account/keys/search` | `keys:view` |
-
-    Calls failing the scope check return `403 FORBIDDEN`.
+    Each endpoint requires the scope listed under `x-scopes`; calls without it return
+    `403`.
 
     ### Rate limiting
 
-    All endpoints are protected by a scope-tier sliding-window rate limiter; on
-    breach the response is `429 Too Many Requests` with a `Retry-After` header.
+    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
+    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
+    the tier assigned to the calling client.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -79,11 +35,11 @@ servers:
     description: "Local Server"
 tags:
   - name: "Account"
-    description: "Endpoints for user registration, authentication, and account management."
+    description: "Registration, authentication and account profile management."
   - name: "Address"
-    description: "Endpoints for managing human-readable identifiers (Addresses)."
+    description: "Human-readable identifiers (Addresses)."
   - name: "Account Keys"
-    description: "Endpoints for managing additional public keys bound to a Finternet account (multi-device, hardware key rotation, agent keys)."
+    description: "Public keys bound to an account, for additional devices, hardware keys and agent keys."
 
 # ===============================================================
 #   PATHS
@@ -96,10 +52,13 @@ paths:
       tags:
         - "Account"
       summary: "Register a new account"
-      description: "Creates a new user account. Requires Developer auth and user authentication token."
+      description: |
+        Create a new account. The email or mobile is taken from the token in
+        `context.authorization`, so it is not accepted in the payload.
       security:
         - developerToken: []
         - developerSignature: []
+      x-scopes: [accounts:create]
       requestBody:
         required: true
         content:
@@ -108,7 +67,7 @@ paths:
               $ref: '#/components/schemas/ApiRequest_RegistrationRequest'
             examples:
               PersonalRegistration:
-                summary: "Example for registering an PERSONAL account"
+                summary: "Register a PERSONAL account"
                 value:
                   context:
                     id: "api.account.create"
@@ -122,7 +81,7 @@ paths:
                     name: "Alice Smith"
                     entityType: "PERSONAL"
               BusinessRegistration:
-                summary: "Example for registering a BUSINESS account"
+                summary: "Register a BUSINESS account"
                 value:
                   context:
                     id: "api.account.create"
@@ -137,12 +96,7 @@ paths:
                     entityType: "BUSINESS"
       responses:
         '200':
-          description: |
-            Account registered successfully. Both federation branches (reservation-proof
-            and signed-envelope) run the signup workflow synchronously to its COMMITTED
-            verdict, then mint a Keycloak session token via token exchange. The response
-            carries that token, so the client is logged in immediately — no follow-up
-            `/v1/account/login` is required.
+          description: "Account created. The response carries a session token, so no separate login call is needed."
           content:
             application/json:
               schema:
@@ -158,56 +112,26 @@ paths:
                   accessToken: "eyJ..."
                   tokenType: "Bearer"
                   expiresIn: 3600
-        '400':
-          description: "Bad request, such as a missing required field."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-              examples:
-                MissingField:
-                  summary: "Missing Required Field"
-                  value:
-                    context:
-                      id: "api.account.create"
-                      version: "v1"
-                      ts: "2025-09-08T12:00:00Z"
-                      msgId: "a1b2c3d4..."
-                      status: "failed"
-                      error:
-                        code: "BAD_REQUEST"
-                        message: "Field 'name' is required."
-                    response: {}
-        '409':
-          description: "Conflict, an identifier is already in use."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-              examples:
-                IdentifierTaken:
-                  summary: "Address Taken"
-                  value:
-                    context:
-                      id: "api.account.create"
-                      version: "v1"
-                      ts: "2025-09-08T12:00:00Z"
-                      msgId: "a1b2c3d4..."
-                      status: "failed"
-                      error:
-                        code: "IDENTIFIER_TAKEN"
-                        message: "The address 'alice' is already in use."
-                    response: {}
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '409': { $ref: '#/components/responses/ConflictError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
 
   /v1/account/update:
     post:
       tags:
         - "Account"
       summary: "Update account profile"
-      description: "Allows an authenticated end-user to update their profile information. The account to update is determined by the session token."
+      description: |
+        Update the profile of the signed-in user. The account is taken from the session
+        token. `action` selects the step: `initiate` starts the update, the `verify_*`
+        actions confirm a new contact with a one-time code, and `cancel` stops an update
+        that is in progress. Requires a user session token.
       security:
         - developerToken: []
         - developerSignature: []
+      x-scopes: [accounts:manage]
       requestBody:
         required: true
         content:
@@ -216,7 +140,7 @@ paths:
               $ref: '#/components/schemas/ApiRequest_UpdateAccountRequest'
             examples:
               Initiate:
-                summary: "Start the profile-update workflow"
+                summary: "Start a profile update"
                 value:
                   context:
                     id: "api.account.update"
@@ -227,9 +151,28 @@ paths:
                     authorization: "Bearer <End_User_JWT_Token>"
                   payload:
                     action: "initiate"
-                    data: {}
+                    data:
+                      name: "Alice A. Smith"
+                      email: "alice.smith@example.com"
+                      mobile: "+919876543210"
+              VerifyNewEmail:
+                summary: "Confirm a new email with the code that was sent to it"
+                value:
+                  context:
+                    id: "api.account.update"
+                    version: "v1"
+                    ts: "2025-09-09T10:02:00Z"
+                    msgId: "d3e4f5a6-b7c8-9012-3456-7890abcdef12"
+                    developerToken: "fnt_..."
+                    authorization: "Bearer <End_User_JWT_Token>"
+                  payload:
+                    action: "verify_new_email"
+                    data:
+                      workflowId: "018f2c3d-4e5f-7890-abcd-1234567890ab"
+                      recipient: "alice.smith@example.com"
+                      otp: "123456"
               Cancel:
-                summary: "Cancel an in-flight profile-update workflow"
+                summary: "Cancel an update that is in progress"
                 value:
                   context:
                     id: "api.account.update"
@@ -244,11 +187,7 @@ paths:
                       workflowId: "018f2c3d-4e5f-7890-abcd-1234567890ab"
       responses:
         '200':
-          description: |
-            Workflow step completed, or (for `action: cancel`) the workflow was cancelled.
-            The `response` object is the workflow step result; its shape depends on the
-            action/step and is validated downstream against the workflow registry schema.
-            For `cancel` it is `{ workflowId, status: "cancelled" }`.
+          description: "Step completed. The `response` object depends on the action."
           content:
             application/json:
               schema:
@@ -267,13 +206,15 @@ paths:
                       workflowId: "018f2c3d-4e5f-7890-abcd-1234567890ab"
                       status: "cancelled"
         '202':
-          description: "Workflow step accepted and still running (asynchronous)."
+          description: "Step accepted and still in progress."
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
 
   /v1/address/checkAvailability:
     post:
@@ -281,12 +222,12 @@ paths:
         - "Address"
       summary: "Check address availability"
       description: |
-        Checks if a given human-readable address is available for registration.
-        Availability now consults the **federation registry**: an address already
-        registered at another federated instance is reported as unavailable.
+        Check whether an address is free to register. An address already registered on
+        another federated instance is reported as unavailable.
       security:
         - developerToken: []
         - developerSignature: []
+      x-scopes: [accounts:view]
       requestBody:
         required: true
         content:
@@ -304,7 +245,7 @@ paths:
                 address: "newuser"
       responses:
         '200':
-          description: "Availability status of the identifier."
+          description: "Availability of the address."
           content:
             application/json:
               schema:
@@ -318,6 +259,10 @@ paths:
                   status: "successful"
                 response:
                   available: true
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
 
   /v1/account/login:
     post:
@@ -325,15 +270,16 @@ paths:
         - "Account"
       summary: "User login (OTP or SSO)"
       description: |
-        Login with one of two flows (see `LoginRequest` for details):
+        Two flows:
 
-        - **OTP** (default): step 1 sends OTP, step 2 verifies and returns JWT.
-        - **SSO** (`authToken`): bypasses OTP; the app backend supplies a signed authToken.
-
-        Password-based login was removed in release 2026.04.07. Requires developer auth.
+        * **OTP**: send `username` to have a one-time code delivered, then send `username`
+          and `otp` to receive a session token.
+        * **SSO**: send `username` and `authToken`, a JWT signed by your own backend, to
+          receive a session token without a code.
       security:
         - developerToken: []
         - developerSignature: []
+      x-scopes: [accounts:manage]
       requestBody:
         required: true
         content:
@@ -342,7 +288,7 @@ paths:
               $ref: '#/components/schemas/ApiRequest_LoginRequest'
             examples:
               InitiateOTPMobile:
-                summary: "Step 1: Initiate login by sending OTP (Mobile)"
+                summary: "OTP step 1: request a code (mobile)"
                 value:
                   context:
                     id: "api.account.login"
@@ -353,7 +299,7 @@ paths:
                   payload:
                     username: "+919876543210"
               InitiateOTPEmail:
-                summary: "Step 1: Initiate login by sending OTP (Email)"
+                summary: "OTP step 1: request a code (email)"
                 value:
                   context:
                     id: "api.account.login"
@@ -364,7 +310,7 @@ paths:
                   payload:
                     username: "alice@example.com"
               VerifyOTP:
-                summary: "Step 2: Verify OTP and get session token"
+                summary: "OTP step 2: submit the code"
                 value:
                   context:
                     id: "api.account.login"
@@ -376,7 +322,7 @@ paths:
                     username: "alice@example.com"
                     otp: "1234"
               SSOLogin:
-                summary: "SSO: bypass OTP with a BFF-signed authToken"
+                summary: "SSO: log in with an authToken"
                 value:
                   context:
                     id: "api.account.login"
@@ -390,16 +336,16 @@ paths:
       responses:
         '200':
           description: |
-            Login response varies based on request:
-            - **Step 1 (username only)**: Returns OTP sent confirmation
-            - **Step 2 (username + otp)**: Returns authentication token
+            An acknowledgement that the code was sent (OTP step 1), or a session token.
+            `isExisting` is `false` when no account exists yet for `username`, in which case
+            the account must be created before the token can be used.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
               examples:
                 InitiateOTP_Response:
-                  summary: "Step 1 Response: OTP sent successfully"
+                  summary: "OTP step 1: code sent"
                   value:
                     context:
                       id: "api.account.login"
@@ -411,7 +357,7 @@ paths:
                       success: true
                       message: "OTP sent successfully"
                 VerifyOTP_Response_AccountExisits:
-                  summary: "Step 2 Response: [Existing Account] Authentication successful, token granted"
+                  summary: "Session token for an existing account"
                   value:
                     context:
                       id: "api.account.login"
@@ -425,7 +371,7 @@ paths:
                       expiresIn: 3600
                       isExisting: true
                 VerifyOTP_Response_NewAccount:
-                  summary: "Step 2 Response: [New Account] Authentication successful, token granted"
+                  summary: "Token for a user who has no account yet"
                   value:
                     context:
                       id: "api.account.login"
@@ -438,24 +384,26 @@ paths:
                       tokenType: "Bearer"
                       expiresIn: 3600
                       isExisting: false
-
-        '401':
-          $ref: '#/components/responses/UnauthorizedError' # Catches both dev auth and user auth failures
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
         '404':
-          description: |
-            SSO flow only — the external identity is not yet registered in UNITS. The
-            application backend is expected to drive account registration and then
-            re-issue its own JWT. Not returned for the OTP flow.
+          description: "No account is registered for `username`. Returned on the OTP flow only."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
 
   /v1/account/logout:
     post:
       tags:
         - "Account"
       summary: "User logout"
-      description: "Invalidates the end-user's current JWT session token. Requires Developer + User auth."
+      description: "Invalidate the user's current session token. Requires a user session token."
       security:
         - developerToken: []
         - developerSignature: []
+      x-scopes: [accounts:view]
       requestBody:
         required: true
         content:
@@ -473,13 +421,14 @@ paths:
               payload: {}
       responses:
         '200':
-          description: "Logout successful."
+          description: "Session ended."
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse_Success'
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
 
 
   /v1/account/get:
@@ -487,10 +436,11 @@ paths:
       tags:
         - "Account"
       summary: "Get current account profile"
-      description: "Retrieves the full account profile for the authenticated end-user. Requires Developer + User auth."
+      description: "Return the profile of the signed-in user. Requires a user session token."
       security:
         - developerToken: []
         - developerSignature: []
+      x-scopes: [accounts:view]
       requestBody:
         required: true
         content:
@@ -508,26 +458,28 @@ paths:
               payload: {}
       responses:
         '200':
-          description: "Account profile retrieved successfully."
+          description: "Account profile."
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse_AccountProfile'
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
 
   /v1/account/otp/generate:
     post:
       tags:
         - "Account"
-      summary: "Generate an OTP for the authenticated user"
+      summary: "Generate an OTP for the signed-in user"
       description: |
-        Generates and sends an OTP to the authenticated user's email or mobile,
-        derived from the account PII. The payload is empty — the recipient is
-        resolved server-side from the session. Requires Developer + User auth.
+        Send a one-time code to the signed-in user's registered email or mobile. The
+        payload is empty; the recipient is resolved from the session. Requires a user
+        session token.
       security:
         - developerToken: []
         - developerSignature: []
+      x-scopes: [accounts:manage]
       requestBody:
         required: true
         content:
@@ -545,7 +497,7 @@ paths:
               payload: {}
       responses:
         '200':
-          description: "OTP generated and sent."
+          description: "Code sent."
           content:
             application/json:
               schema:
@@ -565,26 +517,25 @@ paths:
                     to: "alice@example.com"
                     channel: "email"
         '400':
-          description: "No contact information available for the account."
+          description: "The account has no email or mobile on record."
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
 
   /v1/account/otp/verify:
     post:
       tags:
         - "Account"
-      summary: "Verify an OTP for the authenticated user"
+      summary: "Verify an OTP for the signed-in user"
       description: |
-        Verifies a 6-digit OTP code for the authenticated user. The recipient is
-        derived server-side from the account PII. Requires Developer + User auth.
+        Verify a code sent to the signed-in user. Requires a user session token.
       security:
         - developerToken: []
         - developerSignature: []
+      x-scopes: [accounts:manage]
       requestBody:
         required: true
         content:
@@ -603,7 +554,7 @@ paths:
                 code: "123456"
       responses:
         '200':
-          description: "OTP verification result."
+          description: "Verification result."
           content:
             application/json:
               schema:
@@ -621,29 +572,28 @@ paths:
                   data:
                     status: "verified"
                     valid: true
-        '400':
-          $ref: '#/components/responses/BadRequestError'
+        '400': { $ref: '#/components/responses/BadRequestError' }
         '401':
-          description: "Unauthorized, or the OTP is invalid."
+          description: "Authentication failed, or the code is not valid."
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
 
   /v1/account/pii/decrypt:
     post:
       tags:
         - "Account"
-      summary: "Decrypt one of the caller's own PII ciphertexts"
+      summary: "Decrypt one of the caller's own encrypted profile values"
       description: |
-        Decrypts a Vault transit ciphertext that belongs to the authenticated
-        account (one of its `pii.*_encrypted` values). A ciphertext that does not
-        belong to the account is refused with `403` (no decryption oracle).
-        Requires Developer + User auth.
+        Decrypt one of the encrypted values on the caller's own profile (a `pii.*_encrypted`
+        value from `/v1/account/get`). A ciphertext belonging to any other account is
+        refused. Requires a user session token.
       security:
         - developerToken: []
         - developerSignature: []
+      x-scopes: [accounts:manage]
       requestBody:
         required: true
         content:
@@ -659,10 +609,10 @@ paths:
                 developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
-                ciphertext: "vault:v1:v90bM0LC7ugYyIEoC1Mry+Xu7p9AndTvYsIGe1gsHI54kut2oxWViXVOHd5w"
+                ciphertext: "<pii.email_encrypted value from /v1/account/get>"
       responses:
         '200':
-          description: "Decrypted plaintext."
+          description: "Decrypted value."
           content:
             application/json:
               schema:
@@ -676,61 +626,21 @@ paths:
                   status: "successful"
                 response:
                   plaintext: "alice@example.com"
-        '400':
-          $ref: '#/components/responses/BadRequestError'
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
-
-  # /v1/account/lookup:
-  #   post:
-  #     tags:
-  #       - "Account"
-  #     summary: "Lookup account by PII"
-  #     description: "Securely looks up an account profile using private info like email or phone. Requires Developer + User auth."
-  #     security:
-  #       - developerToken: []
-  #       - developerSignature: []
-  #     requestBody:
-  #       required: true
-  #       content:
-  #         application/json:
-  #           schema:
-  #             $ref: '#/components/schemas/ApiRequest_LookupRequest'
-  #           example:
-  #             context:
-  #               id: "api.account.lookup"
-  #               version: "v1"
-  #               ts: "2025-09-09T09:06:00Z"
-  #               msgId: "e2f3a4b5-c6d7-8901-2345-67890abcdef"
-  #               developerToken: "fnt_..."
-  #               authorization: "Bearer eyJ..."
-  #             payload:
-  #               email: "bob.smith@example.com"
-  #     responses:
-  #       '200':
-  #         description: "Account profile retrieved successfully."
-  #         content:
-  #           application/json:
-  #             schema:
-  #               $ref: '#/components/schemas/ApiResponse_AccountProfile'
-  #       '401':
-  #         $ref: '#/components/responses/UnauthorizedError'
-  #       '404':
-  #         $ref: '#/components/responses/NotFoundError'
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
 
   /v1/address/resolve:
     post:
       tags:
         - "Address"
-      summary: "[Placeholder] Resolve an Address"
-      description: "Publicly resolves a human-readable address. Requires Developer auth."
+      summary: "Resolve an address"
+      description: "Resolve an address to its DID."
       security:
         - developerToken: []
         - developerSignature: []
+      x-scopes: [accounts:view]
       requestBody:
         required: true
         content:
@@ -748,13 +658,26 @@ paths:
                 address: "alice"
       responses:
         '200':
-          description: "Public key and DID retrieved."
+          description: "Resolved address."
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse_ResolveResponse'
-        '404':
-          $ref: '#/components/responses/NotFoundError'
+              example:
+                context:
+                  id: "api.address.resolve"
+                  version: "v1"
+                  ts: "2025-09-09T11:05:01Z"
+                  msgId: "f1a2b3c4-d5e6-7890-1234-567890abcdef"
+                  status: "successful"
+                response:
+                  address: "alice"
+                  did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '404': { $ref: '#/components/responses/NotFoundError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
 
 
   # -------------------- Account Keys --------------------
@@ -762,12 +685,10 @@ paths:
   /v1/account/keys/register:
     post:
       tags: [Account Keys]
-      summary: "Register an additional public key for the calling account"
+      summary: "Register an additional public key for the account"
       description: |
-        Register a key reference for the authenticated account in the unified
-        `key_references` store. Supply `type` plus **exactly one** of
-        `publicKey` (hex- or base58-encoded key) or `address` (the MetaMask/EVM
-        exception, used when only the on-chain wallet address is available).
+        Register a public key for the signed-in user. Supply `type` plus exactly one of
+        `publicKey` or `address`. Requires a user session token.
       security:
         - developerToken: []
         - developerSignature: []
@@ -793,7 +714,7 @@ paths:
                 isDefault: false
       responses:
         '201':
-          description: "Key registered in the unified key_references store."
+          description: "Key registered."
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiResponse_AccountKeyInfo' }
@@ -806,11 +727,11 @@ paths:
   /v1/account/keys/remove:
     post:
       tags: [Account Keys]
-      summary: "Remove a public key from the calling account"
+      summary: "Remove a public key from the account"
       description: |
-        Revoke a key reference from the account's unified `key_references` store,
-        identified by its `id` or `address`. The primary key (the one initially provisioned
-        at registration) cannot be removed via this endpoint.
+        Remove one of the signed-in user's keys, identified by its `id` or `address`. The
+        default key cannot be removed; make another key the default first. Requires a user
+        session token.
       security:
         - developerToken: []
         - developerSignature: []
@@ -820,6 +741,16 @@ paths:
         content:
           application/json:
             schema: { $ref: '#/components/schemas/ApiRequest_RemoveKeyRequest' }
+            example:
+              context:
+                id: "api.account.keys.remove"
+                version: "v1"
+                ts: "2026-04-07T10:00:00Z"
+                msgId: "33333333-4444-5555-6666-777777777777"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                id: "0f8fad5b-d9cb-469f-a165-70867728950e"
       responses:
         '200':
           description: "Key removed."
@@ -830,15 +761,23 @@ paths:
         '401': { $ref: '#/components/responses/UnauthorizedError' }
         '403': { $ref: '#/components/responses/ForbiddenError' }
         '404': { $ref: '#/components/responses/NotFoundError' }
+        '409':
+          description: "The key is the account's default key."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+              example:
+                context: { id: "api.account.keys.remove", version: "v1", ts: "...", msgId: "...", status: "failed", error: { code: "CONFLICT", message: "cannot remove the default key; set another key as default first" } }
+                response: {}
         '429': { $ref: '#/components/responses/RateLimitedError' }
 
   /v1/account/keys/get:
     post:
       tags: [Account Keys]
-      summary: "Get a single public key for the calling account"
+      summary: "Get a single public key for the account"
       description: |
-        Fetch a single key reference from the account's unified `key_references`
-        store, identified by its `id` or `address`.
+        Return one of the signed-in user's keys, identified by its `id` or `address`.
+        Requires a user session token.
       security:
         - developerToken: []
         - developerSignature: []
@@ -848,12 +787,23 @@ paths:
         content:
           application/json:
             schema: { $ref: '#/components/schemas/ApiRequest_GetKeyRequest' }
+            example:
+              context:
+                id: "api.account.keys.get"
+                version: "v1"
+                ts: "2026-04-07T10:00:00Z"
+                msgId: "44444444-5555-6666-7777-888888888888"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                id: "0f8fad5b-d9cb-469f-a165-70867728950e"
       responses:
         '200':
-          description: "Key info."
+          description: "Key."
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiResponse_AccountKeyInfo' }
+        '400': { $ref: '#/components/responses/BadRequestError' }
         '401': { $ref: '#/components/responses/UnauthorizedError' }
         '403': { $ref: '#/components/responses/ForbiddenError' }
         '404': { $ref: '#/components/responses/NotFoundError' }
@@ -862,11 +812,10 @@ paths:
   /v1/account/keys/search:
     post:
       tags: [Account Keys]
-      summary: "List/search public keys for an account"
+      summary: "List the account's public keys"
       description: |
-        Returns the key references bound to the calling account from the unified
-        `key_references` store, optionally filtered by `type`/`status` and paginated
-        with `limit`/`offset`.
+        List the signed-in user's keys. Optionally filter by `type` and `status`, and page
+        the results with `pagination`. Requires a user session token.
       security:
         - developerToken: []
         - developerSignature: []
@@ -890,10 +839,11 @@ paths:
                 pagination: { limit: 20, offset: 0 }
       responses:
         '200':
-          description: "Key list."
+          description: "Keys."
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiResponse_AccountKeyList' }
+        '400': { $ref: '#/components/responses/BadRequestError' }
         '401': { $ref: '#/components/responses/UnauthorizedError' }
         '403': { $ref: '#/components/responses/ForbiddenError' }
         '429': { $ref: '#/components/responses/RateLimitedError' }
@@ -915,10 +865,10 @@ components:
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "B2B Developer API Key/Token" }
-        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "B2B Developer Signature (e.g., HMAC)" }
-        authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token." }
+        transactionId: { type: string, format: uuid, nullable: true, description: "ID for asynchronous operations." }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "The calling application's developer token." }
+        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "Signature over the request (RFC 9421)." }
+        authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End user's session token." }
     ResponseContext:
       type: object
       required: [id, version, ts, msgId, status]
@@ -938,7 +888,7 @@ components:
       required: [keyId, jws]
       properties:
         keyId: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
-        jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object." }
+        jws: { type: string, example: "eyJ...", description: "End user's JWS over the payload object." }
     ErrorPayload:
       type: object
       required: [code, message]
@@ -992,20 +942,20 @@ components:
 
     ApiResponse_Success: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { type: object, properties: { message: { type: string, example: "Signout successful" } } } } } ] }
 
-    # --- Account Keys (unified key_references store) ---
+    # --- Account Keys ---
     KeyRegistrationEntry:
       type: object
       required: [id, type, address, isPrimary, isDefault, status, createdAt, updatedAt]
-      description: "A key reference from the account's unified `key_references` store."
+      description: "A public key registered to the account."
       properties:
         id: { type: string, format: uuid }
-        name: { type: string, nullable: true, description: "Human-readable label; null for unnamed rows." }
-        type: { type: string, example: "ed25519", description: "Key type/algorithm." }
-        publicKeyHex: { type: string, nullable: true, example: "3f8a1c9d...", description: "Hex-encoded raw public key. Null for address-only (EVM) rows." }
+        name: { type: string, nullable: true, description: "Label for the key." }
+        type: { type: string, example: "ed25519", description: "Key algorithm." }
+        publicKeyHex: { type: string, nullable: true, example: "3f8a1c9d...", description: "Hex-encoded public key. Null when only a wallet address was registered." }
         address: { type: string, example: "0xAbC1230000000000000000000000000000000000" }
         isPrimary: { type: boolean, example: true }
         isDefault: { type: boolean, example: false }
-        did: { type: string, nullable: true, example: "did:key:z...", description: "Null for address-only rows (no pubkey → no DID)." }
+        did: { type: string, nullable: true, example: "did:key:z...", description: "Null when only a wallet address was registered." }
         status: { type: string, example: "active" }
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
@@ -1014,44 +964,43 @@ components:
       required: [type]
       additionalProperties: false
       description: |
-        Supply `type` plus **exactly one** of `publicKey` (hex- or base58-encoded
-        key) or `address` (the MetaMask/EVM exception, used when only the on-chain
-        wallet address is available, not the raw public key).
+        Supply `type` plus exactly one of `publicKey` or `address`. Use `address` for
+        wallets that expose only an on-chain address, such as MetaMask.
       oneOf:
         - required: [publicKey]
         - required: [address]
       properties:
-        type: { type: string, enum: [ed25519, secp256k1], example: "ed25519", description: "Key type/algorithm." }
-        publicKey: { type: string, description: "Hex- or base58-encoded public key (auto-detected). Supply for standard keys." }
-        address: { type: string, description: "On-chain wallet address. MetaMask/EVM exception, used when the raw public key is unavailable." }
-        name: { type: string, description: "Human-readable label for the key." }
+        type: { type: string, enum: [ed25519, secp256k1], example: "ed25519", description: "Key algorithm." }
+        publicKey: { type: string, description: "Hex- or base58-encoded public key." }
+        address: { type: string, description: "On-chain wallet address, when the public key is not available." }
+        name: { type: string, description: "Label for the key." }
         isPrimary: { type: boolean }
         isDefault: { type: boolean }
     RemoveKeyRequest:
       type: object
       additionalProperties: false
-      description: "Identify the key by **exactly one** of `id` (the key_references UUID) or `address` (the canonical family address)."
+      description: "Identify the key by exactly one of `id` or `address`."
       oneOf:
         - required: [id]
         - required: [address]
       properties:
-        id: { type: string, format: uuid, description: "Key reference UUID." }
-        address: { type: string, minLength: 1, description: "Canonical family address." }
+        id: { type: string, format: uuid }
+        address: { type: string, minLength: 1 }
     GetKeyRequest:
       type: object
       additionalProperties: false
-      description: "Identify the key by **exactly one** of `id` or `address`."
+      description: "Identify the key by exactly one of `id` or `address`."
       oneOf:
         - required: [id]
         - required: [address]
       properties:
-        id: { type: string, format: uuid, description: "Key reference UUID." }
-        address: { type: string, minLength: 1, description: "Canonical family address." }
+        id: { type: string, format: uuid }
+        address: { type: string, minLength: 1 }
     SearchKeysRequest:
       type: object
       additionalProperties: false
       properties:
-        type: { type: string, enum: [ed25519, secp256k1], description: "Filter by key type/algorithm." }
+        type: { type: string, enum: [ed25519, secp256k1], description: "Filter by key algorithm." }
         status: { type: string, description: "Filter by key status." }
         pagination:
           type: object
@@ -1085,38 +1034,32 @@ components:
       type: object
       required: [address, name, entityType]
       description: |
-        Email/mobile are NOT accepted here — they are taken from the JWT access token
-        (username claim) in the Authorization header, obtained via the OTP login flow.
+        The email or mobile is taken from the token in `context.authorization`, not from
+        this payload.
       properties:
         address: { type: string, example: "alice" }
         name: { type: string, example: "Alice Smith" }
         entityType: { type: string, enum: [PERSONAL, BUSINESS] }
-        signedRegisterNameEnvelope: { type: string, nullable: true, description: "Optional base64-encoded ULIP envelope the user signed with their Ed25519 key. When present, registration uses the envelope-driven asynchronous workflow path that registers the name at the central registry." }
-        reservationProof: { type: string, nullable: true, description: "JSON-serialized signed reservation proof from the registry (ADR-007 OTP-first). When present, units-api verifies the registrar signature and creates the account directly." }
-        homeInstance: { type: string, nullable: true, description: "Accepted for forward-compatibility but currently IGNORED. The receiving instance is always the home." }
+        signedRegisterNameEnvelope: { type: string, nullable: true, description: "Optional base64-encoded envelope, signed by the user's Ed25519 key, authorising registration of the address in the federation." }
+        reservationProof: { type: string, nullable: true, description: "Optional signed proof that the address was already reserved for this user." }
+        homeInstance: { type: string, nullable: true, description: "Accepted for forward compatibility and currently ignored; the receiving instance is always the home instance." }
     UpdateAccountRequest:
       type: object
       required: [action, data]
-      description: |
-        Public facade for the profile-update workflow. `action` discriminates the operation:
-        workflow steps (`initiate`, `verify_*`) are dispatched to the workflow executor and
-        the per-action `data` is validated downstream against the registered workflow schema;
-        `cancel` cancels the workflow and requires `data.workflowId`.
       properties:
         action:
           type: string
           enum: [initiate, verify_current_ownership, verify_new_email, verify_new_mobile, cancel]
-          description: "Workflow step or control-plane operation."
         data:
           type: object
-          description: "For workflow steps: action-specific data validated dynamically against the workflow registry schema. For `cancel`: must include `workflowId`."
+          description: |
+            Fields for the chosen action. `initiate` accepts any of `name`, `email` and
+            `mobile`. The `verify_*` actions require `workflowId`, `recipient` and `otp`.
+            `cancel` requires `workflowId`.
     CreateAccountResponse:
       type: object
       required: [accessToken, tokenType, expiresIn]
-      description: |
-        Registration completes synchronously to its COMMITTED verdict and mints a Keycloak
-        session token via token exchange. The response carries that token, so the client is
-        logged in immediately — no follow-up `/v1/account/login` is required.
+      description: "Session token for the new account, so no separate login call is needed."
       properties:
         accessToken: { type: string, example: "eyJ..." }
         tokenType: { type: string, example: "Bearer" }
@@ -1130,29 +1073,14 @@ components:
       type: object
       required: [address]
       properties:
-        address: { type: string, example: "alice", description: "The address to resolve (e.g., alice)" }
+        address: { type: string, example: "alice", description: "The address to resolve." }
     LoginRequest:
       type: object
       required: [username]
-      description: |
-        Login payload. Two supported flows:
-
-        1. **OTP login** — omit `authToken`. Send request without `otp` to
-           receive an OTP on the registered email/mobile. Send again with `otp` populated
-           to receive a JWT access token.
-
-        2. **SSO login** — supply `authToken` (a BFF-signed Ed25519 JWT). UNITS does not
-           call the OTP service; it verifies the BFF's signature. The app backend/BFF
-           verifies the external IdP (NextAuth — Google, Microsoft, etc.), signs the
-           authToken, and returns the final session JWT to the end user. On the first SSO
-           call for a brand-new user, UNITS returns HTTP 404 — the app backend drives the
-           registration flow before issuing a JWT.
-
-        Password-based login has been removed as of release 2026.04.07.
       properties:
-        username: { type: string, example: "alice", description: "Finternet address, email, or mobile number" }
-        otp: { type: string, example: "1234", nullable: true, description: "One-time password for verification. Only used for OTP flow." }
-        authToken: { type: string, minLength: 1, description: "BFF-signed Ed25519 authToken JWT. Supply (instead of otp) to complete an SSO login without OTP; UNITS verifies the BFF key." }
+        username: { type: string, example: "alice", description: "Finternet address, email or mobile number." }
+        otp: { type: string, example: "1234", nullable: true, description: "The one-time code. OTP flow only." }
+        authToken: { type: string, minLength: 1, description: "A JWT signed by your backend. Supply instead of `otp` to log in without a code." }
     AvailabilityResponse:
       type: object
       properties:
@@ -1175,24 +1103,25 @@ components:
         status: { type: string, example: "active" }
         controllers:
           type: array
-          description: "Array of DIDs for key controllers."
+          description: "DIDs of the account's key controllers."
           items: { type: string }
-        vaultEntityID: { type: string, example: "b50db0e7d5f76bfefcbf7f45ae7683e106f221b9a6d34036284ad749c761422b" }
-        homeInstance: { type: string, nullable: true, description: "Federation home-instance UUID the account is bound to. Empty for non-federation accounts." }
+        vaultEntityID: { type: string }
+        homeInstance: { type: string, nullable: true, description: "The federated instance the account belongs to. Empty when the account is not federated." }
         createdAt: { type: string, format: date-time }
         pii:
           type: object
           nullable: true
+          description: "Masked and encrypted forms of the account's contact details. Pass an encrypted value to `/v1/account/pii/decrypt` to read it."
           properties:
             address_encrypted: { type: string }
             address_masked: { type: string }
-            email_encrypted: { type: string, example: "vault:v1:v90bM0LC7ugYyIEoC1Mry+Xu7p9AndTvYsIGe1gsHI54kut2oxWViXVOHd5w" }
+            email_encrypted: { type: string }
             email_masked: { type: string, example: "u***@example.com" }
-            mobile_encrypted: { type: string, example: "vault:v1:LMliIQx/Urho2xrAidounWtzDT01P1lmA+l+bisgefLervcpdJhdhdc=" }
+            mobile_encrypted: { type: string }
             mobile_masked: { type: string, example: "+9***3210" }
         consents:
           type: array
-          description: "Per-document consent status so the app can prompt for outstanding Terms agreements."
+          description: "Consent status per document, so the application can prompt for outstanding Terms agreements."
           items:
             type: object
             required: [docType, currentVersion, consentRequired]
@@ -1202,7 +1131,7 @@ components:
               acceptedVersion: { type: integer, nullable: true, example: 2 }
               consentRequired: { type: boolean, example: true }
 
-    # --- OTP & PII (authenticated user) ---
+    # --- OTP and profile values ---
     OTPVerifyRequest:
       type: object
       properties:
@@ -1210,7 +1139,7 @@ components:
           type: string
           pattern: '^\d{6}$'
           example: "123456"
-          description: "6-digit OTP code."
+          description: "The 6-digit code."
     DecryptPIIRequest:
       type: object
       required: [ciphertext]
@@ -1218,8 +1147,7 @@ components:
         ciphertext:
           type: string
           minLength: 1
-          example: "vault:v1:v90bM0LC7ugYyIEoC1Mry+Xu7p9AndTvYsIGe1gsHI54kut2oxWViXVOHd5w"
-          description: "A Vault transit ciphertext that belongs to the caller's account (one of pii.*_encrypted)."
+          description: "One of the caller's own `pii.*_encrypted` values."
     OTPGenerateResponse:
       type: object
       required: [success, message, data]
@@ -1230,7 +1158,7 @@ components:
           type: object
           properties:
             status: { type: string, example: "pending" }
-            to: { type: string, example: "alice@example.com", description: "Recipient the OTP was sent to, as reported by the OTP service (email or mobile)." }
+            to: { type: string, example: "alice@example.com", description: "Where the code was sent." }
             channel: { type: string, enum: [email, sms], example: "email" }
     OTPVerifyResponse:
       type: object
@@ -1246,7 +1174,6 @@ components:
             valid: { type: boolean, example: true }
             jwt:
               nullable: true
-              description: "Present only when the underlying OTP service returns a token."
               allOf:
                 - $ref: '#/components/schemas/OTPJWTData'
     OTPJWTData:
@@ -1260,33 +1187,25 @@ components:
       type: object
       required: [plaintext]
       properties:
-        plaintext: { type: string, example: "alice@example.com", description: "The decrypted PII value." }
+        plaintext: { type: string, example: "alice@example.com", description: "The decrypted value." }
 
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
+      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
-            response: {}
-    UnauthorizedDeveloperError:
-      description: "Developer authentication failed (HTTP 401)."
-      content:
-        application/json:
-          schema: { $ref: '#/components/schemas/ApiError' }
-          example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Invalid developer token." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "Forbidden. Insufficient permissions."
+      description: "The caller does not have the scope required by this endpoint."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope: accounts:view" } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -1294,7 +1213,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "The requested resource was not found." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "The requested resource was not found." } }
             response: {}
     BadRequestError:
       description: "Invalid request."
@@ -1302,20 +1221,18 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     ConflictError:
-      description: "Conflict with existing resource."
+      description: "The address is already registered."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "CONFLICT", message: "An account with this identifier already exists." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "RESOURCE_ALREADY_EXISTS", message: "This address is already registered in the federation; sign in instead" } }
             response: {}
     RateLimitedError:
-      description: |
-        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
-        response header indicates how long the caller should wait before retrying.
+      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }
@@ -1323,33 +1240,24 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
 
   # -------------------- Security --------------------
   securitySchemes:
-    # This section is for documentation purposes.
-    # The server will check for the HTTP header first and fallbacks to context in case the headers are missing.
-
-    # 1. The Developer's Identity Token (Who they are)
     developerToken:
       type: http
       scheme: bearer
       bearerFormat: "JWT or Opaque"
-      description: |
-        A JWT or Opaque token that identifies the calling B2B developer/backend service.
+      description: "Token identifying the calling application, sent as `context.developerToken`."
 
-    # 2. The Developer's Request Signature (What they're attesting to)
     developerSignature:
       type: apiKey
       in: header
       name: Signature
       description: |
-        The IETF HTTP Signature (RFC 9421) used by B2B developers to ensure message
-        integrity and non-repudiation. This is passed in the `Signature` header.
+        Optional request signature (RFC 9421) for message integrity and non-repudiation,
+        sent in the `Signature` header.
 
-        Example Format:
+        Format:
         Signature keyId="...",algorithm="...",created="...",expires="...",headers="...",signature="..."
-
-        Example Value:
-        Signature keyId="fcd8c50d-edf0-49f0-b322-4b9bc2bc6218",algorithm="ed25519",created="1760443594",expires="1760447194",headers="(created) (expires) digest",signature="enGs3APIGK7PFRbefP1hMQe/iPjBAwc6R4wjmcysafnEAK5q9/+aKr0Ohc4J6w4XexD1nLgnmSy21yTYDRkSDw=="'

--- a/api/accounts-interfaces.yaml
+++ b/api/accounts-interfaces.yaml
@@ -112,7 +112,7 @@ paths:
                 value:
                   context:
                     id: "api.account.create"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-09-08T12:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                     developerToken: "fnt_..."
@@ -126,7 +126,7 @@ paths:
                 value:
                   context:
                     id: "api.account.create"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-09-08T12:01:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
                     developerToken: "fnt_..."
@@ -149,7 +149,7 @@ paths:
               example:
                 context:
                   id: "api.account.create"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2025-09-08T12:00:01Z"
                   msgId: "c1b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "successful"
@@ -169,7 +169,7 @@ paths:
                   value:
                     context:
                       id: "api.account.create"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-09-08T12:00:00Z"
                       msgId: "a1b2c3d4..."
                       status: "failed"
@@ -189,7 +189,7 @@ paths:
                   value:
                     context:
                       id: "api.account.create"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-09-08T12:00:00Z"
                       msgId: "a1b2c3d4..."
                       status: "failed"
@@ -219,7 +219,7 @@ paths:
                 value:
                   context:
                     id: "api.account.update"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-09-09T10:00:00Z"
                     msgId: "d1e2f3a4-b5c6-7890-1234-567890abcdef"
                     developerToken: "fnt_..."
@@ -232,7 +232,7 @@ paths:
                 value:
                   context:
                     id: "api.account.update"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-09-09T10:05:00Z"
                     msgId: "d2e3f4a5-b6c7-8901-2345-67890abcdef1"
                     developerToken: "fnt_..."
@@ -258,7 +258,7 @@ paths:
                   value:
                     context:
                       id: "api.account.update"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-09-09T10:05:01Z"
                       msgId: "d2e3f4a5-b6c7-8901-2345-67890abcdef1"
                       status: "successful"
@@ -295,7 +295,7 @@ paths:
             example:
               context:
                 id: "api.address.checkAvailability"
-                version: "1.0"
+                version: "v1"
                 ts: "2025-09-08T11:00:00Z"
                 msgId: "e1f2a3b4-c5d6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -311,7 +311,7 @@ paths:
               example:
                 context:
                   id: "api.address.checkAvailability"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2025-09-08T11:00:01Z"
                   msgId: "f1a2b3c4-d5e6-7890-1234-567890abcdef"
                   status: "successful"
@@ -345,7 +345,7 @@ paths:
                 value:
                   context:
                     id: "api.account.login"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-09-09T09:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                     developerToken: "fnt_..."
@@ -356,7 +356,7 @@ paths:
                 value:
                   context:
                     id: "api.account.login"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-09-09T09:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                     developerToken: "fnt_..."
@@ -367,7 +367,7 @@ paths:
                 value:
                   context:
                     id: "api.account.login"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-09-09T09:00:30Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
                     developerToken: "fnt_..."
@@ -379,7 +379,7 @@ paths:
                 value:
                   context:
                     id: "api.account.login"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-09-09T09:00:00Z"
                     msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef23"
                     developerToken: "fnt_..."
@@ -402,7 +402,7 @@ paths:
                   value:
                     context:
                       id: "api.account.login"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-09-09T09:00:01Z"
                       msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                       status: "successful"
@@ -414,7 +414,7 @@ paths:
                   value:
                     context:
                       id: "api.account.login"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-11-25T12:05:01Z"
                       msgId: "e1f2a3b4-c5d6-7890-1234-567890abcdef"
                       status: "successful"
@@ -428,7 +428,7 @@ paths:
                   value:
                     context:
                       id: "api.account.login"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-11-25T12:05:01Z"
                       msgId: "e1f2a3b4-c5d6-7890-1234-567890abcdef"
                       status: "successful"
@@ -464,7 +464,7 @@ paths:
             example:
               context:
                 id: "api.account.logout"
-                version: "1.0"
+                version: "v1"
                 ts: "2025-09-09T10:30:00Z"
                 msgId: "c1d2e3f4-a5b6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -499,7 +499,7 @@ paths:
             example:
               context:
                 id: "api.account.get"
-                version: "1.0"
+                version: "v1"
                 ts: "2025-09-09T09:05:00Z"
                 msgId: "e1f2a3b4-c5d6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -536,7 +536,7 @@ paths:
             example:
               context:
                 id: "api.account.otp.generate"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "aa11bb22-cc33-dd44-ee55-ff6677889900"
                 developerToken: "fnt_..."
@@ -552,7 +552,7 @@ paths:
               example:
                 context:
                   id: "api.account.otp.generate"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-04-07T10:00:01Z"
                   msgId: "aa11bb22-cc33-dd44-ee55-ff6677889900"
                   status: "successful"
@@ -593,7 +593,7 @@ paths:
             example:
               context:
                 id: "api.account.otp.verify"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-04-07T10:01:00Z"
                 msgId: "bb22cc33-dd44-ee55-ff66-778899001122"
                 developerToken: "fnt_..."
@@ -610,7 +610,7 @@ paths:
               example:
                 context:
                   id: "api.account.otp.verify"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-04-07T10:01:01Z"
                   msgId: "bb22cc33-dd44-ee55-ff66-778899001122"
                   status: "successful"
@@ -652,7 +652,7 @@ paths:
             example:
               context:
                 id: "api.account.pii.decrypt"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-04-07T10:02:00Z"
                 msgId: "cc33dd44-ee55-ff66-7788-990011223344"
                 developerToken: "fnt_..."
@@ -669,7 +669,7 @@ paths:
               example:
                 context:
                   id: "api.account.pii.decrypt"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-04-07T10:02:01Z"
                   msgId: "cc33dd44-ee55-ff66-7788-990011223344"
                   status: "successful"
@@ -702,7 +702,7 @@ paths:
   #           example:
   #             context:
   #               id: "api.account.lookup"
-  #               version: "1.0"
+  #               version: "v1"
   #               ts: "2025-09-09T09:06:00Z"
   #               msgId: "e2f3a4b5-c6d7-8901-2345-67890abcdef"
   #               developerToken: "fnt_..."
@@ -739,7 +739,7 @@ paths:
             example:
               context:
                 id: "api.address.resolve"
-                version: "1.0"
+                version: "v1"
                 ts: "2025-09-09T11:05:00Z"
                 msgId: "f1a2b3c4-d5e6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -779,7 +779,7 @@ paths:
             example:
               context:
                 id: "api.account.keys.register"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "11111111-2222-3333-4444-555555555555"
                 developerToken: "fnt_..."
@@ -878,7 +878,7 @@ paths:
             example:
               context:
                 id: "api.account.keys.search"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "22222222-3333-4444-5555-666666666666"
                 developerToken: "fnt_..."
@@ -911,7 +911,7 @@ components:
       required: [id, version, ts, msgId]
       properties:
         id: { type: string, example: "api.account.create" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
@@ -923,7 +923,7 @@ components:
       required: [id, version, ts, msgId, status]
       properties:
         id: { type: string, example: "api.account.create" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true }
@@ -1192,7 +1192,6 @@ components:
     # --- OTP & PII (authenticated user) ---
     OTPVerifyRequest:
       type: object
-      required: [code]
       properties:
         code:
           type: string

--- a/api/accounts-interfaces.yaml
+++ b/api/accounts-interfaces.yaml
@@ -1323,8 +1323,6 @@ components:
       bearerFormat: "JWT or Opaque"
       description: |
         A JWT or Opaque token that identifies the calling B2B developer/backend service.
-        This is passed in the standard `Authorization: Bearer <token>` header.
-        (This can also be passed in the `context.developerToken` as a fallback).
 
     # 2. The Developer's Request Signature (What they're attesting to)
     developerSignature:

--- a/api/accounts-interfaces.yaml
+++ b/api/accounts-interfaces.yaml
@@ -140,8 +140,9 @@ paths:
           description: |
             Account registered successfully. Both federation branches (reservation-proof
             and signed-envelope) run the signup workflow synchronously to its COMMITTED
-            verdict before returning, so the call always answers 200. No token is minted
-            (`accessToken` is empty) — the client calls `/v1/account/login` next.
+            verdict, then mint a Keycloak session token via token exchange. The response
+            carries that token, so the client is logged in immediately — no follow-up
+            `/v1/account/login` is required.
           content:
             application/json:
               schema:
@@ -154,9 +155,9 @@ paths:
                   msgId: "c1b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "successful"
                 response:
-                  accountId: "018f2c3d-4e5f-7890-abcd-1234567890ab"
-                  did: "did:key:z..."
-                  status: "active"
+                  accessToken: "eyJ..."
+                  tokenType: "Bearer"
+                  expiresIn: 3600
         '400':
           description: "Bad request, such as a missing required field."
           content:
@@ -1096,18 +1097,15 @@ components:
           description: "For workflow steps: action-specific data validated dynamically against the workflow registry schema. For `cancel`: must include `workflowId`."
     CreateAccountResponse:
       type: object
+      required: [accessToken, tokenType, expiresIn]
       description: |
-        Registration completes synchronously to its COMMITTED verdict. Per R3 the workflow
-        does NOT mint a token — `accessToken` is empty and the client calls `/v1/account/login`
-        next. `txnId` is no longer populated (retained for back-compat). All fields are optional.
+        Registration completes synchronously to its COMMITTED verdict and mints a Keycloak
+        session token via token exchange. The response carries that token, so the client is
+        logged in immediately — no follow-up `/v1/account/login` is required.
       properties:
-        accessToken: { type: string, example: "" }
+        accessToken: { type: string, example: "eyJ..." }
         tokenType: { type: string, example: "Bearer" }
         expiresIn: { type: integer, example: 3600 }
-        txnId: { type: string, description: "Deprecated — no longer populated; registration completes synchronously." }
-        accountId: { type: string, example: "018f2c3d-4e5f-7890-abcd-1234567890ab" }
-        did: { type: string, example: "did:key:z..." }
-        status: { type: string, example: "active" }
     AvailabilityCheckRequest:
       type: object
       required: [address]

--- a/api/accounts-interfaces.yaml
+++ b/api/accounts-interfaces.yaml
@@ -306,21 +306,26 @@ paths:
         - "Account"
       summary: "User login (OTP or SSO)"
       description: |
-        Two flows:
+        Three request shapes, selectable above:
 
-        * **OTP**: send `username` to have a one-time code delivered, then send `username`
-          and `otp` to receive a session token.
-        * **SSO**: send `username` and `authToken`, a JWT signed by your own backend, to
-          receive a session token without a code.
+        * **Send OTP**: `username` only. Delivers a one-time code.
+        * **Verify OTP**: `username` and `otp`. Returns a session token.
+        * **SSO login**: `username` and `authToken`, a JWT signed by your own backend.
+          Returns a session token without a code.
+
+        `otp` and `authToken` are mutually exclusive.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_LoginRequest'
+              oneOf:
+                - $ref: '#/components/schemas/ApiRequest_LoginSendOTP'
+                - $ref: '#/components/schemas/ApiRequest_LoginVerifyOTP'
+                - $ref: '#/components/schemas/ApiRequest_LoginSSO'
             examples:
               InitiateOTPMobile:
-                summary: "OTP step 1: request a code (mobile)"
+                summary: "Send OTP (mobile)"
                 value:
                   context:
                     id: "api.account.login"
@@ -331,7 +336,7 @@ paths:
                   payload:
                     username: "+919876543210"
               InitiateOTPEmail:
-                summary: "OTP step 1: request a code (email)"
+                summary: "Send OTP (email)"
                 value:
                   context:
                     id: "api.account.login"
@@ -342,7 +347,7 @@ paths:
                   payload:
                     username: "alice@example.com"
               VerifyOTP:
-                summary: "OTP step 2: submit the code"
+                summary: "Verify OTP"
                 value:
                   context:
                     id: "api.account.login"
@@ -354,7 +359,7 @@ paths:
                     username: "alice@example.com"
                     otp: "1234"
               SSOLogin:
-                summary: "SSO: log in with an authToken"
+                summary: "SSO login"
                 value:
                   context:
                     id: "api.account.login"
@@ -377,7 +382,7 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               examples:
                 InitiateOTP_Response:
-                  summary: "OTP step 1: code sent"
+                  summary: "Send OTP: code delivered"
                   value:
                     context:
                       id: "api.account.login"
@@ -971,7 +976,9 @@ components:
     ApiRequest_RegistrationRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/RegistrationRequest' } } } ] }
     ApiRequest_UpdateAccountRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/UpdateAccountRequest' } } } ] }
     ApiRequest_AvailabilityCheckRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/AvailabilityCheckRequest' } } } ] }
-    ApiRequest_LoginRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/LoginRequest' } } } ] }
+    ApiRequest_LoginSendOTP: { title: "Send OTP", allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/LoginSendOTPRequest' } } } ] }
+    ApiRequest_LoginVerifyOTP: { title: "Verify OTP", allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/LoginVerifyOTPRequest' } } } ] }
+    ApiRequest_LoginSSO: { title: "SSO login", allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/LoginSSORequest' } } } ] }
     ApiRequest_ResolveRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/ResolveRequest' } } } ] }
     ApiRequest_OTPVerifyRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/OTPVerifyRequest' } } } ] }
     ApiRequest_DecryptPIIRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/DecryptPIIRequest' } } } ] }
@@ -1119,13 +1126,32 @@ components:
       required: [address]
       properties:
         address: { type: string, example: "alice", description: "The address to resolve." }
-    LoginRequest:
+    LoginSendOTPRequest:
       type: object
+      title: "Send OTP"
+      description: "Step 1 of the OTP flow: deliver a one-time code to the user."
       required: [username]
+      additionalProperties: false
       properties:
         username: { type: string, example: "alice", description: "Finternet address, email or mobile number." }
-        otp: { type: string, example: "1234", nullable: true, description: "The one-time code. OTP flow only." }
-        authToken: { type: string, minLength: 1, description: "A JWT signed by your backend. Supply instead of `otp` to log in without a code." }
+    LoginVerifyOTPRequest:
+      type: object
+      title: "Verify OTP"
+      description: "Step 2 of the OTP flow: exchange the code for a session token."
+      required: [username, otp]
+      additionalProperties: false
+      properties:
+        username: { type: string, example: "alice", description: "Finternet address, email or mobile number." }
+        otp: { type: string, example: "1234", description: "The one-time code delivered in step 1." }
+    LoginSSORequest:
+      type: object
+      title: "SSO login"
+      description: "Exchange a JWT signed by your own backend for a session token, without a code."
+      required: [username, authToken]
+      additionalProperties: false
+      properties:
+        username: { type: string, example: "alice", description: "Finternet address, email or mobile number." }
+        authToken: { type: string, minLength: 1, description: "A JWT signed by your backend." }
     AvailabilityResponse:
       type: object
       properties:

--- a/api/accounts-interfaces.yaml
+++ b/api/accounts-interfaces.yaml
@@ -53,6 +53,9 @@ info:
     | `POST /v1/account/create` | `accounts:create` |
     | `POST /v1/account/update` | `accounts:manage` |
     | `POST /v1/account/get` | `accounts:view` |
+    | `POST /v1/account/otp/generate` | *(scope resolved from apiID; requires user auth)* |
+    | `POST /v1/account/otp/verify` | *(scope resolved from apiID; requires user auth)* |
+    | `POST /v1/account/pii/decrypt` | *(scope resolved from apiID; requires user auth)* |
     | `POST /v1/account/login` | *(public — OTP/SSO bootstrap)* |
     | `POST /v1/account/logout` | *(public)* |
     | `POST /v1/address/checkAvailability` | *(public)* |
@@ -112,7 +115,7 @@ paths:
                     version: "1.0"
                     ts: "2025-09-08T12:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     address: "alice"
@@ -126,15 +129,19 @@ paths:
                     version: "1.0"
                     ts: "2025-09-08T12:01:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     address: "acmecorp"
                     name: "Acme Corporation"
                     entityType: "BUSINESS"
       responses:
-        '201':
-          description: "Account registered successfully."
+        '200':
+          description: |
+            Account registered successfully. Both federation branches (reservation-proof
+            and signed-envelope) run the signup workflow synchronously to its COMMITTED
+            verdict before returning, so the call always answers 200. No token is minted
+            (`accessToken` is empty) — the client calls `/v1/account/login` next.
           content:
             application/json:
               schema:
@@ -147,9 +154,9 @@ paths:
                   msgId: "c1b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "successful"
                 response:
-                  accessToken: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
-                  tokenType: "Bearer"
-                  expiresIn: 3600
+                  accountId: "018f2c3d-4e5f-7890-abcd-1234567890ab"
+                  did: "did:key:z..."
+                  status: "COMMITTED"
         '400':
           description: "Bad request, such as a missing required field."
           content:
@@ -206,43 +213,66 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ApiRequest_UpdateAccountRequest'
-            example:
-              context:
-                id: "api.account.update"
-                version: "1.0"
-                ts: "2025-09-09T10:00:00Z"
-                msgId: "d1e2f3a4-b5c6-7890-1234-567890abcdef"
-                developerToken: "dev_pk_..."
-                authorization: "Bearer <End_User_JWT_Token>"
-              payload:
-                name: "Alice Smith-Jones"
-                mobile: "+919876543211"
+            examples:
+              Initiate:
+                summary: "Start the profile-update workflow"
+                value:
+                  context:
+                    id: "api.account.update"
+                    version: "1.0"
+                    ts: "2025-09-09T10:00:00Z"
+                    msgId: "d1e2f3a4-b5c6-7890-1234-567890abcdef"
+                    developerToken: "fnt_..."
+                    authorization: "Bearer <End_User_JWT_Token>"
+                  payload:
+                    action: "initiate"
+                    data: {}
+              Cancel:
+                summary: "Cancel an in-flight profile-update workflow"
+                value:
+                  context:
+                    id: "api.account.update"
+                    version: "1.0"
+                    ts: "2025-09-09T10:05:00Z"
+                    msgId: "d2e3f4a5-b6c7-8901-2345-67890abcdef1"
+                    developerToken: "fnt_..."
+                    authorization: "Bearer <End_User_JWT_Token>"
+                  payload:
+                    action: "cancel"
+                    data:
+                      workflowId: "018f2c3d-4e5f-7890-abcd-1234567890ab"
       responses:
         '200':
-          description: "Account profile updated successfully."
+          description: |
+            Workflow step completed, or (for `action: cancel`) the workflow was cancelled.
+            The `response` object is the workflow step result; its shape depends on the
+            action/step and is validated downstream against the workflow registry schema.
+            For `cancel` it is `{ workflowId, status: "cancelled" }`.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse_UpdatedAccountProfile'
+                $ref: '#/components/schemas/ApiResponse'
+              examples:
+                Cancelled:
+                  summary: "action: cancel"
+                  value:
+                    context:
+                      id: "api.account.update"
+                      version: "1.0"
+                      ts: "2025-09-09T10:05:01Z"
+                      msgId: "d2e3f4a5-b6c7-8901-2345-67890abcdef1"
+                      status: "successful"
+                    response:
+                      workflowId: "018f2c3d-4e5f-7890-abcd-1234567890ab"
+                      status: "cancelled"
+        '202':
+          description: "Workflow step accepted and still running (asynchronous)."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '409':
-          description: "Conflict, the new phone number is already in use."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-              example:
-                context:
-                  id: "api.account.update"
-                  version: "1.0"
-                  ts: "2025-09-08T12:00:00Z"
-                  msgId: "a1b2c3d4..."
-                  status: "failed"
-                  error:
-                    code: "PHONE_NUMBER_IN_USE"
-                    message: "The phone number is already associated with another account."
-                response: {}
 
   /v1/address/checkAvailability:
     post:
@@ -265,7 +295,7 @@ paths:
                 version: "1.0"
                 ts: "2025-09-08T11:00:00Z"
                 msgId: "e1f2a3b4-c5d6-7890-1234-567890abcdef"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
               payload:
                 address: "newuser"
       responses:
@@ -315,7 +345,7 @@ paths:
                     version: "1.0"
                     ts: "2025-09-09T09:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     username: "+919876543210"
               InitiateOTPEmail:
@@ -326,7 +356,7 @@ paths:
                     version: "1.0"
                     ts: "2025-09-09T09:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     username: "alice@example.com"
               VerifyOTP:
@@ -337,7 +367,7 @@ paths:
                     version: "1.0"
                     ts: "2025-09-09T09:00:30Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     username: "alice@example.com"
                     otp: "1234"
@@ -349,7 +379,7 @@ paths:
                     version: "1.0"
                     ts: "2025-09-09T09:00:00Z"
                     msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef23"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     username: "alice@example.com"
                     ssoLogin: true
@@ -434,7 +464,7 @@ paths:
                 version: "1.0"
                 ts: "2025-09-09T10:30:00Z"
                 msgId: "c1d2e3f4-a5b6-7890-1234-567890abcdef"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload: {}
       responses:
@@ -469,7 +499,7 @@ paths:
                 version: "1.0"
                 ts: "2025-09-09T09:05:00Z"
                 msgId: "e1f2a3b4-c5d6-7890-1234-567890abcdef"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload: {}
       responses:
@@ -481,6 +511,175 @@ paths:
                 $ref: '#/components/schemas/ApiResponse_AccountProfile'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+
+  /v1/account/otp/generate:
+    post:
+      tags:
+        - "Account"
+      summary: "Generate an OTP for the authenticated user"
+      description: |
+        Generates and sends an OTP to the authenticated user's email or mobile,
+        derived from the account PII. The payload is empty — the recipient is
+        resolved server-side from the session. Requires Developer + User auth.
+      security:
+        - developerToken: []
+        - developerSignature: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_Empty'
+            example:
+              context:
+                id: "api.account.otp.generate"
+                version: "1.0"
+                ts: "2026-04-07T10:00:00Z"
+                msgId: "aa11bb22-cc33-dd44-ee55-ff6677889900"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload: {}
+      responses:
+        '200':
+          description: "OTP generated and sent."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_OTPGenerate'
+              example:
+                context:
+                  id: "api.account.otp.generate"
+                  version: "1.0"
+                  ts: "2026-04-07T10:00:01Z"
+                  msgId: "aa11bb22-cc33-dd44-ee55-ff6677889900"
+                  status: "successful"
+                response:
+                  success: true
+                  message: "OTP sent successfully"
+                  data:
+                    status: "pending"
+                    to: "alice@example.com"
+                    channel: "email"
+        '400':
+          description: "No contact information available for the account."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+
+  /v1/account/otp/verify:
+    post:
+      tags:
+        - "Account"
+      summary: "Verify an OTP for the authenticated user"
+      description: |
+        Verifies a 6-digit OTP code for the authenticated user. The recipient is
+        derived server-side from the account PII. Requires Developer + User auth.
+      security:
+        - developerToken: []
+        - developerSignature: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_OTPVerifyRequest'
+            example:
+              context:
+                id: "api.account.otp.verify"
+                version: "1.0"
+                ts: "2026-04-07T10:01:00Z"
+                msgId: "bb22cc33-dd44-ee55-ff66-778899001122"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                code: "123456"
+      responses:
+        '200':
+          description: "OTP verification result."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_OTPVerify'
+              example:
+                context:
+                  id: "api.account.otp.verify"
+                  version: "1.0"
+                  ts: "2026-04-07T10:01:01Z"
+                  msgId: "bb22cc33-dd44-ee55-ff66-778899001122"
+                  status: "successful"
+                response:
+                  success: true
+                  message: "OTP verified successfully"
+                  data:
+                    status: "verified"
+                    valid: true
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          description: "Unauthorized, or the OTP is invalid."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+
+  /v1/account/pii/decrypt:
+    post:
+      tags:
+        - "Account"
+      summary: "Decrypt one of the caller's own PII ciphertexts"
+      description: |
+        Decrypts a Vault transit ciphertext that belongs to the authenticated
+        account (one of its `pii.*_encrypted` values). A ciphertext that does not
+        belong to the account is refused with `403` (no decryption oracle).
+        Requires Developer + User auth.
+      security:
+        - developerToken: []
+        - developerSignature: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_DecryptPIIRequest'
+            example:
+              context:
+                id: "api.account.pii.decrypt"
+                version: "1.0"
+                ts: "2026-04-07T10:02:00Z"
+                msgId: "cc33dd44-ee55-ff66-7788-990011223344"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                ciphertext: "vault:v1:v90bM0LC7ugYyIEoC1Mry+Xu7p9AndTvYsIGe1gsHI54kut2oxWViXVOHd5w"
+      responses:
+        '200':
+          description: "Decrypted plaintext."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_DecryptPII'
+              example:
+                context:
+                  id: "api.account.pii.decrypt"
+                  version: "1.0"
+                  ts: "2026-04-07T10:02:01Z"
+                  msgId: "cc33dd44-ee55-ff66-7788-990011223344"
+                  status: "successful"
+                response:
+                  plaintext: "alice@example.com"
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   # /v1/account/lookup:
   #   post:
@@ -503,7 +702,7 @@ paths:
   #               version: "1.0"
   #               ts: "2025-09-09T09:06:00Z"
   #               msgId: "e2f3a4b5-c6d7-8901-2345-67890abcdef"
-  #               developerToken: "dev_pk_..."
+  #               developerToken: "fnt_..."
   #               authorization: "Bearer eyJ..."
   #             payload:
   #               email: "bob.smith@example.com"
@@ -540,7 +739,7 @@ paths:
                 version: "1.0"
                 ts: "2025-09-09T11:05:00Z"
                 msgId: "f1a2b3c4-d5e6-7890-1234-567890abcdef"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
               payload:
                 address: "alice"
       responses:
@@ -561,8 +760,8 @@ paths:
       tags: [Account Keys]
       summary: "Register an additional public key for the calling account"
       description: |
-        Bind an additional public key to the authenticated account. Used for adding a
-        new device, a hardware-backed key, or an agent key with a constrained purpose.
+        Register an additional public key (or wallet address) for the authenticated
+        account on a given chain. Supply the raw `publicKey` and/or the `walletAddress`.
       security:
         - developerToken: []
         - developerSignature: []
@@ -578,15 +777,14 @@ paths:
                 version: "1.0"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "11111111-2222-3333-4444-555555555555"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
-                publicKeyMultibase: "z6Mk..."
-                keyType: "Ed25519VerificationKey2020"
-                purpose: ["assertion", "authentication"]
-                label: "iPhone 15"
+                chainId: "eip155:1"
+                publicKey: "0x04a1b2c3d4e5f6..."
+                isPrimary: true
       responses:
-        '200':
+        '201':
           description: "Key registered."
           content:
             application/json:
@@ -654,8 +852,8 @@ paths:
       tags: [Account Keys]
       summary: "List/search public keys for an account"
       description: |
-        Returns the keys bound to the calling account (or to the account specified by
-        `address` when called with admin scope), filtered by purpose/status.
+        Returns the keys bound to the calling account, optionally filtered by
+        `chainId`/`isPrimary` and paginated with `limit`/`offset`.
       security:
         - developerToken: []
         - developerSignature: []
@@ -671,13 +869,13 @@ paths:
                 version: "1.0"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "22222222-3333-4444-5555-666666666666"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
                 filters:
-                  purpose: "assertion"
-                  status: "active"
-                pagination: { page: 1, pageSize: 20 }
+                  chainId: "eip155:1"
+                  isPrimary: true
+                pagination: { limit: 20, offset: 0 }
       responses:
         '200':
           description: "Key list."
@@ -706,7 +904,7 @@ components:
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
-        developerToken: { type: string, example: "dev_pk_...", nullable: true, description: "B2B Developer API Key/Token" }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "B2B Developer API Key/Token" }
         developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "B2B Developer Signature (e.g., HMAC)" }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token." }
     ResponseContext:
@@ -725,9 +923,9 @@ components:
             - $ref: '#/components/schemas/ErrorPayload'
     Signature:
       type: object
-      required: [type, jws]
+      required: [key_id, jws]
       properties:
-        type: { type: string, example: "JsonWebSignature2020" }
+        key_id: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
         jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object." }
     ErrorPayload:
       type: object
@@ -767,121 +965,134 @@ components:
     ApiRequest_AvailabilityCheckRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/AvailabilityCheckRequest' } } } ] }
     ApiRequest_LoginRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/LoginRequest' } } } ] }
     ApiRequest_ResolveRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/ResolveRequest' } } } ] }
+    ApiRequest_OTPVerifyRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/OTPVerifyRequest' } } } ] }
+    ApiRequest_DecryptPIIRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/DecryptPIIRequest' } } } ] }
 
 
     # --- Specific Response Envelopes ---
-    ApiResponse_RegistrationSuccess: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/RegistrationSuccessResponse' } } } ] }
+    ApiResponse_RegistrationSuccess: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/CreateAccountResponse' } } } ] }
     ApiResponse_AvailabilityResponse: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/AvailabilityResponse' } } } ] }
     ApiResponse_AccountProfile: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/AccountProfile' } } } ] }
-    ApiResponse_UpdatedAccountProfile: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/UpdatedAccountProfile' } } } ] }
     ApiResponse_ResolveResponse: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/ResolveResponse' } } } ] }
+    ApiResponse_OTPGenerate: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/OTPGenerateResponse' } } } ] }
+    ApiResponse_OTPVerify: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/OTPVerifyResponse' } } } ] }
+    ApiResponse_DecryptPII: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/DecryptPIIResponse' } } } ] }
 
     ApiResponse_Success: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { type: object, properties: { message: { type: string, example: "Signout successful" } } } } } ] }
 
-    # --- Account Keys ---
-    AccountKeyPurpose:
-      type: string
-      enum: [authentication, assertion, keyAgreement, capabilityInvocation, capabilityDelegation]
-    AccountKeyStatus:
-      type: string
-      enum: [active, revoked]
-    AccountKeyInfo:
+    # --- Account Keys (Public Key Registry) ---
+    PublicKeyRegistryEntry:
       type: object
-      required: [keyId, publicKeyMultibase, keyType, status, createdAt]
+      required: [id, chainId, address, isPrimary, createdAt, updatedAt]
       properties:
-        keyId: { type: string, format: uuid }
-        publicKeyMultibase: { type: string, example: "z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH" }
-        keyType: { type: string, example: "Ed25519VerificationKey2020" }
-        purpose:
-          type: array
-          items: { $ref: '#/components/schemas/AccountKeyPurpose' }
-        label: { type: string, nullable: true, description: "Human-readable label (e.g. device name)." }
-        status: { $ref: '#/components/schemas/AccountKeyStatus' }
-        isPrimary: { type: boolean, default: false, description: "Primary key — provisioned at registration; cannot be removed via /remove." }
+        id: { type: string, format: uuid }
+        chainId: { type: string, example: "eip155:1", description: "Chain identifier the key is registered against." }
+        publicKey: { type: string, example: "0x04a1b2c3d4e5f6...", description: "Raw chain-specific public key. Omitted when only a wallet address was registered." }
+        address: { type: string, example: "0xAbC1230000000000000000000000000000000000", description: "On-chain wallet address derived from / supplied with the key." }
+        isPrimary: { type: boolean, example: true }
         createdAt: { type: string, format: date-time }
-        revokedAt: { type: string, format: date-time, nullable: true }
+        updatedAt: { type: string, format: date-time }
     RegisterKeyRequest:
       type: object
-      required: [publicKeyMultibase, keyType, purpose]
+      required: [chainId]
+      description: "At least one of `publicKey` or `walletAddress` must be supplied."
       properties:
-        publicKeyMultibase: { type: string }
-        keyType: { type: string, example: "Ed25519VerificationKey2020" }
-        purpose:
-          type: array
-          minItems: 1
-          items: { $ref: '#/components/schemas/AccountKeyPurpose' }
-        label: { type: string, nullable: true }
+        chainId: { type: string, minLength: 1, example: "eip155:1", description: "Chain identifier." }
+        publicKey: { type: string, minLength: 10, description: "Raw chain-specific public key (e.g. secp256k1 for EVM)." }
+        walletAddress: { type: string, minLength: 1, description: "On-chain address; used when the raw key is unavailable." }
+        isPrimary: { type: boolean }
+      anyOf:
+        - required: [publicKey]
+        - required: [walletAddress]
     RemoveKeyRequest:
       type: object
-      required: [keyId]
+      required: [id]
       properties:
-        keyId: { type: string, format: uuid }
+        id: { type: string, format: uuid }
     GetKeyRequest:
       type: object
-      required: [keyId]
+      required: [id]
       properties:
-        keyId: { type: string, format: uuid }
+        id: { type: string, format: uuid }
     SearchKeysRequest:
       type: object
       properties:
-        address:
-          type: string
-          nullable: true
-          description: "Account address to search keys for. Defaults to the caller. Specifying another address requires admin scope."
         filters:
           type: object
           properties:
-            purpose: { $ref: '#/components/schemas/AccountKeyPurpose' }
-            status: { $ref: '#/components/schemas/AccountKeyStatus' }
-          additionalProperties: true
+            chainId: { type: string }
+            isPrimary: { type: boolean }
         pagination:
           type: object
           properties:
-            page: { type: integer, minimum: 1, default: 1 }
-            pageSize: { type: integer, minimum: 1, maximum: 200, default: 20 }
+            limit: { type: integer, minimum: 1, maximum: 200 }
+            offset: { type: integer, minimum: 0 }
     AccountKeyList:
       type: object
-      required: [keys]
+      required: [keys, pagination]
       properties:
         keys:
           type: array
-          items: { $ref: '#/components/schemas/AccountKeyInfo' }
+          items: { $ref: '#/components/schemas/PublicKeyRegistryEntry' }
         pagination:
           type: object
           properties:
-            page: { type: integer }
-            pageSize: { type: integer }
-            totalItems: { type: integer }
-            totalPages: { type: integer }
+            total: { type: integer }
+            limit: { type: integer }
+            offset: { type: integer }
 
     ApiRequest_RegisterKeyRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/RegisterKeyRequest' } } } ] }
     ApiRequest_RemoveKeyRequest:   { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/RemoveKeyRequest' } } } ] }
     ApiRequest_GetKeyRequest:      { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/GetKeyRequest' } } } ] }
     ApiRequest_SearchKeysRequest:  { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/SearchKeysRequest' } } } ] }
 
-    ApiResponse_AccountKeyInfo: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/AccountKeyInfo' } } } ] }
+    ApiResponse_AccountKeyInfo: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/PublicKeyRegistryEntry' } } } ] }
     ApiResponse_AccountKeyList: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/AccountKeyList' } } } ] }
 
     # --- Core Data Schemas (Payloads) ---
     RegistrationRequest:
       type: object
       required: [address, name, entityType]
+      description: |
+        Email/mobile are NOT accepted here — they are taken from the JWT access token
+        (username claim) in the Authorization header, obtained via the OTP login flow.
       properties:
         address: { type: string, example: "alice" }
         name: { type: string, example: "Alice Smith" }
         entityType: { type: string, enum: [PERSONAL, BUSINESS] }
+        signedRegisterNameEnvelope: { type: string, nullable: true, description: "Optional base64-encoded ULIP envelope the user signed with their Ed25519 key. When present, registration uses the envelope-driven asynchronous workflow path that registers the name at the central registry." }
+        reservationProof: { type: string, nullable: true, description: "JSON-serialized signed reservation proof from the registry (ADR-007 OTP-first). When present, units-api verifies the registrar signature and creates the account directly." }
+        homeInstance: { type: string, nullable: true, description: "Accepted for forward-compatibility but currently IGNORED. The receiving instance is always the home." }
     UpdateAccountRequest:
       type: object
+      required: [action, data]
+      description: |
+        Public facade for the profile-update workflow. `action` discriminates the operation:
+        workflow steps (`initiate`, `verify_*`) are dispatched to the workflow executor and
+        the per-action `data` is validated downstream against the registered workflow schema;
+        `cancel` cancels the workflow and requires `data.workflowId`.
       properties:
-        name: { type: string, example: "Alice Smith-Jones" }
-        mobile: { type: string, example: "+919876543211", nullable: true }
-    RegistrationSuccessResponse:
+        action:
+          type: string
+          enum: [initiate, verify_current_ownership, verify_new_email, verify_new_mobile, cancel]
+          description: "Workflow step or control-plane operation."
+        data:
+          type: object
+          description: "For workflow steps: action-specific data validated dynamically against the workflow registry schema. For `cancel`: must include `workflowId`."
+    CreateAccountResponse:
       type: object
+      description: |
+        Registration completes synchronously to its COMMITTED verdict. Per R3 the workflow
+        does NOT mint a token — `accessToken` is empty and the client calls `/v1/account/login`
+        next. `txnId` is no longer populated (retained for back-compat). All fields are optional.
       properties:
-        accessToken: { type: string, example: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..." }
+        accessToken: { type: string, example: "" }
         tokenType: { type: string, example: "Bearer" }
         expiresIn: { type: integer, example: 3600 }
-        isExisting: { type: boolean, example: false, description: "Indicates if the account already existed" }
+        txnId: { type: string, description: "Deprecated — no longer populated; registration completes synchronously." }
+        accountId: { type: string, example: "018f2c3d-4e5f-7890-abcd-1234567890ab" }
+        did: { type: string, example: "did:key:z..." }
+        status: { type: string, example: "COMMITTED" }
     AvailabilityCheckRequest:
       type: object
       required: [address]
@@ -891,8 +1102,7 @@ components:
       type: object
       required: [address]
       properties:
-        address: { type: string, example: "alice" }
-        purpose: { type: string, enum: [authentication, assertion, keyAgreement, capabilityInvocation, capabilityDelegation], nullable: true, description: "Filter keys by purpose" }
+        address: { type: string, example: "alice", description: "The address to resolve (e.g., alice)" }
     LoginRequest:
       type: object
       required: [username]
@@ -926,32 +1136,104 @@ components:
         did: { type: string, example: "did:key:z..." }
     AccountProfile:
       type: object
-      required: [did, address, name, entityType]
+      required: [did, address, email, name, entityType, status, vaultEntityID, createdAt]
       properties:
         did: { type: string, example: "did:key:z..." }
         address: { type: string, example: "alice" }
-        email: { type: string, format: email, example: "u***@example.com", nullable: true }
+        email: { type: string, format: email, example: "u***@example.com" }
         name: { type: string, example: "Alice Smith" }
-        mobile: { type: string, example: "+9***3210", nullable: true }
+        phoneNumber: { type: string, example: "+9***3210", nullable: true }
         entityType: { type: string, enum: [PERSONAL, BUSINESS] }
+        status: { type: string, example: "active" }
+        controllers:
+          type: array
+          description: "Array of DIDs for key controllers."
+          items: { type: string }
         vaultEntityID: { type: string, example: "b50db0e7d5f76bfefcbf7f45ae7683e106f221b9a6d34036284ad749c761422b" }
+        homeInstance: { type: string, nullable: true, description: "Federation home-instance UUID the account is bound to. Empty for non-federation accounts." }
+        createdAt: { type: string, format: date-time }
         pii:
           type: object
+          nullable: true
           properties:
+            address_encrypted: { type: string }
+            address_masked: { type: string }
             email_encrypted: { type: string, example: "vault:v1:v90bM0LC7ugYyIEoC1Mry+Xu7p9AndTvYsIGe1gsHI54kut2oxWViXVOHd5w" }
             email_masked: { type: string, example: "u***@example.com" }
             mobile_encrypted: { type: string, example: "vault:v1:LMliIQx/Urho2xrAidounWtzDT01P1lmA+l+bisgefLervcpdJhdhdc=" }
             mobile_masked: { type: string, example: "+9***3210" }
-    UpdatedAccountProfile:
+        consents:
+          type: array
+          description: "Per-document consent status so the app can prompt for outstanding Terms agreements."
+          items:
+            type: object
+            required: [docType, currentVersion, consentRequired]
+            properties:
+              docType: { type: string, example: "privacy_policy" }
+              currentVersion: { type: integer, example: 3 }
+              acceptedVersion: { type: integer, nullable: true, example: 2 }
+              consentRequired: { type: boolean, example: true }
+
+    # --- OTP & PII (authenticated user) ---
+    OTPVerifyRequest:
       type: object
-      required: [did, address, name, entityType]
+      required: [code]
       properties:
-        did: { type: string, example: "did:key:z..." }
-        address: { type: string, example: "alice" }
-        email: { type: string, format: email, example: "u***@example.com", nullable: true }
-        name: { type: string, example: "Alice Smith" }
-        mobile: { type: string, example: "+9***3210", nullable: true }
-        entityType: { type: string, enum: [PERSONAL, BUSINESS] }
+        code:
+          type: string
+          pattern: '^\d{6}$'
+          example: "123456"
+          description: "6-digit OTP code."
+    DecryptPIIRequest:
+      type: object
+      required: [ciphertext]
+      properties:
+        ciphertext:
+          type: string
+          minLength: 1
+          example: "vault:v1:v90bM0LC7ugYyIEoC1Mry+Xu7p9AndTvYsIGe1gsHI54kut2oxWViXVOHd5w"
+          description: "A Vault transit ciphertext that belongs to the caller's account (one of pii.*_encrypted)."
+    OTPGenerateResponse:
+      type: object
+      required: [success, message, data]
+      properties:
+        success: { type: boolean, example: true }
+        message: { type: string, example: "OTP sent successfully" }
+        data:
+          type: object
+          properties:
+            status: { type: string, example: "pending" }
+            to: { type: string, example: "alice@example.com", description: "Recipient the OTP was sent to, as reported by the OTP service (email or mobile)." }
+            channel: { type: string, enum: [email, sms], example: "email" }
+    OTPVerifyResponse:
+      type: object
+      required: [success, message, data]
+      properties:
+        success: { type: boolean, example: true }
+        message: { type: string, example: "OTP verified successfully" }
+        data:
+          type: object
+          required: [status, valid]
+          properties:
+            status: { type: string, example: "verified" }
+            valid: { type: boolean, example: true }
+            jwt:
+              nullable: true
+              description: "Present only when the underlying OTP service returns a token."
+              allOf:
+                - $ref: '#/components/schemas/OTPJWTData'
+    OTPJWTData:
+      type: object
+      properties:
+        token: { type: string, example: "eyJ..." }
+        expiresIn: { type: integer, example: 3600 }
+        tokenType: { type: string, example: "Bearer" }
+        issuer: { type: string, example: "otp-service" }
+    DecryptPIIResponse:
+      type: object
+      required: [plaintext]
+      properties:
+        plaintext: { type: string, example: "alice@example.com", description: "The decrypted PII value." }
 
   # -------------------- Responses --------------------
   responses:

--- a/api/adapter-interface.yaml
+++ b/api/adapter-interface.yaml
@@ -2363,7 +2363,7 @@ components:
               msgId: "..."
               status: "failed"
               error:
-                code: "INVALID_INPUT"
+                code: "INVALID_REQUEST"
                 message: "Invalid address format for this chain"
             response: {}
 

--- a/api/adapter-interface.yaml
+++ b/api/adapter-interface.yaml
@@ -6,29 +6,26 @@ info:
 
     Chain adapters are **standalone services** that bridge UNITS with external blockchain networks.
     They can be built by the core team or the community. Each adapter handles chain-specific
-    RPC calls, data normalization, and transaction lifecycle.
+    RPC calls and the transaction lifecycle.
 
     ### Key Design Principles
 
-    - **All POST, Envelope Pattern** — Every endpoint uses POST with the UNITS envelope
+    - **All POST, Envelope Pattern** — Every developer endpoint uses POST with the UNITS envelope
       (`{context, payload}` request / `{context, response}` response). This enables:
       - End-to-end request tracing via `context.msgId` across all services
       - Future gRPC migration without changing request/response bodies (no HTTP hard-binding)
       - Consistent error handling across all endpoints
-    - **Lighter Context** — Adapter context carries `id`, `version`, `ts`, `msgId` only.
-      No `developerToken` or `authorization` — adapter auth uses mTLS or shared secret at the transport layer.
-    - **Normalization contract** — The adapter is the authoritative source for decimal conversion.
-      Hex conversion happens INSIDE the adapter. All amounts are opaque strings — never parsed as float.
-      The `context.valueFormat` field controls the representation:
-      - `raw` (default): Smallest-unit integer strings (`"100500000"` for 100.5 USDC). Used by internal callers.
-      - `display`: Human-readable decimal strings (`"100.50"` for 100.5 USDC). Used by UI-facing callers.
-      No `decimals` field is ever sent alongside an amount. The adapter converts both directions using
-      token class / chain metadata. This avoids cross-ecosystem issues (JS overflow, floating-point precision).
-    - **Stateless** — Adapters do not store state. They are proxies to on-chain data.
-    - **Multi-chain capable** — A single adapter deployment MAY serve multiple chains (e.g., all EVM chains via Alchemy).
-      The `chainId` (CAIP-2) is **always required** in every payload — even for single-chain adapters.
-      This avoids ambiguity, supports adapters serving both mainnet and testnet, and means the
-      caller (which already knows the chainId from the registry lookup) simply passes it through.
+    - **Stateless** — Adapters do not store durable request state; they are proxies to on-chain data.
+    - **Multi-chain capable** — A single adapter deployment MAY serve multiple chains (e.g., all EVM
+      chains via Alchemy). The `chainId` is **always required** in every payload — even for single-chain
+      adapters. Both Alchemy-style identifiers (`ethereum-mainnet`) and CAIP-2 identifiers (`eip155:1`)
+      are accepted.
+
+    ### Base Path
+
+    All developer routes are mounted under the base group `/api/v1/chain-adapter`. The `GET /health`
+    liveness probe is registered at the root, outside the base group, and is the only endpoint that
+    does not use the envelope.
 
     ### Envelope Format
 
@@ -36,10 +33,12 @@ info:
     ```json
     {
       "context": {
-        "id": "adapter.chain.info",
+        "id": "chain.info",
         "version": "1.0",
         "ts": "2026-02-17T10:00:00Z",
-        "msgId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        "msgId": "550e8400-e29b-41d4-a716-446655440000",
+        "developerToken": "dev_key_abc123",
+        "authorization": "Bearer eyJhbGciOiJIUzI1NiJ9..."
       },
       "payload": { ... }
     }
@@ -49,10 +48,10 @@ info:
     ```json
     {
       "context": {
-        "id": "adapter.chain.info",
+        "id": "chain.info",
         "version": "1.0",
         "ts": "2026-02-17T10:00:01Z",
-        "msgId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "msgId": "550e8400-e29b-41d4-a716-446655440000",
         "status": "successful"
       },
       "response": { ... }
@@ -63,12 +62,12 @@ info:
     ```json
     {
       "context": {
-        "id": "adapter.chain.info",
+        "id": "chain.info",
         "version": "1.0",
         "ts": "2026-02-17T10:00:01Z",
-        "msgId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "msgId": "550e8400-e29b-41d4-a716-446655440000",
         "status": "failed",
-        "error": { "code": "UPSTREAM_UNAVAILABLE", "message": "Chain RPC endpoint is not responding" }
+        "error": { "code": "SERVICE_UNAVAILABLE", "message": "Chain RPC endpoint is not responding" }
       },
       "response": {}
     }
@@ -78,44 +77,33 @@ info:
 
     The `context.msgId` flows from App Backend → UNITS Workflow → Adapter → UNITS Callback,
     enabling grep-based log correlation across all services in a single transaction flow.
-
-    ### Authentication
-
-    Adapters manage their own authentication with upstream providers (API keys, bearer tokens).
-    UNITS authenticates to adapters via a shared secret or mTLS (configured per deployment).
-    No authentication fields appear in the envelope — auth is at the transport layer.
-
-    ### Callback Contract
-
-    For asynchronous transaction monitoring, the `/transactions/submit` endpoint accepts a
-    `callbackUrl` and `transactionId`. When the adapter detects transaction confirmation on-chain,
-    it calls UNITS back at `POST /v1/token/transact` with `operation: "update"` and the
-    `transactionId` for reverse mapping. The adapter owns the monitoring loop.
+    The `context.version` and `context.msgId` are echoed back on the response; the response
+    `context.id` is set by the adapter to the operation identifier.
 
     ### Building a Community Adapter
 
-    1. Implement all required endpoints (Chain Discovery + Balance Discovery + Transaction Lifecycle)
+    1. Implement all required endpoints (Chain Discovery + Address/Balance + Asset + Transaction Lifecycle)
     2. Pass the conformance test suite (published alongside this spec)
-    3. Register your adapter URL in the UNITS chain registry via `POST /v1/registry/chains/register`
+    3. Register your adapter URL in the UNITS chain registry
   version: "1.0.0"
   contact:
     name: "Finternet Adapter Team"
 servers:
   - url: "https://adapter-alchemy.finternet.io"
     description: "Alchemy Adapter (Reference Implementation)"
-  - url: "http://localhost:4000"
+  - url: "http://localhost:3500"
     description: "Local Adapter Development"
 tags:
   - name: "Chain Discovery"
-    description: "Chain identity, capabilities, and current state endpoints."
+    description: "Chain identity, capabilities, current head, and block lookup endpoints."
   - name: "Chain Address"
-    description: "On-chain address resolution and balance discovery. Called by App Backend during import and by TokenEngine during pre-hook verification."
+    description: "On-chain account resolution and balance discovery. Called by App Backend during import and by TokenEngine during pre-hook verification."
   - name: "Chain Assets"
-    description: "On-chain asset resolution. Resolve token metadata from contract address."
+    description: "On-chain asset resolution. Resolve token metadata from an asset identifier."
   - name: "Chain Transactions"
-    description: "Transaction lifecycle endpoints — build, sign, submit, status, receipt. Called by TokenEngine during proxy transfer execution."
-  - name: "Adapter Info"
-    description: "Adapter metadata and health endpoints."
+    description: "Transaction lifecycle endpoints — build, submit, get, status, receipt. Called by TokenEngine during proxy transfer execution."
+  - name: "Health"
+    description: "Liveness probe (root path, no envelope)."
 
 # ===============================================================
 #   PATHS
@@ -123,42 +111,29 @@ tags:
 
 paths:
   # -------------------- Chain Discovery --------------------
-  /chain/info:
+  /api/v1/chain-adapter/chain/info:
     post:
       tags: ["Chain Discovery"]
       summary: "Get chain identity and metadata"
       description: |
-        Returns static identity and metadata for the specified chain — name, native currency,
-        block time, consensus mechanism, and explorer URLs.
-
-        Called during chain registration and by monitoring dashboards.
+        Returns static identity and metadata for the specified chain — name, network,
+        native currency, decimals, and average block time.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_ChainInfoRequest'
-            examples:
-              single_chain_adapter:
-                summary: "Single-chain adapter (e.g., Solana-only)"
-                value:
-                  context:
-                    id: "adapter.chain.info"
-                    version: "1.0"
-                    ts: "2026-02-17T10:00:00Z"
-                    msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                  payload:
-                    chainId: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
-              multi_chain_adapter:
-                summary: "Multi-chain adapter (e.g., Alchemy serving all EVM)"
-                value:
-                  context:
-                    id: "adapter.chain.info"
-                    version: "1.0"
-                    ts: "2026-02-17T10:00:00Z"
-                    msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef0"
-                  payload:
-                    chainId: "eip155:1"
+              $ref: '#/components/schemas/ApiRequest_ChainPayload'
+            example:
+              context:
+                id: "chain.info"
+                version: "1.0"
+                ts: "2026-02-17T10:00:00Z"
+                msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                developerToken: "dev_key_abc123"
+                authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
+              payload:
+                chainId: "ethereum-mainnet"
       responses:
         '200':
           description: "Chain info retrieved"
@@ -166,96 +141,48 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse_ChainInfo'
-              examples:
-                ethereum:
-                  summary: "Ethereum Mainnet"
-                  value:
-                    context:
-                      id: "adapter.chain.info"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef0"
-                      status: "successful"
-                    response:
-                      chainId: "eip155:1"
-                      name: "Ethereum Mainnet"
-                      chainFamily: "evm"
-                      isTestnet: false
-                      nativeCurrency:
-                        name: "Ether"
-                        symbol: "ETH"
-                        decimals: 18
-                      blockTime: 12
-                      consensus: "proof-of-stake"
-                      explorers:
-                        - name: "Etherscan"
-                          url: "https://etherscan.io"
-                          type: "primary"
-                solana:
-                  summary: "Solana Mainnet"
-                  value:
-                    context:
-                      id: "adapter.chain.info"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                      status: "successful"
-                    response:
-                      chainId: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
-                      name: "Solana Mainnet"
-                      chainFamily: "solana"
-                      isTestnet: false
-                      nativeCurrency:
-                        name: "SOL"
-                        symbol: "SOL"
-                        decimals: 9
-                      blockTime: 0.4
-                      consensus: "proof-of-history"
-                      explorers:
-                        - name: "Solana Explorer"
-                          url: "https://explorer.solana.com"
-                          type: "primary"
+              example:
+                context:
+                  id: "chain.info"
+                  version: "1.0"
+                  ts: "2026-02-17T10:00:01Z"
+                  msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                  status: "successful"
+                response:
+                  chainId: "ethereum-mainnet"
+                  name: "Ethereum Mainnet"
+                  network: "mainnet"
+                  currency: "ETH"
+                  decimals: 18
+                  blockTime: 12
         '400':
           $ref: '#/components/responses/BadRequestError'
         '503':
           $ref: '#/components/responses/UpstreamUnavailableError'
 
-  /chain/capabilities:
+  /api/v1/chain-adapter/chain/capabilities:
     post:
       tags: ["Chain Discovery"]
       summary: "Get chain capabilities"
       description: |
-        Returns the capability matrix for the specified chain — which operations the adapter
-        supports, which asset types are available, and any chain-specific constraints.
-
-        Used by UNITS to determine which operations can be routed to this adapter.
+        Returns the capability matrix for the specified chain — which transfer classes the
+        adapter supports and which asset types are available.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_ChainCapabilitiesRequest'
-            examples:
-              evm_chain:
-                summary: "EVM chain capabilities"
-                value:
-                  context:
-                    id: "adapter.chain.capabilities"
-                    version: "1.0"
-                    ts: "2026-02-17T10:00:00Z"
-                    msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef0"
-                  payload:
-                    chainId: "eip155:1"
-              solana_chain:
-                summary: "Solana chain capabilities"
-                value:
-                  context:
-                    id: "adapter.chain.capabilities"
-                    version: "1.0"
-                    ts: "2026-02-17T10:00:00Z"
-                    msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef01"
-                  payload:
-                    chainId: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+              $ref: '#/components/schemas/ApiRequest_ChainPayload'
+            example:
+              context:
+                id: "chain.capabilities"
+                version: "1.0"
+                ts: "2026-02-17T10:00:00Z"
+                msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef0"
+                developerToken: "dev_key_abc123"
+                authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
+              payload:
+                chainId: "ethereum-mainnet"
       responses:
         '200':
           description: "Capabilities retrieved"
@@ -263,95 +190,47 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse_ChainCapabilities'
-              examples:
-                evm_capabilities:
-                  summary: "Ethereum capabilities (full feature set)"
-                  value:
-                    context:
-                      id: "adapter.chain.capabilities"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef0"
-                      status: "successful"
-                    response:
-                      chainId: "eip155:1"
-                      supportedAssetTypes: ["native", "erc20", "erc721", "erc1155"]
-                      supportedOperations:
-                        - "chain.info"
-                        - "chain.capabilities"
-                        - "chain.head"
-                        - "accounts.resolve"
-                        - "accounts.holdings"
-                        - "balance.get"
-                        - "assets.resolve"
-                        - "transactions.build"
-                        - "transactions.submit"
-                        - "transactions.status"
-                        - "transactions.receipt"
-                      features:
-                        multisig: false
-                        batchTransactions: false
-                        callbacks: true
-                        gasEstimation: true
-                        feePreference: true
-                      constraints:
-                        maxBatchSize: 1
-                        maxGasLimit: "30000000"
-                solana_capabilities:
-                  summary: "Solana capabilities (no feePreference)"
-                  value:
-                    context:
-                      id: "adapter.chain.capabilities"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef01"
-                      status: "successful"
-                    response:
-                      chainId: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
-                      supportedAssetTypes: ["native", "spl"]
-                      supportedOperations:
-                        - "chain.info"
-                        - "chain.capabilities"
-                        - "chain.head"
-                        - "accounts.holdings"
-                        - "balance.get"
-                        - "transactions.build"
-                        - "transactions.submit"
-                        - "transactions.status"
-                      features:
-                        multisig: false
-                        batchTransactions: false
-                        callbacks: true
-                        gasEstimation: true
-                        feePreference: false
-                      constraints:
-                        maxBatchSize: 1
+              example:
+                context:
+                  id: "chain.capabilities"
+                  version: "1.0"
+                  ts: "2026-02-17T10:00:01Z"
+                  msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef0"
+                  status: "successful"
+                response:
+                  nativeTransfers: true
+                  tokenTransfers: true
+                  nftTransfers: true
+                  smartContracts: true
+                  assetTypes: ["native", "erc20", "erc721", "erc1155"]
         '400':
           $ref: '#/components/responses/BadRequestError'
         '503':
           $ref: '#/components/responses/UpstreamUnavailableError'
 
-  /chain/head:
+  /api/v1/chain-adapter/chain/head:
     post:
       tags: ["Chain Discovery"]
       summary: "Get latest block/slot"
       description: |
-        Returns the latest block (or slot) information for the specified chain.
+        Returns the latest block (or slot) for the specified chain.
         Used for liveness monitoring and to determine confirmation depth.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_ChainHeadRequest'
+              $ref: '#/components/schemas/ApiRequest_ChainPayload'
             example:
               context:
-                id: "adapter.chain.head"
+                id: "chain.head"
                 version: "1.0"
                 ts: "2026-02-17T10:00:00Z"
                 msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef01"
+                developerToken: "dev_key_abc123"
+                authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
               payload:
-                chainId: "eip155:1"
+                chainId: "ethereum-mainnet"
       responses:
         '200':
           description: "Chain head retrieved"
@@ -361,202 +240,217 @@ paths:
                 $ref: '#/components/schemas/ApiResponse_ChainHead'
               example:
                 context:
-                  id: "adapter.chain.head"
+                  id: "chain.head"
                   version: "1.0"
                   ts: "2026-02-17T10:00:01Z"
                   msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef01"
                   status: "successful"
                 response:
-                  chainId: "eip155:1"
-                  blockNumber: 19234567
-                  blockHash: "0xabc123def456..."
-                  timestamp: "2026-02-17T09:59:48Z"
-                  parentHash: "0xdef789abc012..."
+                  blockNumber: 19500000
+                  blockHash: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+                  timestamp: 1705312200
         '400':
           $ref: '#/components/responses/BadRequestError'
         '503':
           $ref: '#/components/responses/UpstreamUnavailableError'
 
+  /api/v1/chain-adapter/chain/block:
+    post:
+      tags: ["Chain Discovery"]
+      summary: "Get block by identifier"
+      description: |
+        Returns metadata for a single block, identified by block number, block hash, or slot.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_BlockPayload'
+            example:
+              context:
+                id: "chain.block"
+                version: "1.0"
+                ts: "2026-02-17T10:00:00Z"
+                msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef012"
+                developerToken: "dev_key_abc123"
+                authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
+              payload:
+                chainId: "ethereum-mainnet"
+                blockId: "19000000"
+      responses:
+        '200':
+          description: "Block retrieved"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_BlockInfo'
+              example:
+                context:
+                  id: "chain.block"
+                  version: "1.0"
+                  ts: "2026-02-17T10:00:01Z"
+                  msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef012"
+                  status: "successful"
+                response:
+                  blockNumber: 19000000
+                  blockHash: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+                  parentHash: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+                  timestamp: 1705312200
+                  transactionCount: 150
+                  transactions:
+                    - "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '503':
+          $ref: '#/components/responses/UpstreamUnavailableError'
+
   # -------------------- Accounts & Balance --------------------
-  /accounts/resolve:
+  /api/v1/chain-adapter/accounts/get:
     post:
       tags: ["Chain Address"]
-      summary: "Resolve account metadata"
+      summary: "Get account metadata"
       description: |
-        Returns metadata about an on-chain account — type (EOA, contract, multisig),
-        whether it exists, and chain-specific attributes.
-
+        Returns metadata about an on-chain account — its native balance and nonce.
         Used during proxy token import to validate addresses before creating shadow ledger entries.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_AccountResolveRequest'
+              $ref: '#/components/schemas/ApiRequest_AccountPayload'
             example:
               context:
-                id: "adapter.accounts.resolve"
+                id: "accounts.get"
                 version: "1.0"
                 ts: "2026-02-17T10:00:00Z"
-                msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef012"
+                msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef0123"
+                developerToken: "dev_key_abc123"
+                authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
               payload:
-                chainId: "eip155:1"
-                address: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
+                chainId: "ethereum-mainnet"
+                accountId: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
       responses:
         '200':
-          description: "Account resolved"
+          description: "Account retrieved"
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse_AccountInfo'
               example:
                 context:
-                  id: "adapter.accounts.resolve"
+                  id: "accounts.get"
                   version: "1.0"
                   ts: "2026-02-17T10:00:01Z"
-                  msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef012"
+                  msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef0123"
                   status: "successful"
                 response:
-                  chainId: "eip155:1"
-                  address: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-                  exists: true
-                  accountType: "eoa"
+                  address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                  balance: "1000000000000000000"
                   nonce: 42
         '400':
           $ref: '#/components/responses/BadRequestError'
         '503':
           $ref: '#/components/responses/UpstreamUnavailableError'
 
-  /accounts/holdings:
+  /api/v1/chain-adapter/accounts/holdings:
     post:
       tags: ["Chain Address"]
-      summary: "Get all token holdings for an address"
+      summary: "Get all token holdings for an account"
       description: |
-        Returns all known token holdings for the given address on the specified chain.
+        Returns all known token holdings for the given account on the specified chain.
         Used by App Backend during wallet import to discover tokens for proxy creation.
 
-        **Normalization:** Balance format depends on `context.valueFormat` (raw: integer strings, display: decimal strings).
+        Set `enrich` to include token metadata (symbol, name, formatted balance, decimals).
+        When omitted, enrichment defaults to enabled.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_HoldingsRequest'
+              $ref: '#/components/schemas/ApiRequest_AccountPayload'
             examples:
-              raw_holdings:
-                summary: "Get holdings — raw mode (default, no valueFormat needed)"
+              enriched:
+                summary: "Holdings with enrichment (default)"
                 value:
                   context:
-                    id: "adapter.accounts.holdings"
+                    id: "accounts.holdings"
                     version: "1.0"
                     ts: "2026-02-17T10:00:00Z"
-                    msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef0123"
+                    msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef01234"
+                    developerToken: "dev_key_abc123"
+                    authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
                   payload:
-                    chainId: "eip155:1"
-                    address: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-                    includeNative: true
-              display_holdings:
-                summary: "Get holdings — display mode (human-readable)"
+                    chainId: "ethereum-mainnet"
+                    accountId: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                    enrich: true
+              minimal:
+                summary: "Holdings without enrichment"
                 value:
                   context:
-                    id: "adapter.accounts.holdings"
+                    id: "accounts.holdings"
                     version: "1.0"
                     ts: "2026-02-17T10:00:00Z"
-                    msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef0124"
-                    valueFormat: "display"
+                    msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef01235"
+                    developerToken: "dev_key_abc123"
+                    authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
                   payload:
-                    chainId: "eip155:1"
-                    address: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-                    includeNative: true
+                    chainId: "ethereum-mainnet"
+                    accountId: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                    enrich: false
       responses:
         '200':
           description: "Holdings retrieved successfully"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse_Holdings'
+                $ref: '#/components/schemas/ApiResponse_HoldingsResponse'
               examples:
-                raw_holdings:
-                  summary: "Holdings — raw mode (smallest-unit integers)"
+                enriched:
+                  summary: "Holdings with enrichment"
                   value:
                     context:
-                      id: "adapter.accounts.holdings"
+                      id: "accounts.holdings"
                       version: "1.0"
                       ts: "2026-02-17T10:00:01Z"
-                      msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef0123"
+                      msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef01234"
                       status: "successful"
                     response:
-                      address: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-                      chainId: "eip155:1"
+                      address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
                       holdings:
-                        - contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+                        - assetId: "erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
                           assetType: "erc20"
                           symbol: "USDC"
                           name: "USD Coin"
                           balance: "1000000000"
+                          balanceFormatted: "1000.000000"
                           decimals: 6
-                        - contractAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
-                          assetType: "erc20"
-                          symbol: "USDT"
-                          name: "Tether USD"
-                          balance: "500000000"
-                          decimals: 6
-                        - contractAddress: "native"
+                        - assetId: "native"
                           assetType: "native"
                           symbol: "ETH"
                           name: "Ether"
                           balance: "3245000000000000000"
-                          decimals: 18
-                display_holdings:
-                  summary: "Holdings — display mode (human-readable decimals)"
-                  value:
-                    context:
-                      id: "adapter.accounts.holdings"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef0124"
-                      status: "successful"
-                    response:
-                      address: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-                      chainId: "eip155:1"
-                      holdings:
-                        - contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-                          assetType: "erc20"
-                          symbol: "USDC"
-                          name: "USD Coin"
-                          balance: "1000.00"
-                          decimals: 6
-                        - contractAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
-                          assetType: "erc20"
-                          symbol: "USDT"
-                          name: "Tether USD"
-                          balance: "500.00"
-                          decimals: 6
-                        - contractAddress: "native"
-                          assetType: "native"
-                          symbol: "ETH"
-                          name: "Ether"
-                          balance: "3.245"
+                          balanceFormatted: "3.245"
                           decimals: 18
                 empty_wallet:
-                  summary: "Wallet with no token holdings"
+                  summary: "Account with no token holdings"
                   value:
                     context:
-                      id: "adapter.accounts.holdings"
+                      id: "accounts.holdings"
                       version: "1.0"
                       ts: "2026-02-17T10:00:01Z"
-                      msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef0125"
+                      msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef01236"
                       status: "successful"
                     response:
                       address: "0x0000000000000000000000000000000000000001"
-                      chainId: "eip155:1"
                       holdings: []
         '400':
           $ref: '#/components/responses/BadRequestError'
         '503':
           $ref: '#/components/responses/UpstreamUnavailableError'
 
-  /balance/get:
+  /api/v1/chain-adapter/balance/get:
     post:
       tags: ["Chain Address"]
       summary: "Get specific token balance"
@@ -564,111 +458,80 @@ paths:
         Returns the balance of a specific token for an address. Used by TokenEngine as a
         pre-hook verification step before building proxy transfer transactions.
 
-        Use `native` as the `contractAddress` for native asset balance.
+        Use `native` as the `contractAddress` for the native asset balance.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_BalanceRequest'
-            examples:
-              raw_usdc:
-                summary: "Get USDC balance — raw mode (default)"
-                value:
-                  context:
-                    id: "adapter.balance.get"
-                    version: "1.0"
-                    ts: "2026-02-17T10:00:00Z"
-                    msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef01234"
-                  payload:
-                    chainId: "eip155:1"
-                    address: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-                    contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-              display_eth:
-                summary: "Get native ETH balance — display mode"
-                value:
-                  context:
-                    id: "adapter.balance.get"
-                    version: "1.0"
-                    ts: "2026-02-17T10:00:00Z"
-                    msgId: "a7b8c9d0-e1f2-3456-7890-abcdef012345"
-                    valueFormat: "display"
-                  payload:
-                    chainId: "eip155:1"
-                    address: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-                    contractAddress: "native"
+              $ref: '#/components/schemas/ApiRequest_BalancePayload'
+            example:
+              context:
+                id: "balance.get"
+                version: "1.0"
+                ts: "2026-02-17T10:00:00Z"
+                msgId: "a7b8c9d0-e1f2-3456-7890-abcdef012345"
+                developerToken: "dev_key_abc123"
+                authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
+              payload:
+                chainId: "ethereum-mainnet"
+                address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
       responses:
         '200':
           description: "Balance retrieved successfully"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse_Balance'
-              examples:
-                raw_usdc:
-                  summary: "USDC balance — raw (smallest-unit integer)"
-                  value:
-                    context:
-                      id: "adapter.balance.get"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef01234"
-                      status: "successful"
-                    response:
-                      address: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-                      chainId: "eip155:1"
-                      contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-                      assetType: "erc20"
-                      symbol: "USDC"
-                      balance: "1000000000"
-                display_eth:
-                  summary: "ETH balance — display (human-readable decimal)"
-                  value:
-                    context:
-                      id: "adapter.balance.get"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "a7b8c9d0-e1f2-3456-7890-abcdef012345"
-                      status: "successful"
-                    response:
-                      address: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-                      chainId: "eip155:1"
-                      contractAddress: "native"
-                      assetType: "native"
-                      symbol: "ETH"
-                      balance: "3.245"
+                $ref: '#/components/schemas/ApiResponse_BalanceInfo'
+              example:
+                context:
+                  id: "balance.get"
+                  version: "1.0"
+                  ts: "2026-02-17T10:00:01Z"
+                  msgId: "a7b8c9d0-e1f2-3456-7890-abcdef012345"
+                  status: "successful"
+                response:
+                  address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                  chainId: "eip155:1"
+                  contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+                  assetType: "erc20"
+                  symbol: "USDC"
+                  balance: "7000000"
+                  decimals: 6
         '400':
           $ref: '#/components/responses/BadRequestError'
         '503':
           $ref: '#/components/responses/UpstreamUnavailableError'
 
   # -------------------- Asset Resolution --------------------
-  /assets/resolve:
+  /api/v1/chain-adapter/assets/get:
     post:
       tags: ["Chain Assets"]
       summary: "Resolve on-chain asset metadata"
       description: |
-        Given a contract address, resolves the asset's on-chain metadata — name, symbol,
+        Given an asset identifier, resolves the asset's on-chain metadata — name, symbol,
         decimals, total supply, and asset type.
 
-        Used during proxy token import when the App Backend encounters an unknown token
-        in a user's wallet holdings. Also used for anti-spam filtering by verifying the
-        contract matches the expected TokenClass configuration.
+        Used during proxy token import when the App Backend encounters an unknown token in a
+        user's wallet holdings, and for anti-spam filtering against the expected TokenClass config.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_AssetResolveRequest'
+              $ref: '#/components/schemas/ApiRequest_AssetPayload'
             example:
               context:
-                id: "adapter.assets.resolve"
+                id: "assets.get"
                 version: "1.0"
                 ts: "2026-02-17T10:00:00Z"
                 msgId: "b8c9d0e1-f2a3-4567-8901-bcdef0123456"
+                developerToken: "dev_key_abc123"
+                authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
               payload:
-                chainId: "eip155:1"
-                contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+                chainId: "ethereum-mainnet"
+                assetId: "erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
       responses:
         '200':
           description: "Asset resolved"
@@ -678,18 +541,18 @@ paths:
                 $ref: '#/components/schemas/ApiResponse_AssetInfo'
               example:
                 context:
-                  id: "adapter.assets.resolve"
+                  id: "assets.get"
                   version: "1.0"
                   ts: "2026-02-17T10:00:01Z"
                   msgId: "b8c9d0e1-f2a3-4567-8901-bcdef0123456"
                   status: "successful"
                 response:
-                  chainId: "eip155:1"
-                  contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+                  assetId: "erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
                   assetType: "erc20"
                   name: "USD Coin"
                   symbol: "USDC"
                   decimals: 6
+                  contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
                   totalSupply: "26000000000000000"
         '400':
           $ref: '#/components/responses/BadRequestError'
@@ -698,287 +561,58 @@ paths:
         '503':
           $ref: '#/components/responses/UpstreamUnavailableError'
 
-  # -------------------- Fees --------------------
-  /fees/estimate:
-    post:
-      tags: ["Chain Transactions"]
-      summary: "Get current fee estimates"
-      description: |
-        Returns current fee conditions for the specified chain, including tier-based
-        estimates and chain-specific fee model details. This is the **single authoritative
-        source** for fee information — the build response does not echo fees back.
-
-        The adapter maintains an in-memory cache of fee data, refreshed every block
-        (or every few seconds). This endpoint is lightweight and suitable for polling
-        to keep the UI fee display fresh.
-
-        Fee amount format depends on `context.valueFormat` (`raw` or `display`).
-        No `decimals` field is included — the adapter owns decimal conversion.
-
-        ### Fee Models by Chain
-
-        | Chain Family | Fee Model | Key Fields |
-        |-------------|-----------|------------|
-        | EVM (EIP-1559) | baseFee + priorityFee | `baseFee`, tiers have `maxPriorityFee` |
-        | EVM (legacy) | Single gasPrice | Tiers have `gasPrice` |
-        | Solana | Compute units + priority fee | `computeUnitPrice` in tiers |
-        | L2 (Optimistic) | L1 data fee + L2 execution | `l1DataFee` + `l2ExecutionFee` |
-
-        The `tiers` array always provides at least a `standard` tier. Additional tiers
-        (slow, fast, urgent, etc.) are chain-dependent. The `feePreference` on
-        `/transactions/build` maps to a tier name here.
-
-        ### Suggested UI Flow
-
-        1. Call `/fees/estimate` to get current tiers and display options
-        2. User selects a tier (or keep default)
-        3. Call `/transactions/build` with `feePreference` matching the tier name
-        4. Show final confirmation with exact amounts
-        5. Optionally re-poll `/fees/estimate` if user takes too long (fee drift)
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ApiRequest_FeeEstimateRequest'
-            examples:
-              raw_evm_fees:
-                summary: "Ethereum fees — raw mode (default)"
-                value:
-                  context:
-                    id: "adapter.fees.estimate"
-                    version: "1.0"
-                    ts: "2026-02-17T10:00:00Z"
-                    msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                  payload:
-                    chainId: "eip155:1"
-                    gasUnits: "65000"
-              display_evm_fees:
-                summary: "Ethereum fees — display mode (human-readable)"
-                value:
-                  context:
-                    id: "adapter.fees.estimate"
-                    version: "1.0"
-                    ts: "2026-02-17T10:00:00Z"
-                    msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567891"
-                    valueFormat: "display"
-                  payload:
-                    chainId: "eip155:1"
-                    gasUnits: "65000"
-              raw_solana_fees:
-                summary: "Solana fees — raw mode"
-                value:
-                  context:
-                    id: "adapter.fees.estimate"
-                    version: "1.0"
-                    ts: "2026-02-17T10:00:00Z"
-                    msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef0"
-                  payload:
-                    chainId: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
-      responses:
-        '200':
-          description: "Fee estimates retrieved"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse_FeeEstimate'
-              examples:
-                raw_evm_eip1559:
-                  summary: "Ethereum EIP-1559 fees — raw"
-                  value:
-                    context:
-                      id: "adapter.fees.estimate"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                      status: "successful"
-                    response:
-                      chainId: "eip155:1"
-                      feeModel: "eip1559"
-                      baseFee: "15000000000"
-                      nativeCurrency: "ETH"
-                      tiers:
-                        - name: "slow"
-                          maxPriorityFee: "1000000000"
-                          estimatedFee: "1040000000000000"
-                          estimatedTimeSeconds: 120
-                        - name: "standard"
-                          maxPriorityFee: "2000000000"
-                          estimatedFee: "1105000000000000"
-                          estimatedTimeSeconds: 30
-                        - name: "fast"
-                          maxPriorityFee: "5000000000"
-                          estimatedFee: "1300000000000000"
-                          estimatedTimeSeconds: 12
-                      updatedAt: "2026-02-17T10:00:00Z"
-                display_evm_eip1559:
-                  summary: "Ethereum EIP-1559 fees — display (human-readable ETH)"
-                  value:
-                    context:
-                      id: "adapter.fees.estimate"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567891"
-                      status: "successful"
-                    response:
-                      chainId: "eip155:1"
-                      feeModel: "eip1559"
-                      baseFee: "0.000000015"
-                      nativeCurrency: "ETH"
-                      tiers:
-                        - name: "slow"
-                          maxPriorityFee: "0.000000001"
-                          estimatedFee: "0.00104"
-                          estimatedTimeSeconds: 120
-                        - name: "standard"
-                          maxPriorityFee: "0.000000002"
-                          estimatedFee: "0.001105"
-                          estimatedTimeSeconds: 30
-                        - name: "fast"
-                          maxPriorityFee: "0.000000005"
-                          estimatedFee: "0.0013"
-                          estimatedTimeSeconds: 12
-                      updatedAt: "2026-02-17T10:00:00Z"
-                raw_solana_fees:
-                  summary: "Solana fees — raw (flat + optional priority)"
-                  value:
-                    context:
-                      id: "adapter.fees.estimate"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef0"
-                      status: "successful"
-                    response:
-                      chainId: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
-                      feeModel: "solana"
-                      nativeCurrency: "SOL"
-                      tiers:
-                        - name: "standard"
-                          estimatedFee: "5000"
-                          estimatedTimeSeconds: 1
-                        - name: "fast"
-                          computeUnitPrice: "1000"
-                          estimatedFee: "10000"
-                          estimatedTimeSeconds: 1
-                      updatedAt: "2026-02-17T10:00:00Z"
-                display_solana_fees:
-                  summary: "Solana fees — display (human-readable SOL)"
-                  value:
-                    context:
-                      id: "adapter.fees.estimate"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
-                      status: "successful"
-                    response:
-                      chainId: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
-                      feeModel: "solana"
-                      nativeCurrency: "SOL"
-                      tiers:
-                        - name: "standard"
-                          estimatedFee: "0.000005"
-                          estimatedTimeSeconds: 1
-                        - name: "fast"
-                          computeUnitPrice: "0.000001"
-                          estimatedFee: "0.00001"
-                          estimatedTimeSeconds: 1
-                      updatedAt: "2026-02-17T10:00:00Z"
-                raw_l2_fees:
-                  summary: "Base L2 fees — raw (two-component)"
-                  value:
-                    context:
-                      id: "adapter.fees.estimate"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef01"
-                      status: "successful"
-                    response:
-                      chainId: "eip155:8453"
-                      feeModel: "optimistic-l2"
-                      baseFee: "100000000"
-                      l1DataFee: "250000000000000"
-                      nativeCurrency: "ETH"
-                      tiers:
-                        - name: "standard"
-                          maxPriorityFee: "1000000"
-                          estimatedFee: "256500000000000"
-                          estimatedTimeSeconds: 2
-                        - name: "fast"
-                          maxPriorityFee: "5000000"
-                          estimatedFee: "260500000000000"
-                          estimatedTimeSeconds: 2
-                      updatedAt: "2026-02-17T10:00:00Z"
-        '400':
-          $ref: '#/components/responses/BadRequestError'
-        '503':
-          $ref: '#/components/responses/UpstreamUnavailableError'
-
   # -------------------- Transactions --------------------
-  /transactions/build:
+  /api/v1/chain-adapter/transactions/build:
     post:
       tags: ["Chain Transactions"]
       summary: "Build unsigned transaction"
       description: |
-        Builds an unsigned transaction payload for the given transfer parameters.
-        Called by TokenEngine during proxy transfer Phase 1.
+        Builds an unsigned transaction payload for the given transfer parameters and records a
+        signing intent. Called by TokenEngine during proxy transfer Phase 1.
 
-        The response contains the raw unsigned transaction that must be signed externally
-        (e.g., by the user via WalletConnect) before submission.
-
-        The `feePreference` maps to a tier name from `/fees/estimate`. Returns
-        `requiredSignatures` for multisig wallets.
-
-        ### Fee Selection UX Flow
-
-        1. Call `/fees/estimate` to get current tiers and fee breakdown
-        2. Show user: amount, fee tiers with estimated cost and time
-        3. User selects a tier (or default to "standard")
-        4. Call `/transactions/build` with `feePreference` matching the selected tier name
-        5. Show final confirmation: amount, exact fee, remaining balance
-        6. User confirms → sign → submit
-        7. Optionally re-poll `/fees/estimate` if user takes too long (fee drift)
-
-        Fee information lives entirely in `/fees/estimate` — the build response does NOT
-        echo fee tiers back. This avoids duplication and keeps one authoritative source.
+        The response returns an `intentId` (referenced later by `/transactions/submit`), the
+        chain-specific `txPayload` to be signed externally, and the `signingMode` the caller
+        must use. An optional `feePreference` selects a fee tier.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_BuildTransactionRequest'
+              $ref: '#/components/schemas/ApiRequest_TransactionBuildRequest'
             examples:
-              raw_erc20_transfer:
-                summary: "Build USDC transfer — raw mode (default)"
+              native_transfer:
+                summary: "Build native ETH transfer"
                 value:
                   context:
-                    id: "adapter.transactions.build"
+                    id: "transactions.build"
                     version: "1.0"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "c9d0e1f2-a3b4-5678-9012-cdef01234567"
+                    developerToken: "dev_key_abc123"
+                    authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
                   payload:
-                    chainId: "eip155:1"
-                    from: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-                    to: "0xBobAddress1234567890abcdef1234567890abcdef"
-                    contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-                    amount: "100000000"
-                    assetType: "erc20"
+                    chainId: "ethereum-mainnet"
+                    from: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                    to: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+                    asset: "native"
+                    amount: "0.5"
                     feePreference: "standard"
-              display_eth_transfer:
-                summary: "Build native ETH transfer — display mode"
+              erc20_transfer:
+                summary: "Build ERC-20 transfer"
                 value:
                   context:
-                    id: "adapter.transactions.build"
+                    id: "transactions.build"
                     version: "1.0"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "d0e1f2a3-b4c5-6789-0123-def012345678"
-                    valueFormat: "display"
+                    developerToken: "dev_key_abc123"
+                    authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
                   payload:
-                    chainId: "eip155:1"
-                    from: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-                    to: "0xBobAddress1234567890abcdef1234567890abcdef"
-                    contractAddress: "native"
-                    amount: "1.0"
-                    assetType: "native"
+                    chainId: "ethereum-mainnet"
+                    from: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                    to: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+                    asset: "erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+                    amount: "100.0"
                     feePreference: "fast"
       responses:
         '200':
@@ -986,264 +620,142 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse_BuildTransaction'
-              examples:
-                raw_erc20_response:
-                  summary: "Build response — raw (smallest-unit integers)"
-                  value:
-                    context:
-                      id: "adapter.transactions.build"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "c9d0e1f2-a3b4-5678-9012-cdef01234567"
-                      status: "successful"
-                    response:
-                      unsignedTx: "0x02f87001808459682f0085174876e80082520894a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4880b844a9059cbb..."
-                      chainId: "eip155:1"
-                      from: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-                      to: "0xBobAddress1234567890abcdef1234567890abcdef"
-                      contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-                      amount: "100000000"
-                      estimatedGas: "65000"
-                      gasPrice: "25000000000"
-                      nonce: 42
-                      requiredSignatures: 1
-                      expiresAt: "2026-02-17T12:10:00Z"
-                display_eth_response:
-                  summary: "Build response — display (human-readable decimals)"
-                  value:
-                    context:
-                      id: "adapter.transactions.build"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "d0e1f2a3-b4c5-6789-0123-def012345678"
-                      status: "successful"
-                    response:
-                      unsignedTx: "0x02f87001808459682f0085174876e80082520894..."
-                      chainId: "eip155:1"
-                      from: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-                      to: "0xBobAddress1234567890abcdef1234567890abcdef"
-                      contractAddress: "native"
-                      amount: "1.0"
-                      estimatedGas: "21000"
-                      gasPrice: "0.000000025"
-                      nonce: 42
-                      requiredSignatures: 1
-                      expiresAt: "2026-02-17T12:10:00Z"
+                $ref: '#/components/schemas/ApiResponse_TransactionBuildResponse'
+              example:
+                context:
+                  id: "transactions.build"
+                  version: "1.0"
+                  ts: "2026-02-17T10:00:01Z"
+                  msgId: "c9d0e1f2-a3b4-5678-9012-cdef01234567"
+                  status: "successful"
+                response:
+                  intentId: "intent_a1b2c3d4"
+                  txPayload:
+                    from: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                    to: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+                    value: "0x6f05b59d3b20000"
+                    nonce: "0x2a"
+                    gas: "0x5208"
+                  signingMode: "signTransaction"
+                  expiresAt: "2026-02-17T12:10:00Z"
         '400':
           $ref: '#/components/responses/BadRequestError'
         '503':
           $ref: '#/components/responses/UpstreamUnavailableError'
 
-  /transactions/sign:
+  /api/v1/chain-adapter/transactions/submit:
     post:
       tags: ["Chain Transactions"]
-      summary: "Sign transaction (custodial)"
+      summary: "Submit signed transaction"
       description: |
-        **Future endpoint** — Signs an unsigned transaction using adapter-managed keys.
-        Only applicable for custodial adapters or HSM-backed signing services.
+        Submits a previously built and signed transaction, referenced by its `intentId`.
+        Called by TokenEngine during proxy transfer Phase 2 after the user has signed.
 
-        For non-custodial flows (WalletConnect), signing happens client-side and this
-        endpoint is not called. The signed transaction is submitted directly to `/transactions/submit`.
-
-        Included for specification completeness — adapters MAY return `501 Not Implemented`.
+        Provide `signedTx` for signed raw transactions, or `txHash` when the transaction was
+        broadcast client-side (sign-and-send mode). Returns the adapter transaction id and its
+        initial queue status; the adapter then monitors the transaction to confirmation.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_SignTransactionRequest'
-            example:
-              context:
-                id: "adapter.transactions.sign"
-                version: "1.0"
-                ts: "2026-02-17T10:00:00Z"
-                msgId: "e1f2a3b4-c5d6-7890-1234-ef0123456789"
-              payload:
-                chainId: "eip155:1"
-                unsignedTx: "0x02f87001808459682f0085174876e80082520894..."
-                signerAddress: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
+              $ref: '#/components/schemas/ApiRequest_TransactionSubmitRequest'
+            examples:
+              signed_raw:
+                summary: "Submit a signed raw transaction"
+                value:
+                  context:
+                    id: "transactions.submit"
+                    version: "1.0"
+                    ts: "2026-02-17T10:00:00Z"
+                    msgId: "e1f2a3b4-c5d6-7890-1234-ef0123456789"
+                    developerToken: "dev_key_abc123"
+                    authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
+                  payload:
+                    intentId: "intent_a1b2c3d4"
+                    signedTx: "0xf86c808504a817c800825208940123..."
+              sign_and_send:
+                summary: "Report a client-broadcast transaction hash"
+                value:
+                  context:
+                    id: "transactions.submit"
+                    version: "1.0"
+                    ts: "2026-02-17T10:00:00Z"
+                    msgId: "f2a3b4c5-d6e7-8901-2345-f01234567890"
+                    developerToken: "dev_key_abc123"
+                    authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
+                  payload:
+                    intentId: "intent_a1b2c3d4"
+                    txHash: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
       responses:
         '200':
-          description: "Transaction signed"
+          description: "Transaction accepted for submission"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse_SignTransaction'
+                $ref: '#/components/schemas/ApiResponse_TransactionSubmitResponse'
               example:
                 context:
-                  id: "adapter.transactions.sign"
+                  id: "transactions.submit"
                   version: "1.0"
                   ts: "2026-02-17T10:00:01Z"
                   msgId: "e1f2a3b4-c5d6-7890-1234-ef0123456789"
                   status: "successful"
                 response:
-                  signedTx: "0x02f87001808459682f0085174876e80082520894...signed"
-                  chainId: "eip155:1"
-        '400':
-          $ref: '#/components/responses/BadRequestError'
-        '501':
-          description: "Signing not supported by this adapter"
-          content:
-            application/json:
-              schema: { $ref: '#/components/schemas/ApiError' }
-        '503':
-          $ref: '#/components/responses/UpstreamUnavailableError'
-
-  /transactions/submit:
-    post:
-      tags: ["Chain Transactions"]
-      summary: "Submit signed transaction"
-      description: |
-        Submits a signed transaction to the blockchain network.
-        Called by TokenEngine during proxy transfer Phase 2 after the user has signed.
-
-        Returns the chain transaction hash. If `callbackUrl` and `transactionId` are provided,
-        the adapter will monitor the transaction on-chain and call back UNITS when the transaction
-        is confirmed or fails:
-
-        **Callback flow:**
-        1. UNITS submits tx with `callbackUrl` + `transactionId`
-        2. Adapter submits to chain, returns `txHash`
-        3. Adapter monitors chain for confirmation
-        4. On confirmation/failure, adapter calls `POST {callbackUrl}` (typically UNITS `/v1/token/transact`)
-           with `operation: "update"` and the `transactionId` for reverse mapping
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ApiRequest_SubmitTransactionRequest'
-            examples:
-              with_callback:
-                summary: "Submit with callback for async monitoring"
-                value:
-                  context:
-                    id: "adapter.transactions.submit"
-                    version: "1.0"
-                    ts: "2026-02-17T10:00:00Z"
-                    msgId: "f2a3b4c5-d6e7-8901-2345-f01234567890"
-                  payload:
-                    chainId: "eip155:1"
-                    signedTx: "0x02f87001808459682f0085174876e80082520894...signed_payload"
-                    transactionId: "units-tx-550e8400-e29b-41d4-a716-446655440000"
-                    callbackUrl: "https://foundry.finternetlab.io/v1/token/transact"
-              without_callback:
-                summary: "Submit without callback (poll mode)"
-                value:
-                  context:
-                    id: "adapter.transactions.submit"
-                    version: "1.0"
-                    ts: "2026-02-17T10:00:00Z"
-                    msgId: "a3b4c5d6-e7f8-9012-3456-012345678901"
-                  payload:
-                    chainId: "eip155:1"
-                    signedTx: "0x02f87001808459682f0085174876e80082520894...signed_payload"
-      responses:
-        '200':
-          description: "Transaction submitted to chain"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse_SubmitTransaction'
-              example:
-                context:
-                  id: "adapter.transactions.submit"
-                  version: "1.0"
-                  ts: "2026-02-17T10:00:01Z"
-                  msgId: "f2a3b4c5-d6e7-8901-2345-f01234567890"
-                  status: "successful"
-                response:
-                  txHash: "0xabc123def456789012345678901234567890123456789012345678901234abcd"
-                  chainId: "eip155:1"
-                  status: "submitted"
-                  submittedAt: "2026-02-17T12:01:30Z"
+                  txId: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                  status: "queued"
         '400':
           $ref: '#/components/responses/BadRequestError'
         '503':
           $ref: '#/components/responses/UpstreamUnavailableError'
 
-  /transactions/status:
+  /api/v1/chain-adapter/transactions/get:
     post:
       tags: ["Chain Transactions"]
-      summary: "Get transaction status"
+      summary: "Get transaction"
       description: |
-        Returns the current status of a submitted transaction by its chain transaction hash.
-        Called by TokenEngine to poll on-chain execution status (when not using callbacks).
-
-        The `confirmations` field indicates the number of block confirmations since the
-        transaction was included, useful for determining finality.
+        Returns on-chain data for a transaction by its id/hash. Identical in shape to
+        `/transactions/status` — both are served by the same handler.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_TransactionStatusRequest'
+              $ref: '#/components/schemas/ApiRequest_TransactionQuery'
             example:
               context:
-                id: "adapter.transactions.status"
+                id: "transactions.get"
                 version: "1.0"
                 ts: "2026-02-17T10:00:00Z"
-                msgId: "b4c5d6e7-f8a9-0123-4567-123456789012"
+                msgId: "a3b4c5d6-e7f8-9012-3456-012345678901"
+                developerToken: "dev_key_abc123"
+                authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
               payload:
-                chainId: "eip155:1"
-                txHash: "0xabc123def456789012345678901234567890123456789012345678901234abcd"
+                chainId: "ethereum-mainnet"
+                txId: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
       responses:
         '200':
-          description: "Transaction status retrieved"
+          description: "Transaction retrieved"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse_TransactionStatus'
-              examples:
-                pending:
-                  summary: "Transaction pending in mempool"
-                  value:
-                    context:
-                      id: "adapter.transactions.status"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "b4c5d6e7-f8a9-0123-4567-123456789012"
-                      status: "successful"
-                    response:
-                      txHash: "0xabc123..."
-                      chainId: "eip155:1"
-                      status: "pending"
-                      confirmations: 0
-                confirmed:
-                  summary: "Transaction confirmed"
-                  value:
-                    context:
-                      id: "adapter.transactions.status"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "b4c5d6e7-f8a9-0123-4567-123456789012"
-                      status: "successful"
-                    response:
-                      txHash: "0xabc123..."
-                      chainId: "eip155:1"
-                      status: "confirmed"
-                      blockNumber: 19234567
-                      blockHash: "0xblock..."
-                      gasUsed: "52000"
-                      confirmations: 12
-                      confirmedAt: "2026-02-17T12:02:15Z"
-                failed:
-                  summary: "Transaction reverted"
-                  value:
-                    context:
-                      id: "adapter.transactions.status"
-                      version: "1.0"
-                      ts: "2026-02-17T10:00:01Z"
-                      msgId: "b4c5d6e7-f8a9-0123-4567-123456789012"
-                      status: "successful"
-                    response:
-                      txHash: "0xabc123..."
-                      chainId: "eip155:1"
-                      status: "failed"
-                      blockNumber: 19234567
-                      failureReason: "execution reverted: ERC20: transfer amount exceeds balance"
-                      confirmations: 12
+                $ref: '#/components/schemas/ApiResponse_TransactionInfo'
+              example:
+                context:
+                  id: "transactions.get"
+                  version: "1.0"
+                  ts: "2026-02-17T10:00:01Z"
+                  msgId: "a3b4c5d6-e7f8-9012-3456-012345678901"
+                  status: "successful"
+                response:
+                  txHash: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                  status: "confirmed"
+                  blockNumber: 19500000
+                  blockHash: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+                  from: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                  to: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+                  value: "0.5"
+                  gasUsed: "21000"
         '400':
           $ref: '#/components/responses/BadRequestError'
         '404':
@@ -1251,30 +763,105 @@ paths:
         '503':
           $ref: '#/components/responses/UpstreamUnavailableError'
 
-  /transactions/receipt:
+  /api/v1/chain-adapter/transactions/status:
     post:
       tags: ["Chain Transactions"]
-      summary: "Get transaction receipt"
+      summary: "Get transaction status"
       description: |
-        Returns the full transaction receipt including event logs and gas details.
-        Only available after a transaction has been included in a block (confirmed or failed).
+        Returns the current on-chain status of a transaction by its id/hash. Called by
+        TokenEngine to poll execution status.
 
-        Used for detailed auditing, event log extraction, and proof generation.
+        This route is served by the same handler as `/transactions/get`; the response
+        `context.id` is therefore emitted as `transactions.get`.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_TransactionReceiptRequest'
+              $ref: '#/components/schemas/ApiRequest_TransactionQuery'
             example:
               context:
-                id: "adapter.transactions.receipt"
+                id: "transactions.status"
+                version: "1.0"
+                ts: "2026-02-17T10:00:00Z"
+                msgId: "b4c5d6e7-f8a9-0123-4567-123456789012"
+                developerToken: "dev_key_abc123"
+                authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
+              payload:
+                chainId: "ethereum-mainnet"
+                txId: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      responses:
+        '200':
+          description: "Transaction status retrieved"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_TransactionInfo'
+              examples:
+                pending:
+                  summary: "Transaction pending in mempool"
+                  value:
+                    context:
+                      id: "transactions.get"
+                      version: "1.0"
+                      ts: "2026-02-17T10:00:01Z"
+                      msgId: "b4c5d6e7-f8a9-0123-4567-123456789012"
+                      status: "successful"
+                    response:
+                      txHash: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                      status: "pending"
+                      from: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                      to: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+                      value: "0.5"
+                confirmed:
+                  summary: "Transaction confirmed"
+                  value:
+                    context:
+                      id: "transactions.get"
+                      version: "1.0"
+                      ts: "2026-02-17T10:00:01Z"
+                      msgId: "b4c5d6e7-f8a9-0123-4567-123456789012"
+                      status: "successful"
+                    response:
+                      txHash: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                      status: "confirmed"
+                      blockNumber: 19500000
+                      blockHash: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+                      from: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                      to: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+                      value: "0.5"
+                      gasUsed: "21000"
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '503':
+          $ref: '#/components/responses/UpstreamUnavailableError'
+
+  /api/v1/chain-adapter/transactions/receipt:
+    post:
+      tags: ["Chain Transactions"]
+      summary: "Get transaction receipt"
+      description: |
+        Returns the full transaction receipt including gas details and freeform event logs.
+        Only available after a transaction has been included in a block (confirmed or failed).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_TransactionQuery'
+            example:
+              context:
+                id: "transactions.receipt"
                 version: "1.0"
                 ts: "2026-02-17T10:00:00Z"
                 msgId: "c5d6e7f8-a9b0-1234-5678-234567890123"
+                developerToken: "dev_key_abc123"
+                authorization: "Bearer eyJhbGciOiJIUzI1NiJ9..."
               payload:
-                chainId: "eip155:1"
-                txHash: "0xabc123def456789012345678901234567890123456789012345678901234abcd"
+                chainId: "ethereum-mainnet"
+                txId: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
       responses:
         '200':
           description: "Receipt retrieved"
@@ -1284,28 +871,24 @@ paths:
                 $ref: '#/components/schemas/ApiResponse_TransactionReceipt'
               example:
                 context:
-                  id: "adapter.transactions.receipt"
+                  id: "transactions.receipt"
                   version: "1.0"
                   ts: "2026-02-17T10:00:01Z"
                   msgId: "c5d6e7f8-a9b0-1234-5678-234567890123"
                   status: "successful"
                 response:
-                  txHash: "0xabc123def456..."
-                  chainId: "eip155:1"
+                  txHash: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
                   status: "confirmed"
-                  blockNumber: 19234567
-                  blockHash: "0xblock..."
-                  from: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-                  to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-                  gasUsed: "52000"
-                  effectiveGasPrice: "25000000000"
+                  blockNumber: 19500000
+                  blockHash: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+                  gasUsed: "21000"
+                  effectiveGasPrice: "20000000000"
                   confirmations: 12
+                  success: true
                   logs:
                     - address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
                       topics:
                         - "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
-                        - "0x00000000000000000000000024596184fccdf7b5f2e93711f39cee4926ec7b2d"
-                        - "0x000000000000000000000000BobAddress1234567890abcdef1234567890abcdef"
                       data: "0x0000000000000000000000000000000000000000000000000000000005f5e100"
                       logIndex: 0
         '400':
@@ -1315,116 +898,23 @@ paths:
         '503':
           $ref: '#/components/responses/UpstreamUnavailableError'
 
-  # -------------------- Meta --------------------
-  /info:
-    post:
-      tags: ["Adapter Info"]
-      summary: "Get adapter metadata"
-      description: |
-        Returns metadata about this adapter: supported chains, version, upstream provider.
-        Used by admin tools, monitoring, and the chain registry for validation.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ApiRequest_Empty'
-            example:
-              context:
-                id: "adapter.info"
-                version: "1.0"
-                ts: "2026-02-17T10:00:00Z"
-                msgId: "d6e7f8a9-b0c1-2345-6789-345678901234"
-              payload: {}
-      responses:
-        '200':
-          description: "Adapter info retrieved"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse_AdapterInfo'
-              example:
-                context:
-                  id: "adapter.info"
-                  version: "1.0"
-                  ts: "2026-02-17T10:00:01Z"
-                  msgId: "d6e7f8a9-b0c1-2345-6789-345678901234"
-                  status: "successful"
-                response:
-                  name: "Finternet Alchemy Adapter"
-                  version: "1.0.0"
-                  provider: "alchemy"
-                  supportedChains:
-                    - chainId: "eip155:1"
-                      name: "Ethereum Mainnet"
-                    - chainId: "eip155:137"
-                      name: "Polygon Mainnet"
-                    - chainId: "eip155:8453"
-                      name: "Base"
-                    - chainId: "eip155:42161"
-                      name: "Arbitrum One"
-
+  # -------------------- Health (root, no envelope) --------------------
   /health:
-    post:
-      tags: ["Adapter Info"]
+    get:
+      tags: ["Health"]
       summary: "Health check"
       description: |
-        Liveness and upstream connectivity check. Returns the adapter's status
-        and whether it can reach its upstream RPC provider(s).
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ApiRequest_Empty'
-            example:
-              context:
-                id: "adapter.health"
-                version: "1.0"
-                ts: "2026-02-17T10:00:00Z"
-                msgId: "e7f8a9b0-c1d2-3456-7890-456789012345"
-              payload: {}
+        Liveness probe registered at the root path, outside the `/api/v1/chain-adapter` base group.
+        Takes no request body and returns a bare status object with no envelope.
       responses:
         '200':
           description: "Adapter is healthy"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse_Health'
+                $ref: '#/components/schemas/HealthResponse'
               example:
-                context:
-                  id: "adapter.health"
-                  version: "1.0"
-                  ts: "2026-02-17T10:00:01Z"
-                  msgId: "e7f8a9b0-c1d2-3456-7890-456789012345"
-                  status: "successful"
-                response:
-                  status: "healthy"
-                  uptime: 86400
-                  upstream:
-                    status: "connected"
-                    latencyMs: 45
-                    lastCheckedAt: "2026-02-17T12:00:00Z"
-        '503':
-          description: "Adapter is unhealthy"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse_Health'
-              example:
-                context:
-                  id: "adapter.health"
-                  version: "1.0"
-                  ts: "2026-02-17T10:00:01Z"
-                  msgId: "e7f8a9b0-c1d2-3456-7890-456789012345"
-                  status: "successful"
-                response:
-                  status: "unhealthy"
-                  uptime: 86400
-                  upstream:
-                    status: "disconnected"
-                    lastCheckedAt: "2026-02-17T12:00:00Z"
-                    error: "Connection timeout to Alchemy RPC"
+                status: "ok"
 
 # ===============================================================
 #   COMPONENTS
@@ -1432,19 +922,18 @@ paths:
 
 components:
   schemas:
-    # --- Envelope Schemas (Lighter Context — No Auth Fields) ---
+    # --- Envelope Schemas ---
     AdapterContext:
       type: object
       description: |
-        Lighter request context for adapter calls. No auth fields — adapter auth
-        is at the transport layer (mTLS / shared secret). The `msgId` flows end-to-end
+        Request context carried on every enveloped adapter call. The `msgId` flows end-to-end
         for log correlation across all services.
       required: [id, version, ts, msgId]
       properties:
         id:
           type: string
-          description: "API identifier (e.g., adapter.chain.info)"
-          example: "adapter.chain.info"
+          description: "Operation identifier (e.g., chain.info)"
+          example: "chain.info"
         version:
           type: string
           description: "API version"
@@ -1453,63 +942,60 @@ components:
           type: string
           format: date-time
           description: "Request timestamp (UTC RFC3339)"
+          example: "2026-02-17T10:00:00Z"
         msgId:
           type: string
           format: uuid
           description: "Unique message ID — same value flows App Backend → UNITS → Adapter → Callback for end-to-end tracing"
-        valueFormat:
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        developerToken:
           type: string
-          enum: [raw, display]
-          default: "raw"
-          description: |
-            Controls how numeric amounts (balances, fees, transfer values) are represented
-            in both the request payload and the response.
-
-            - `raw` (default) — Smallest-unit integer strings. No decimal point.
-              Example: `"100500000"` (100.5 USDC with 6 decimals), `"1625000000000000"` (0.001625 ETH).
-              Used by: TokenEngine, internal system-to-system calls.
-
-            - `display` — Human-readable decimal strings. The adapter applies the correct
-              decimal precision based on the token class or native currency.
-              Example: `"100.50"` (USDC), `"0.001625"` (ETH).
-              Used by: UI-facing callers, direct adapter access for transaction building.
-
-            The adapter is the authoritative source for decimal conversion. When `display`
-            is requested, the adapter converts raw chain values to decimal strings on the way
-            out, and converts decimal strings back to raw values on the way in.
-
-            This avoids cross-ecosystem issues: JS `Number.MAX_SAFE_INTEGER` overflow,
-            language-specific floating-point precision, and consumer burden of doing
-            `value / 10^decimals` arithmetic. Amounts are always opaque strings — never
-            parsed as float by any system.
-          example: "raw"
+          description: "Developer API key identifying the calling application"
+          example: "dev_key_abc123"
+        authorization:
+          type: string
+          description: "Bearer authorization token for the calling principal"
+          example: "Bearer eyJhbGciOiJIUzI1NiJ9..."
 
     AdapterResponseContext:
       type: object
       required: [id, version, ts, msgId, status]
       properties:
-        id: { type: string }
-        version: { type: string }
-        ts: { type: string, format: date-time }
-        msgId: { type: string, format: uuid }
+        id:
+          type: string
+          example: "chain.info"
+        version:
+          type: string
+          example: "1.0"
+        ts:
+          type: string
+          format: date-time
+          example: "2026-02-17T10:00:01Z"
+        msgId:
+          type: string
+          format: uuid
+          example: "550e8400-e29b-41d4-a716-446655440000"
         status:
           type: string
           enum: [successful, failed]
+          example: "successful"
         error:
           $ref: '#/components/schemas/ErrorPayload'
 
     ErrorPayload:
       type: object
+      description: "Present only when `status` is `failed`."
       required: [code, message]
       nullable: true
       properties:
         code:
           type: string
           description: "Machine-readable error code"
-          example: "INVALID_ADDRESS"
+          example: "BAD_REQUEST"
         message:
           type: string
           description: "Human-readable error description"
+          example: "from, to, and amount are required"
 
     AdapterRequest:
       type: object
@@ -1532,730 +1018,451 @@ components:
         context: { $ref: '#/components/schemas/AdapterResponseContext' }
         response: { type: object, example: {} }
 
-    # --- Chain Discovery Schemas ---
-    ChainInfoRequest:
+    # --- Request Payload Schemas ---
+    ChainPayload:
       type: object
       required: [chainId]
       properties:
         chainId:
           type: string
-          description: "CAIP-2 chain identifier"
-          example: "eip155:1"
+          description: "Chain identifier — Alchemy-style (e.g., ethereum-mainnet) or CAIP-2 (e.g., eip155:1)"
+          example: "ethereum-mainnet"
 
-    ChainInfo:
+    BlockPayload:
       type: object
-      required: [chainId, name, chainFamily]
+      required: [chainId, blockId]
       properties:
-        chainId: { type: string, example: "eip155:1" }
-        name: { type: string, example: "Ethereum Mainnet" }
-        chainFamily:
+        chainId:
           type: string
-          enum: [evm, solana, cosmos, substrate]
-          example: "evm"
-        isTestnet: { type: boolean }
-        nativeCurrency:
-          type: object
-          properties:
-            name: { type: string, example: "Ether" }
-            symbol: { type: string, example: "ETH" }
-            decimals: { type: integer, example: 18 }
-        blockTime:
-          type: number
-          description: "Average block time in seconds"
-          example: 12
-        consensus:
+          description: "Chain identifier — Alchemy-style or CAIP-2"
+          example: "ethereum-mainnet"
+        blockId:
           type: string
-          description: "Consensus mechanism"
-          example: "proof-of-stake"
-        explorers:
-          type: array
-          items:
-            type: object
-            properties:
-              name: { type: string }
-              url: { type: string, format: uri }
-              type: { type: string, enum: [primary, secondary] }
+          description: "Block number, block hash, or slot"
+          example: "19000000"
 
-    ChainCapabilitiesRequest:
+    AccountPayload:
       type: object
-      required: [chainId]
+      required: [chainId, accountId]
       properties:
-        chainId: { type: string, example: "eip155:1" }
-
-    ChainCapabilities:
-      type: object
-      required: [chainId, supportedAssetTypes, supportedOperations]
-      properties:
-        chainId: { type: string, example: "eip155:1" }
-        supportedAssetTypes:
-          type: array
-          items:
-            type: string
-            enum: [native, erc20, erc721, erc1155, spl]
-          description: "Asset types this adapter can handle for this chain"
-        supportedOperations:
-          type: array
-          items: { type: string }
-          description: "List of operations supported (e.g., chain.info, balance.get, transactions.build)"
-        features:
-          type: object
-          description: "Feature flags for advanced capabilities"
-          properties:
-            multisig: { type: boolean, default: false }
-            batchTransactions: { type: boolean, default: false }
-            callbacks: { type: boolean, default: true }
-            gasEstimation: { type: boolean, default: true }
-            feePreference: { type: boolean, default: true }
-          additionalProperties: true
-        constraints:
-          type: object
-          description: "Chain-specific constraints"
-          properties:
-            maxBatchSize: { type: integer }
-            maxGasLimit: { type: string }
-          additionalProperties: true
-
-    ChainHeadRequest:
-      type: object
-      required: [chainId]
-      properties:
-        chainId: { type: string, example: "eip155:1" }
-
-    ChainHead:
-      type: object
-      required: [chainId, blockNumber, timestamp]
-      properties:
-        chainId: { type: string, example: "eip155:1" }
-        blockNumber:
-          type: integer
-          description: "Latest block number (or slot for Solana)"
-          example: 19234567
-        blockHash:
+        chainId:
           type: string
-          description: "Latest block hash"
-        timestamp:
+          description: "Chain identifier — Alchemy-style or CAIP-2"
+          example: "ethereum-mainnet"
+        accountId:
           type: string
-          format: date-time
-          description: "Block timestamp"
-        parentHash:
-          type: string
-          description: "Parent block hash"
-
-    # --- Account & Balance Schemas ---
-    AccountResolveRequest:
-      type: object
-      required: [chainId, address]
-      properties:
-        chainId: { type: string, example: "eip155:1" }
-        address:
-          type: string
-          description: "On-chain wallet address"
-          example: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-
-    AccountInfo:
-      type: object
-      required: [chainId, address, exists]
-      properties:
-        chainId: { type: string, example: "eip155:1" }
-        address: { type: string }
-        exists:
+          description: "On-chain account address"
+          example: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+        enrich:
           type: boolean
-          description: "Whether the account exists on-chain (has any history)"
-        accountType:
-          type: string
-          enum: [eoa, contract, multisig]
-          description: "Account type (EVM-specific: EOA vs contract)"
-        nonce:
-          type: integer
-          description: "Current transaction nonce"
+          description: "Whether to include token metadata (symbol, name, formatted balance, decimals). Defaults to true when omitted."
+          example: true
 
-    HoldingsRequest:
+    AssetPayload:
       type: object
-      required: [chainId, address]
+      required: [chainId, assetId]
       properties:
-        chainId: { type: string, example: "eip155:1" }
-        address:
+        chainId:
           type: string
-          description: "On-chain wallet address"
-          example: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
-        includeNative:
-          type: boolean
-          default: true
-          description: "Whether to include native asset (ETH, POL, etc.) in results"
+          description: "Chain identifier — Alchemy-style or CAIP-2"
+          example: "ethereum-mainnet"
+        assetId:
+          type: string
+          description: "Asset identifier (e.g., erc20:<contract>, or native)"
+          example: "erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 
-    TokenHolding:
-      type: object
-      required: [contractAddress, assetType, balance, decimals]
-      properties:
-        contractAddress:
-          type: string
-          description: "Contract address, or 'native' for native assets"
-          example: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-        assetType:
-          type: string
-          enum: [erc20, erc721, erc1155, native, spl]
-          description: "Asset standard on chain"
-          example: "erc20"
-        symbol:
-          type: string
-          description: "Token symbol"
-          example: "USDC"
-        name:
-          type: string
-          description: "Token name"
-          example: "USD Coin"
-        balance:
-          type: string
-          description: |
-            Token balance. Format depends on `context.valueFormat`:
-            - `raw`: smallest-unit integer string (e.g., `"1000000000"` for 1000 USDC)
-            - `display`: human-readable decimal string (e.g., `"1000.00"` for 1000 USDC)
-            Adapter MUST normalize upstream responses (never hex, never float).
-          example: "1000000000"
-        decimals:
-          type: integer
-          minimum: 0
-          maximum: 18
-          description: "Asset metadata: decimal precision for this token on chain. Used during import to create token classes — NOT a conversion hint for the balance field."
-          example: 6
-
-    HoldingsResponse:
-      type: object
-      required: [address, chainId, holdings]
-      properties:
-        address: { type: string }
-        chainId: { type: string, example: "eip155:1" }
-        holdings:
-          type: array
-          items: { $ref: '#/components/schemas/TokenHolding' }
-          description: "Token holdings (may be empty if wallet has no tokens)"
-
-    BalanceRequest:
+    BalancePayload:
       type: object
       required: [chainId, address, contractAddress]
       properties:
-        chainId: { type: string, example: "eip155:1" }
+        chainId:
+          type: string
+          description: "Chain identifier — Alchemy-style or CAIP-2"
+          example: "ethereum-mainnet"
         address:
           type: string
           description: "On-chain wallet address"
-          example: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
+          example: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
         contractAddress:
           type: string
-          description: "Contract address, or 'native' for native asset"
+          description: "Token contract address, or 'native' for the native asset"
           example: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 
-    BalanceResponse:
+    TransactionBuildRequest:
       type: object
-      required: [address, chainId, contractAddress, balance]
-      properties:
-        address: { type: string }
-        chainId: { type: string, example: "eip155:1" }
-        contractAddress: { type: string }
-        assetType: { type: string, enum: [erc20, erc721, erc1155, native, spl] }
-        symbol: { type: string }
-        balance:
-          type: string
-          description: "Balance. Format depends on `context.valueFormat` (raw: smallest-unit integer, display: human-readable decimal)"
-
-    # --- Fee Estimation Schemas ---
-    FeeEstimateRequest:
-      type: object
-      required: [chainId]
+      required: [chainId, from, to, asset, amount]
       properties:
         chainId:
           type: string
-          description: "CAIP-2 chain identifier"
-          example: "eip155:1"
-        gasUnits:
-          type: string
-          pattern: "^[0-9]+$"
-          description: |
-            Optional: estimated gas units for the operation. If provided, the adapter
-            will calculate `estimatedFee` based on these units. If omitted, uses a
-            default (e.g., 21000 for native transfer, 65000 for ERC-20).
-          example: "65000"
-
-    FeeTier:
-      type: object
-      description: |
-        A single fee tier. The `name` field is the tier identifier that maps to
-        `feePreference` on `/transactions/build`. Additional fields are chain-specific.
-
-        Fee amount format depends on `context.valueFormat`:
-        - `raw`: smallest-unit integer string (e.g., `"1625000000000000"` wei)
-        - `display`: human-readable decimal string (e.g., `"0.001625"` ETH)
-        No `decimals` field is included — the adapter owns decimal conversion.
-      required: [name, estimatedFee]
-      properties:
-        name:
-          type: string
-          description: "Tier name — used as `feePreference` value in build requests"
-          example: "standard"
-        estimatedFee:
-          type: string
-          description: |
-            Total estimated fee in native currency.
-            Format depends on `context.valueFormat`:
-            - `raw`: `"1625000000000000"` (wei)
-            - `display`: `"0.001625"` (ETH)
-          example: "1625000000000000"
-        estimatedTimeSeconds:
-          type: integer
-          description: "Estimated time to block inclusion in seconds"
-          example: 30
-        gasPrice:
-          type: string
-          description: "Legacy gas price (for non-EIP-1559 chains)"
-        maxPriorityFee:
-          type: string
-          description: "EIP-1559 max priority fee per gas (tip)"
-        computeUnitPrice:
-          type: string
-          description: "Solana compute unit price"
-      additionalProperties: true
-
-    FeeEstimateResponse:
-      type: object
-      required: [chainId, feeModel, tiers]
-      properties:
-        chainId:
-          type: string
-          example: "eip155:1"
-        feeModel:
-          type: string
-          description: |
-            Fee model identifier for this chain. Tells the UI how to interpret
-            the tier fields and whether to show fee breakdown components.
-          enum: [legacy, eip1559, solana, optimistic-l2, fixed]
-          example: "eip1559"
-        baseFee:
-          type: string
-          description: "Current base fee (EIP-1559 chains). Burns on inclusion."
-        l1DataFee:
-          type: string
-          description: "L1 data availability fee component (L2 chains)"
-        nativeCurrency:
-          type: string
-          description: "Native currency symbol for fee display"
-          example: "ETH"
-        tiers:
-          type: array
-          items:
-            $ref: '#/components/schemas/FeeTier'
-          description: |
-            Available fee tiers. Always includes at least "standard".
-            Tier names are free-form — the adapter defines them based on the chain's fee model.
-            Common: ["slow", "standard", "fast"]. Some chains may have fewer or more tiers.
-          minItems: 1
-        updatedAt:
-          type: string
-          format: date-time
-          description: "When these fee estimates were last refreshed (cache age indicator)"
-
-    # --- Asset Resolution Schemas ---
-    AssetResolveRequest:
-      type: object
-      required: [chainId, contractAddress]
-      properties:
-        chainId: { type: string, example: "eip155:1" }
-        contractAddress:
-          type: string
-          description: "Contract address to resolve"
-          example: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-
-    AssetInfo:
-      type: object
-      required: [chainId, contractAddress, assetType]
-      properties:
-        chainId: { type: string, example: "eip155:1" }
-        contractAddress: { type: string }
-        assetType:
-          type: string
-          enum: [erc20, erc721, erc1155, spl]
-        name: { type: string, example: "USD Coin" }
-        symbol: { type: string, example: "USDC" }
-        decimals:
-          type: integer
-          minimum: 0
-          maximum: 18
-          example: 6
-        totalSupply:
-          type: string
-          description: "Total supply. Format depends on `context.valueFormat` (raw: smallest-unit integer, display: human-readable decimal)"
-
-    # --- Transaction Schemas ---
-    BuildTransactionRequest:
-      type: object
-      required: [chainId, from, to, contractAddress, amount, assetType]
-      properties:
-        chainId:
-          type: string
-          description: "CAIP-2 chain identifier"
-          example: "eip155:1"
+          description: "Chain identifier — Alchemy-style or CAIP-2"
+          example: "ethereum-mainnet"
         from:
           type: string
           description: "Sender wallet address"
-          example: "0x24596184fccdf7b5f2e93711f39cee4926ec7b2d"
+          example: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
         to:
           type: string
           description: "Recipient wallet address"
-          example: "0xBobAddress1234567890abcdef1234567890abcdef"
-        contractAddress:
+          example: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+        asset:
           type: string
-          description: "Token contract address, or 'native' for native asset transfer"
-          example: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+          description: "Asset to transfer (e.g., native, or erc20:<contract>)"
+          example: "native"
         amount:
           type: string
-          description: |
-            Transfer amount. Format depends on `context.valueFormat`:
-            - `raw`: smallest-unit integer string (e.g., `"100000000"` for 100 USDC)
-            - `display`: human-readable decimal string (e.g., `"100.00"` for 100 USDC)
-            The adapter converts between formats using the token's decimal precision.
-          example: "100000000"
-        assetType:
-          type: string
-          enum: [erc20, erc721, erc1155, native, spl]
-          description: "Asset standard"
-          example: "erc20"
+          description: "Transfer amount as a string"
+          example: "0.5"
         feePreference:
           type: string
-          default: "standard"
-          description: |
-            Fee tier name — must match a tier `name` from `/fees/estimate` response.
-            Common tiers: "slow", "standard", "fast". Adapters may define additional
-            chain-specific tiers. Defaults to "standard" if omitted.
+          enum: [low, standard, fast]
+          description: "Fee tier preference"
           example: "standard"
 
-    BuildTransactionResponse:
+    TransactionSubmitRequest:
       type: object
-      required: [unsignedTx, chainId, from, to, amount]
+      required: [intentId]
       properties:
-        unsignedTx:
+        intentId:
           type: string
-          description: "Raw unsigned transaction payload (hex-encoded for EVM)"
-          example: "0x02f87001..."
-        chainId: { type: string, example: "eip155:1" }
-        from: { type: string }
-        to: { type: string }
-        contractAddress: { type: string }
-        amount: { type: string }
-        estimatedGas:
-          type: string
-          description: "Estimated gas units"
-          example: "65000"
-        gasPrice:
-          type: string
-          description: "Current gas price. Format depends on `context.valueFormat`"
-          example: "25000000000"
-        nonce:
-          type: integer
-          description: "Transaction nonce"
-          example: 42
-        requiredSignatures:
-          type: integer
-          description: "Number of signatures required (1 for EOA, >1 for multisig)"
-          default: 1
-          example: 1
-        expiresAt:
-          type: string
-          format: date-time
-          description: "Timestamp after which this unsigned tx may be stale (gas/nonce drift)"
-          example: "2026-02-17T12:10:00Z"
-    SignTransactionRequest:
-      type: object
-      required: [chainId, unsignedTx, signerAddress]
-      properties:
-        chainId: { type: string, example: "eip155:1" }
-        unsignedTx:
-          type: string
-          description: "Unsigned transaction payload from /transactions/build"
-        signerAddress:
-          type: string
-          description: "Address of the signer (must match adapter-managed key)"
-
-    SignTransactionResponse:
-      type: object
-      required: [signedTx, chainId]
-      properties:
+          description: "Intent identifier returned by /transactions/build"
+          example: "intent_a1b2c3d4"
         signedTx:
           type: string
-          description: "Signed transaction payload ready for submission"
-        chainId: { type: string, example: "eip155:1" }
+          description: "Signed raw transaction payload (hex-encoded for EVM)"
+          example: "0xf86c..."
+        txHash:
+          type: string
+          description: "Transaction hash when broadcast client-side (sign-and-send mode)"
+          example: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
-    SubmitTransactionRequest:
+    TransactionQuery:
       type: object
-      required: [chainId, signedTx]
+      required: [chainId, txId]
       properties:
         chainId:
           type: string
-          description: "CAIP-2 chain identifier"
-          example: "eip155:1"
-        signedTx:
+          description: "Chain identifier — Alchemy-style or CAIP-2"
+          example: "ethereum-mainnet"
+        txId:
           type: string
-          description: "Signed transaction payload (hex-encoded for EVM)"
-        transactionId:
-          type: string
-          description: |
-            UNITS internal transaction ID. Passed to the adapter so it can include it
-            in the callback for reverse mapping. Optional — omit for poll-only mode.
-          example: "units-tx-550e8400-e29b-41d4-a716-446655440000"
-        callbackUrl:
-          type: string
-          format: uri
-          description: |
-            URL the adapter should call when the transaction is confirmed or fails on-chain.
-            Typically UNITS `/v1/token/transact`. Optional — omit for poll-only mode.
-          example: "https://foundry.finternetlab.io/v1/token/transact"
+          description: "Transaction id / on-chain hash"
+          example: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
-    SubmitTransactionResponse:
+    # --- Response Schemas ---
+    ChainInfo:
       type: object
-      required: [txHash, chainId, status]
+      required: [chainId, name, network, currency, decimals, blockTime]
       properties:
-        txHash:
-          type: string
-          description: "On-chain transaction hash"
-          example: "0xabc123..."
-        chainId: { type: string, example: "eip155:1" }
-        status:
-          type: string
-          enum: [submitted, pending]
-          description: "Initial status after submission"
-        submittedAt:
-          type: string
-          format: date-time
+        chainId: { type: string, example: "ethereum-mainnet" }
+        name: { type: string, example: "Ethereum Mainnet" }
+        network: { type: string, example: "mainnet" }
+        currency: { type: string, example: "ETH" }
+        decimals: { type: integer, example: 18 }
+        blockTime:
+          type: integer
+          description: "Average block time in seconds"
+          example: 12
 
-    TransactionStatusRequest:
+    ChainCapabilities:
       type: object
-      required: [chainId, txHash]
+      required: [nativeTransfers, tokenTransfers, nftTransfers, smartContracts, assetTypes]
       properties:
-        chainId: { type: string, example: "eip155:1" }
-        txHash:
-          type: string
-          description: "On-chain transaction hash"
-          example: "0xabc123def456789012345678901234567890123456789012345678901234abcd"
+        nativeTransfers: { type: boolean, example: true }
+        tokenTransfers: { type: boolean, example: true }
+        nftTransfers: { type: boolean, example: true }
+        smartContracts: { type: boolean, example: true }
+        assetTypes:
+          type: array
+          items: { type: string }
+          description: "Asset types this adapter can handle for this chain"
+          example: ["native", "erc20", "erc721", "erc1155"]
 
-    TransactionStatusResponse:
+    ChainHead:
       type: object
-      required: [txHash, chainId, status]
+      required: [blockNumber, blockHash, timestamp]
       properties:
-        txHash: { type: string }
-        chainId: { type: string, example: "eip155:1" }
-        status:
-          type: string
-          enum: [pending, confirmed, failed]
-          description: "On-chain transaction status"
         blockNumber:
           type: integer
-          description: "Block number where tx was included (if confirmed or failed)"
+          description: "Latest block number (or slot for Solana)"
+          example: 19500000
         blockHash:
           type: string
-          description: "Block hash (if confirmed)"
-        gasUsed:
-          type: string
-          description: "Actual gas consumed"
-        confirmations:
+          description: "Latest block hash"
+          example: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+        timestamp:
           type: integer
-          description: "Number of block confirmations since inclusion (0 if pending)"
-          example: 12
-        confirmedAt:
-          type: string
-          format: date-time
-          description: "Block timestamp (if confirmed)"
-        failureReason:
-          type: string
-          description: "Revert reason (if failed)"
+          format: int64
+          description: "Block timestamp (Unix epoch seconds)"
+          example: 1705312200
 
-    TransactionReceiptRequest:
+    BlockInfo:
       type: object
-      required: [chainId, txHash]
+      required: [blockNumber, blockHash, parentHash, timestamp, transactionCount]
       properties:
-        chainId: { type: string, example: "eip155:1" }
-        txHash:
+        blockNumber: { type: integer, example: 19500000 }
+        blockHash:
           type: string
-          description: "On-chain transaction hash"
-
-    TransactionReceipt:
-      type: object
-      required: [txHash, chainId, status]
-      properties:
-        txHash: { type: string }
-        chainId: { type: string, example: "eip155:1" }
-        status:
+          example: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+        parentHash:
           type: string
-          enum: [confirmed, failed]
-        blockNumber: { type: integer }
-        blockHash: { type: string }
-        from: { type: string }
-        to: { type: string }
-        gasUsed: { type: string }
-        effectiveGasPrice:
-          type: string
-          description: "Actual gas price paid (decimal integer string)"
-        confirmations: { type: integer }
-        logs:
+          example: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        timestamp:
+          type: integer
+          format: int64
+          description: "Block timestamp (Unix epoch seconds)"
+          example: 1705312200
+        transactionCount: { type: integer, example: 150 }
+        transactions:
           type: array
-          description: "Event logs emitted during transaction execution"
-          items:
-            $ref: '#/components/schemas/EventLog'
+          items: { type: string }
+          description: "Transaction hashes included in the block (optional)"
 
-    EventLog:
+    AccountInfo:
       type: object
-      description: "On-chain event log entry"
+      required: [address, balance, nonce]
       properties:
         address:
           type: string
-          description: "Contract address that emitted the event"
-        topics:
-          type: array
-          items: { type: string }
-          description: "Indexed event topics (first topic is the event signature hash)"
-        data:
+          example: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+        balance:
           type: string
-          description: "Non-indexed event data (hex-encoded)"
-        logIndex:
+          description: "Native balance in smallest units"
+          example: "1000000000000000000"
+        nonce:
           type: integer
-          description: "Log position within the block"
+          description: "Current transaction nonce"
+          example: 42
 
-    # --- Meta Schemas ---
-    SupportedChain:
+    Holding:
       type: object
-      required: [chainId, name]
+      required: [assetId, assetType, balance]
       properties:
-        chainId: { type: string, example: "eip155:1" }
-        name: { type: string, example: "Ethereum Mainnet" }
+        assetId:
+          type: string
+          example: "erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        assetType:
+          type: string
+          enum: [native, erc20, erc721, erc1155, spl]
+          example: "erc20"
+        symbol: { type: string, example: "USDC" }
+        name: { type: string, example: "USD Coin" }
+        balance:
+          type: string
+          description: "Balance in smallest units"
+          example: "1000000"
+        balanceFormatted:
+          type: string
+          description: "Human-readable balance (present when enriched)"
+          example: "1.000000"
+        decimals: { type: integer, example: 6 }
 
-    AdapterInfo:
+    HoldingsResponse:
       type: object
-      required: [name, version, provider, supportedChains]
+      required: [address, holdings]
       properties:
-        name:
+        address:
           type: string
-          description: "Adapter display name"
-          example: "Finternet Alchemy Adapter"
-        version:
-          type: string
-          description: "Adapter software version"
-          example: "1.0.0"
-        provider:
-          type: string
-          description: "Upstream data provider"
-          example: "alchemy"
-        supportedChains:
+          example: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+        holdings:
           type: array
-          items: { $ref: '#/components/schemas/SupportedChain' }
+          items: { $ref: '#/components/schemas/Holding' }
+          description: "Token holdings (may be empty if the account has no tokens)"
 
+    AssetInfo:
+      type: object
+      required: [assetId, assetType, name, symbol, decimals]
+      properties:
+        assetId:
+          type: string
+          example: "erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        assetType:
+          type: string
+          enum: [native, erc20, erc721, erc1155, spl]
+          example: "erc20"
+        name: { type: string, example: "USD Coin" }
+        symbol: { type: string, example: "USDC" }
+        decimals: { type: integer, example: 6 }
+        contractAddress:
+          type: string
+          example: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        totalSupply:
+          type: string
+          example: "1000000000000"
+
+    BalanceInfo:
+      type: object
+      required: [address, chainId, contractAddress, balance]
+      properties:
+        address:
+          type: string
+          example: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+        chainId: { type: string, example: "eip155:1" }
+        contractAddress:
+          type: string
+          example: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        assetType:
+          type: string
+          enum: [native, erc20, erc721, erc1155, spl]
+          example: "erc20"
+        symbol: { type: string, example: "USDC" }
+        balance:
+          type: string
+          description: "Balance in smallest units"
+          example: "7000000"
+        decimals: { type: integer, example: 6 }
+
+    TransactionBuildResponse:
+      type: object
+      required: [intentId, txPayload, signingMode]
+      properties:
+        intentId:
+          type: string
+          example: "intent_a1b2c3d4"
+        txPayload:
+          type: object
+          additionalProperties: true
+          description: "Chain-specific unsigned transaction payload (freeform JSON) to be signed externally"
+        signingMode:
+          type: string
+          enum: [signTransaction, signAndSendTransaction]
+          example: "signTransaction"
+        expiresAt:
+          type: string
+          format: date-time
+          description: "Timestamp after which this intent expires"
+          example: "2026-02-17T12:10:00Z"
+
+    TransactionSubmitResponse:
+      type: object
+      required: [txId, status]
+      properties:
+        txId:
+          type: string
+          example: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        status:
+          type: string
+          enum: [queued, pending]
+          example: "queued"
+
+    TransactionInfo:
+      type: object
+      required: [txHash, status, from, to, value]
+      properties:
+        txHash:
+          type: string
+          example: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        status:
+          type: string
+          enum: [pending, confirmed, failed]
+          example: "confirmed"
+        blockNumber: { type: integer, example: 19500000 }
+        blockHash:
+          type: string
+          example: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+        from:
+          type: string
+          example: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+        to:
+          type: string
+          example: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+        value:
+          type: string
+          example: "0.5"
+        gasUsed:
+          type: string
+          example: "21000"
+
+    TransactionReceipt:
+      type: object
+      required: [txHash, status, blockNumber, blockHash, gasUsed, confirmations, success]
+      properties:
+        txHash:
+          type: string
+          example: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        status:
+          type: string
+          enum: [confirmed, failed]
+          example: "confirmed"
+        blockNumber: { type: integer, example: 19500000 }
+        blockHash:
+          type: string
+          example: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+        gasUsed:
+          type: string
+          example: "21000"
+        effectiveGasPrice:
+          type: string
+          description: "Actual gas price paid (decimal integer string)"
+          example: "20000000000"
+        confirmations: { type: integer, example: 12 }
+        success: { type: boolean, example: true }
+        logs:
+          description: "Freeform chain-specific event logs (raw JSON — array or object)"
+          example:
+            - address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+              topics:
+                - "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+              data: "0x0000000000000000000000000000000000000000000000000000000005f5e100"
+              logIndex: 0
+
+    # --- Health (bare, no envelope) ---
     HealthResponse:
       type: object
       required: [status]
       properties:
         status:
           type: string
-          enum: [healthy, degraded, unhealthy]
-          description: "Overall adapter health"
-        uptime:
-          type: integer
-          description: "Uptime in seconds"
-        upstream:
-          type: object
-          description: "Upstream provider connectivity"
-          properties:
-            status:
-              type: string
-              enum: [connected, degraded, disconnected]
-            latencyMs:
-              type: integer
-              description: "Last measured roundtrip latency to upstream"
-            lastCheckedAt:
-              type: string
-              format: date-time
-            error:
-              type: string
-              description: "Error message if upstream is not connected"
+          description: "Liveness status"
+          example: "ok"
 
     # --- Request Envelopes ---
-    ApiRequest_Empty:
+    ApiRequest_ChainPayload:
       allOf:
         - $ref: '#/components/schemas/AdapterRequest'
         - properties:
-            payload: { type: object }
+            payload: { $ref: '#/components/schemas/ChainPayload' }
 
-    ApiRequest_ChainInfoRequest:
+    ApiRequest_BlockPayload:
       allOf:
         - $ref: '#/components/schemas/AdapterRequest'
         - properties:
-            payload: { $ref: '#/components/schemas/ChainInfoRequest' }
+            payload: { $ref: '#/components/schemas/BlockPayload' }
 
-    ApiRequest_ChainCapabilitiesRequest:
+    ApiRequest_AccountPayload:
       allOf:
         - $ref: '#/components/schemas/AdapterRequest'
         - properties:
-            payload: { $ref: '#/components/schemas/ChainCapabilitiesRequest' }
+            payload: { $ref: '#/components/schemas/AccountPayload' }
 
-    ApiRequest_ChainHeadRequest:
+    ApiRequest_BalancePayload:
       allOf:
         - $ref: '#/components/schemas/AdapterRequest'
         - properties:
-            payload: { $ref: '#/components/schemas/ChainHeadRequest' }
+            payload: { $ref: '#/components/schemas/BalancePayload' }
 
-    ApiRequest_AccountResolveRequest:
+    ApiRequest_AssetPayload:
       allOf:
         - $ref: '#/components/schemas/AdapterRequest'
         - properties:
-            payload: { $ref: '#/components/schemas/AccountResolveRequest' }
+            payload: { $ref: '#/components/schemas/AssetPayload' }
 
-    ApiRequest_HoldingsRequest:
+    ApiRequest_TransactionBuildRequest:
       allOf:
         - $ref: '#/components/schemas/AdapterRequest'
         - properties:
-            payload: { $ref: '#/components/schemas/HoldingsRequest' }
+            payload: { $ref: '#/components/schemas/TransactionBuildRequest' }
 
-    ApiRequest_BalanceRequest:
+    ApiRequest_TransactionSubmitRequest:
       allOf:
         - $ref: '#/components/schemas/AdapterRequest'
         - properties:
-            payload: { $ref: '#/components/schemas/BalanceRequest' }
+            payload: { $ref: '#/components/schemas/TransactionSubmitRequest' }
 
-    ApiRequest_AssetResolveRequest:
+    ApiRequest_TransactionQuery:
       allOf:
         - $ref: '#/components/schemas/AdapterRequest'
         - properties:
-            payload: { $ref: '#/components/schemas/AssetResolveRequest' }
-
-    ApiRequest_FeeEstimateRequest:
-      allOf:
-        - $ref: '#/components/schemas/AdapterRequest'
-        - properties:
-            payload: { $ref: '#/components/schemas/FeeEstimateRequest' }
-
-    ApiRequest_BuildTransactionRequest:
-      allOf:
-        - $ref: '#/components/schemas/AdapterRequest'
-        - properties:
-            payload: { $ref: '#/components/schemas/BuildTransactionRequest' }
-
-    ApiRequest_SignTransactionRequest:
-      allOf:
-        - $ref: '#/components/schemas/AdapterRequest'
-        - properties:
-            payload: { $ref: '#/components/schemas/SignTransactionRequest' }
-
-    ApiRequest_SubmitTransactionRequest:
-      allOf:
-        - $ref: '#/components/schemas/AdapterRequest'
-        - properties:
-            payload: { $ref: '#/components/schemas/SubmitTransactionRequest' }
-
-    ApiRequest_TransactionStatusRequest:
-      allOf:
-        - $ref: '#/components/schemas/AdapterRequest'
-        - properties:
-            payload: { $ref: '#/components/schemas/TransactionStatusRequest' }
-
-    ApiRequest_TransactionReceiptRequest:
-      allOf:
-        - $ref: '#/components/schemas/AdapterRequest'
-        - properties:
-            payload: { $ref: '#/components/schemas/TransactionReceiptRequest' }
+            payload: { $ref: '#/components/schemas/TransactionQuery' }
 
     # --- Response Envelopes ---
     ApiResponse_ChainInfo:
@@ -2276,23 +1483,23 @@ components:
         - properties:
             response: { $ref: '#/components/schemas/ChainHead' }
 
+    ApiResponse_BlockInfo:
+      allOf:
+        - $ref: '#/components/schemas/AdapterResponse'
+        - properties:
+            response: { $ref: '#/components/schemas/BlockInfo' }
+
     ApiResponse_AccountInfo:
       allOf:
         - $ref: '#/components/schemas/AdapterResponse'
         - properties:
             response: { $ref: '#/components/schemas/AccountInfo' }
 
-    ApiResponse_Holdings:
+    ApiResponse_HoldingsResponse:
       allOf:
         - $ref: '#/components/schemas/AdapterResponse'
         - properties:
             response: { $ref: '#/components/schemas/HoldingsResponse' }
-
-    ApiResponse_Balance:
-      allOf:
-        - $ref: '#/components/schemas/AdapterResponse'
-        - properties:
-            response: { $ref: '#/components/schemas/BalanceResponse' }
 
     ApiResponse_AssetInfo:
       allOf:
@@ -2300,53 +1507,35 @@ components:
         - properties:
             response: { $ref: '#/components/schemas/AssetInfo' }
 
-    ApiResponse_FeeEstimate:
+    ApiResponse_BalanceInfo:
       allOf:
         - $ref: '#/components/schemas/AdapterResponse'
         - properties:
-            response: { $ref: '#/components/schemas/FeeEstimateResponse' }
+            response: { $ref: '#/components/schemas/BalanceInfo' }
 
-    ApiResponse_BuildTransaction:
+    ApiResponse_TransactionBuildResponse:
       allOf:
         - $ref: '#/components/schemas/AdapterResponse'
         - properties:
-            response: { $ref: '#/components/schemas/BuildTransactionResponse' }
+            response: { $ref: '#/components/schemas/TransactionBuildResponse' }
 
-    ApiResponse_SignTransaction:
+    ApiResponse_TransactionSubmitResponse:
       allOf:
         - $ref: '#/components/schemas/AdapterResponse'
         - properties:
-            response: { $ref: '#/components/schemas/SignTransactionResponse' }
+            response: { $ref: '#/components/schemas/TransactionSubmitResponse' }
 
-    ApiResponse_SubmitTransaction:
+    ApiResponse_TransactionInfo:
       allOf:
         - $ref: '#/components/schemas/AdapterResponse'
         - properties:
-            response: { $ref: '#/components/schemas/SubmitTransactionResponse' }
-
-    ApiResponse_TransactionStatus:
-      allOf:
-        - $ref: '#/components/schemas/AdapterResponse'
-        - properties:
-            response: { $ref: '#/components/schemas/TransactionStatusResponse' }
+            response: { $ref: '#/components/schemas/TransactionInfo' }
 
     ApiResponse_TransactionReceipt:
       allOf:
         - $ref: '#/components/schemas/AdapterResponse'
         - properties:
             response: { $ref: '#/components/schemas/TransactionReceipt' }
-
-    ApiResponse_AdapterInfo:
-      allOf:
-        - $ref: '#/components/schemas/AdapterResponse'
-        - properties:
-            response: { $ref: '#/components/schemas/AdapterInfo' }
-
-    ApiResponse_Health:
-      allOf:
-        - $ref: '#/components/schemas/AdapterResponse'
-        - properties:
-            response: { $ref: '#/components/schemas/HealthResponse' }
 
   # -------------------- Error Responses --------------------
   responses:
@@ -2357,14 +1546,14 @@ components:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
             context:
-              id: "adapter.balance.get"
+              id: "balance.get"
               version: "1.0"
               ts: "2026-02-17T10:00:01Z"
-              msgId: "..."
+              msgId: "550e8400-e29b-41d4-a716-446655440000"
               status: "failed"
               error:
-                code: "INVALID_REQUEST"
-                message: "Invalid address format for this chain"
+                code: "BAD_REQUEST"
+                message: "contractAddress is required"
             response: {}
 
     NotFoundError:
@@ -2374,10 +1563,10 @@ components:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
             context:
-              id: "adapter.transactions.status"
+              id: "transactions.get"
               version: "1.0"
               ts: "2026-02-17T10:00:01Z"
-              msgId: "..."
+              msgId: "550e8400-e29b-41d4-a716-446655440000"
               status: "failed"
               error:
                 code: "NOT_FOUND"
@@ -2391,12 +1580,12 @@ components:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
             context:
-              id: "adapter.chain.info"
+              id: "chain.info"
               version: "1.0"
               ts: "2026-02-17T10:00:01Z"
-              msgId: "..."
+              msgId: "550e8400-e29b-41d4-a716-446655440000"
               status: "failed"
               error:
-                code: "UPSTREAM_UNAVAILABLE"
+                code: "SERVICE_UNAVAILABLE"
                 message: "Chain RPC endpoint is not responding"
             response: {}

--- a/api/adapter-interface.yaml
+++ b/api/adapter-interface.yaml
@@ -2363,7 +2363,7 @@ components:
               msgId: "..."
               status: "failed"
               error:
-                code: "INVALID_REQUEST"
+                code: "INVALID_INPUT"
                 message: "Invalid address format for this chain"
             response: {}
 

--- a/api/central-registry-interfaces.yaml
+++ b/api/central-registry-interfaces.yaml
@@ -1,0 +1,312 @@
+openapi: 3.1.0
+
+info:
+  title: UNITS Federation — Central Registry API (Public Surface)
+  version: 1.0.0
+  description: |
+    The externally-facing surface of the UNITS Federation Central Registry:
+    trust-anchor distribution and read-only discovery (name/DID/instance
+    lookups). These are the only Central Registry endpoints intended for
+    consumers outside the federation internals.
+
+    **Scope — intentionally excluded (internal):** the signed ULIP
+    instance-to-registry federation surface (`/ulip/v1/*` — name register/
+    resolve, account get/update, capabilities, and all credential/scope/
+    delegation/client/key operations) and the admin surface (`/v1/internal/*`).
+    Those are federation/operator machinery and are NOT documented here.
+
+    Reconciled field-for-field against the deployed registry service at
+    units-services tag `2026.07.13_RC`.
+
+servers:
+  - url: http://registry.units-services.svc.cluster.local:3000
+    description: In-cluster public surface
+
+tags:
+  - { name: trust,     description: Trust-anchor and signing-key distribution }
+  - { name: names,     description: Name / DID / contact resolution (signed records) }
+  - { name: instances, description: Instance capability and public-key discovery }
+
+security:
+  - devToken: []
+
+paths:
+  /v1/.well-known/registrar-pubkey:
+    get:
+      tags: [trust]
+      summary: Registrar signing key (trust anchor)
+      description: |
+        The registrar's current Ed25519 signing key. Unauthenticated by design
+        (TOFU) — clients SHOULD pin/validate this value out of band.
+      security: []
+      responses:
+        "200":
+          description: Registrar public key
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RegistrarPublicKey" }
+
+  /.well-known/ulip.json:
+    get:
+      tags: [trust]
+      summary: Registry signing keys (JWKS-style)
+      description: |
+        The registry's active signing keys in a JWKS-style document (ADR-005).
+        Cacheable and unauthenticated; peers use it to verify registry-signed
+        name records, capability mirrors, and registry-issued login JWTs.
+      security: []
+      responses:
+        "200":
+          description: Signing-key set
+          headers:
+            Cache-Control:
+              schema: { type: string, example: "public, max-age=3600" }
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/WellKnownDocument" }
+
+  /v1/names/{name}:
+    get:
+      tags: [names]
+      summary: Resolve a name (address) to its signed record
+      description: |
+        Returns the signed `NameRecord` for the given handle. The path segment
+        is the PLAINTEXT address; the registry hashes it server-side.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: Plaintext address/handle to resolve.
+          schema: { type: string }
+      responses:
+        "200":
+          description: Signed name record
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/NameRecord" }
+        "400": { description: Invalid address format }
+        "404": { description: Not registered (no body) }
+
+  /v1/accounts/{did}:
+    get:
+      tags: [names]
+      summary: Resolve a DID to its signed record
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string, example: "did:units:0x…" }
+      responses:
+        "200":
+          description: Signed name record
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/NameRecord" }
+        "400": { description: did is required }
+        "404": { description: Unknown DID (no body) }
+
+  /v1/resolve:
+    post:
+      tags: [names]
+      summary: Resolve a contact (email/phone) to a home instance
+      description: |
+        Email/phone-first login routing. Minimal-disclosure by design: on a hit
+        returns ONLY `{did, home, home_endpoints, home_instance_name?}` — never
+        the address, contact hashes, or registrar signature. On a miss, `404`
+        with no body (the status code is the only existence signal). Behind a
+        per-contact-hash rate limiter.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/ContactResolveRequest" }
+      responses:
+        "200":
+          description: Home-instance routing pointer
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ContactResolveResponse" }
+        "404": { description: Unknown / withheld / no contact supplied (no body) }
+        "429": { description: Rate limited (per contact hash) }
+
+  /v1/instances:
+    get:
+      tags: [instances]
+      summary: List the instance catalog
+      description: The full instance catalog the app instance-picker reads.
+      responses:
+        "200":
+          description: Instance catalog
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/InstanceList" }
+
+  /v1/instances/{id}:
+    get:
+      tags: [instances]
+      summary: Get an instance capability document
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Instance UUID.
+          schema: { type: string, format: uuid }
+      responses:
+        "200":
+          description: Signed capability document
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/CapabilityDocument" }
+        "400": { description: instance id is required }
+        "404": { description: Unknown instance (no body) }
+
+  /v1/instances/{id}/public-key:
+    get:
+      tags: [instances]
+      summary: Get an instance's signing public key
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        "200":
+          description: Instance public key
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/InstancePublicKey" }
+        "400": { description: instance id is required }
+        "404": { description: Unknown instance / no active key (no body) }
+
+components:
+  securitySchemes:
+    devToken:
+      type: apiKey
+      in: header
+      name: X-Developer-Token
+      description: Trusted-BFF shared secret for the REST discovery surface.
+
+  schemas:
+    RegistrarPublicKey:
+      type: object
+      required: [key_id, algorithm, public_key]
+      properties:
+        key_id:     { type: string }
+        algorithm:  { type: string, example: "ed25519" }
+        public_key: { type: string, description: "Base64-encoded Ed25519 public key." }
+
+    WellKnownDocument:
+      type: object
+      required: [instance, keys, as_of]
+      properties:
+        instance: { type: string, example: "registry" }
+        as_of:    { type: string, format: date-time }
+        keys:
+          type: array
+          items:
+            type: object
+            required: [key_id, algorithm, public_key, status]
+            properties:
+              key_id:     { type: string }
+              algorithm:  { type: string, example: "ed25519" }
+              public_key: { type: string, description: "Base64-encoded public key." }
+              status:     { type: string, example: "active" }
+
+    NameRecord:
+      type: object
+      description: |
+        The signed name record. `address` is the plaintext handle attested by
+        the signature (the registry keys uniqueness on a server-side hash).
+        `name` is an optional human-readable display label.
+      required: [address, did, home, version, as_of, signed_by]
+      properties:
+        address:        { type: string, description: "Plaintext handle (JCS body field 'address')." }
+        did:            { type: string, example: "did:units:0x…" }
+        home:           { type: string, description: "UUID id of the home instance.", format: uuid }
+        home_endpoints: { type: object, additionalProperties: { type: string } }
+        name:           { type: string, description: "Optional display name." }
+        user_public_key: { type: string }
+        email_hash:     { type: string }
+        phone_hash:     { type: string }
+        version:        { type: integer }
+        as_of:          { type: string, format: date-time }
+        signed_by:      { type: string, description: "Signer key id / instance." }
+        key_id:         { type: string, description: "Omitted on legacy unsigned records." }
+        signature:      { type: string, description: "Omitted on legacy unsigned records." }
+
+    ContactResolveRequest:
+      type: object
+      description: Supply email or phone (plaintext; hashed server-side).
+      properties:
+        email: { type: string }
+        phone: { type: string }
+
+    ContactResolveResponse:
+      type: object
+      required: [did, home]
+      properties:
+        did:                { type: string }
+        home:               { type: string, description: "Home instance UUID id.", format: uuid }
+        home_endpoints:     { type: object, additionalProperties: { type: string } }
+        home_instance_name: { type: string, description: "Display label (best-effort; omitted if unavailable)." }
+
+    InstanceList:
+      type: object
+      required: [instances]
+      properties:
+        instances:
+          type: array
+          items: { $ref: "#/components/schemas/InstanceSummary" }
+
+    InstanceSummary:
+      type: object
+      required: [id, name, api_url, ulip_url, public_key, accepts_new_signups, updated_at]
+      properties:
+        id:                  { type: string, format: uuid }
+        name:                { type: string }
+        api_url:             { type: string }
+        ulip_url:            { type: string }
+        public_key:          { type: string }
+        accepts_new_signups: { type: boolean }
+        updated_at:          { type: string, format: date-time }
+
+    CapabilityDocument:
+      type: object
+      required: [id, ulip_versions, accepts_new_signups, endpoints, signing_keys, as_of, version, signed_by, signature]
+      properties:
+        id:                     { type: string, format: uuid }
+        name:                   { type: string }
+        lifecycle_state:        { type: string }
+        ulip_versions:          { type: array, items: { type: string } }
+        token_classes_accepted: { type: array, items: { type: string } }
+        token_classes_issued:   { type: array, items: { type: string } }
+        chains_supported:       { type: array, items: { type: string } }
+        accepts_new_signups:    { type: boolean }
+        peering:                { type: object, additionalProperties: true }
+        endpoints:              { type: object, additionalProperties: true }
+        primitive_capabilities: { type: object, additionalProperties: true }
+        signing_keys:
+          type: array
+          items: { $ref: "#/components/schemas/SigningKey" }
+        as_of:     { type: string, format: date-time }
+        version:   { type: integer }
+        signed_by: { type: string }
+        signature: { type: string }
+
+    SigningKey:
+      type: object
+      required: [key_id, algorithm, public_key, valid_from]
+      properties:
+        key_id:      { type: string }
+        algorithm:   { type: string, example: "ed25519" }
+        public_key:  { type: string }
+        valid_from:  { type: string, format: date-time }
+        valid_until: { type: string, format: date-time }
+
+    InstancePublicKey:
+      type: object
+      required: [id, algorithm, public_key]
+      properties:
+        id:         { type: string, format: uuid }
+        algorithm:  { type: string, example: "ed25519" }
+        public_key: { type: string }

--- a/api/clients-interfaces.yaml
+++ b/api/clients-interfaces.yaml
@@ -61,7 +61,7 @@ paths:
             example:
               context:
                 id: "api.clients.register"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "11111111-2222-3333-4444-555555555555"
                 developerToken: "fnt_..."
@@ -206,7 +206,7 @@ paths:
             example:
               context:
                 id: "api.clients.keys.create"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "22222222-3333-4444-5555-666666666666"
                 developerToken: "fnt_..."
@@ -286,7 +286,7 @@ components:
       required: [id, version, ts, msgId]
       properties:
         id: { type: string, example: "api.clients.register" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         developerToken: { type: string, description: "Caller's developer token (API key)." }

--- a/api/clients-interfaces.yaml
+++ b/api/clients-interfaces.yaml
@@ -7,12 +7,13 @@ info:
     An **API client** represents a developer or application that integrates with the
     Finternet platform. Each client:
 
-    - Owns one or more **API keys** (developer tokens). Keys are hashed with SHA-256
-      before storage; the plaintext is returned **once** at creation time and must be
-      captured by the caller.
+    - Is backed by a Keycloak client. Registration returns the `clientSecret` and an
+      initial `developerToken` **once** — the plaintext secret is not recoverable and
+      must be captured by the caller. Use `/v1/clients/rotate-secret` to roll it.
     - Is granted a set of **scopes** (see the RBAC vocabulary under
       `#/components/schemas/Scope`). Scopes are enforced on every endpoint; calls with
-      an insufficient scope return `403 FORBIDDEN`.
+      an insufficient scope return `403 FORBIDDEN`. Scopes are managed via
+      `/v1/clients/scopes/update`.
     - May have `allowedOperations` restricting which operations the client can
       perform, keyed by scope.
 
@@ -34,9 +35,7 @@ servers:
 
 tags:
   - name: "API Clients"
-    description: "Register, list, update, and deactivate API clients."
-  - name: "Client Keys"
-    description: "Create, list, and revoke developer tokens (API keys) for a client."
+    description: "Register, list, update, deactivate, reactivate, rotate the secret of, and manage scopes for API clients."
 
 paths:
 
@@ -47,8 +46,9 @@ paths:
       tags: [API Clients]
       summary: "Register a new API client"
       description: |
-        Create a new API client. Returns the client profile (without a key —
-        call `/v1/clients/keys/create` to mint one).
+        Create a new API client backed by a Keycloak client. Returns the
+        `clientSecret` and an initial `developerToken` **once** — capture them now,
+        the plaintext secret cannot be recovered.
       security:
         - developerToken: []
         - developerSignature: []
@@ -72,12 +72,15 @@ paths:
                 allowedOperations:
                   "tokens:transact":
                     "payload.operation": ["transfer", "burn"]
+                identities:
+                  - type: "email"
+                    address: "dev@acme.example"
       responses:
         '201':
-          description: "Client registered."
+          description: "Client registered. `clientSecret` and `developerToken` are returned **only on this response**."
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/ApiResponse_ClientProfile' }
+              schema: { $ref: '#/components/schemas/ApiResponse_RegisterClient' }
         '400': { $ref: '#/components/responses/BadRequestError' }
         '401': { $ref: '#/components/responses/UnauthorizedError' }
         '403': { $ref: '#/components/responses/ForbiddenError' }
@@ -125,7 +128,7 @@ paths:
           description: "Client list."
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/ApiResponse_ClientList' }
+              schema: { $ref: '#/components/schemas/ApiResponse_ListClients' }
         '401': { $ref: '#/components/responses/UnauthorizedError' }
         '403': { $ref: '#/components/responses/ForbiddenError' }
         '429': { $ref: '#/components/responses/RateLimitedError' }
@@ -133,10 +136,11 @@ paths:
   /v1/clients/update:
     post:
       tags: [API Clients]
-      summary: "Update an API client (name, description, scopes)"
+      summary: "Update an API client (name, description)"
       description: |
-        Covers the previous `update-scopes` operation — any subset of fields may be
-        supplied in `payload`. Absent fields are left unchanged.
+        Partial update of client metadata. Any subset of `name` / `description` may be
+        supplied in `payload`; absent fields are left unchanged. Scopes are managed
+        separately via `/v1/clients/scopes/update`.
       security:
         - developerToken: []
         - developerSignature: []
@@ -158,12 +162,81 @@ paths:
         '404': { $ref: '#/components/responses/NotFoundError' }
         '429': { $ref: '#/components/responses/RateLimitedError' }
 
+  /v1/clients/scopes/update:
+    post:
+      tags: [API Clients]
+      summary: "Update the scope set of an API client"
+      description: |
+        Replace the scope set granted to the client. Supplying `scopes` replaces the
+        full set (replace semantics): scopes absent from the array are dropped, scopes
+        present are added / preserved / re-requested.
+      security:
+        - developerToken: []
+        - developerSignature: []
+      x-scopes: [clients:manage]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ApiRequest_UpdateClientScopes' }
+      responses:
+        '200':
+          description: "Updated client profile."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiResponse_ClientProfile' }
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '404': { $ref: '#/components/responses/NotFoundError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+  /v1/clients/rotate-secret:
+    post:
+      tags: [API Clients]
+      summary: "Rotate an API client's secret"
+      description: |
+        Issue a new `clientSecret` and `developerToken` for the client. The previous
+        secret may remain valid for a grace period (`graceSeconds`); the effective
+        cutover time is returned as `oldSecretValidUntil`. The new plaintext secret is
+        returned **only on this response**.
+      security:
+        - developerToken: []
+        - developerSignature: []
+      x-scopes: [clients:manage]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ApiRequest_RotateSecret' }
+            example:
+              context:
+                id: "api.clients.rotate-secret"
+                version: "v1"
+                ts: "2026-04-07T10:00:00Z"
+                msgId: "33333333-4444-5555-6666-777777777777"
+                developerToken: "fnt_..."
+              payload:
+                clientId: "c1a0f00d-aaaa-bbbb-cccc-000000000001"
+                graceSeconds: 3600
+      responses:
+        '200':
+          description: "Secret rotated. `clientSecret` and `developerToken` are returned **only on this response**."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiResponse_RotateSecret' }
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '404': { $ref: '#/components/responses/NotFoundError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
   /v1/clients/deactivate:
     post:
       tags: [API Clients]
       summary: "Deactivate an API client"
       description: |
-        Deactivating a client immediately invalidates every key it owns. Part of the
+        Deactivating a client immediately invalidates its credentials. Part of the
         client lifecycle; requires the same scope as `register` by design.
       security:
         - developerToken: []
@@ -185,89 +258,28 @@ paths:
         '404': { $ref: '#/components/responses/NotFoundError' }
         '429': { $ref: '#/components/responses/RateLimitedError' }
 
-  # -------------------- Key Lifecycle --------------------
-
-  /v1/clients/keys/create:
+  /v1/clients/reactivate:
     post:
-      tags: [Client Keys]
-      summary: "Create (mint) a new developer token for a client"
+      tags: [API Clients]
+      summary: "Reactivate a deactivated API client"
       description: |
-        Returns the plaintext key **once**. The server stores only a SHA-256 hash —
-        lost keys cannot be recovered and must be rotated.
+        Restore a previously deactivated client. Part of the client lifecycle.
       security:
         - developerToken: []
         - developerSignature: []
-      x-scopes: [keys:create]
+      x-scopes: [clients:create]
       requestBody:
         required: true
         content:
           application/json:
-            schema: { $ref: '#/components/schemas/ApiRequest_CreateKey' }
-            example:
-              context:
-                id: "api.clients.keys.create"
-                version: "v1"
-                ts: "2026-04-07T10:00:00Z"
-                msgId: "22222222-3333-4444-5555-666666666666"
-                developerToken: "fnt_..."
-              payload:
-                clientId: "c1a0f00d-aaaa-bbbb-cccc-000000000001"
-                name: "Production — Acme Wallet, primary"
-                expiresInDays: 365
+            schema: { $ref: '#/components/schemas/ApiRequest_ReactivateClient' }
       responses:
-        '201':
-          description: "Key created. `key` is returned **only on this response**."
+        '200':
+          description: "Client reactivated."
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/ApiResponse_CreateKey' }
+              schema: { $ref: '#/components/schemas/ApiResponse_ClientProfile' }
         '400': { $ref: '#/components/responses/BadRequestError' }
-        '401': { $ref: '#/components/responses/UnauthorizedError' }
-        '403': { $ref: '#/components/responses/ForbiddenError' }
-        '404': { $ref: '#/components/responses/NotFoundError' }
-        '429': { $ref: '#/components/responses/RateLimitedError' }
-
-  /v1/clients/keys/list:
-    post:
-      tags: [Client Keys]
-      summary: "List keys for a client"
-      security:
-        - developerToken: []
-        - developerSignature: []
-      x-scopes: [keys:view]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema: { $ref: '#/components/schemas/ApiRequest_ListKeys' }
-      responses:
-        '200':
-          description: "Key list (metadata only — plaintext keys are never returned)."
-          content:
-            application/json:
-              schema: { $ref: '#/components/schemas/ApiResponse_KeyList' }
-        '401': { $ref: '#/components/responses/UnauthorizedError' }
-        '403': { $ref: '#/components/responses/ForbiddenError' }
-        '429': { $ref: '#/components/responses/RateLimitedError' }
-
-  /v1/clients/keys/revoke:
-    post:
-      tags: [Client Keys]
-      summary: "Revoke a developer token"
-      security:
-        - developerToken: []
-        - developerSignature: []
-      x-scopes: [keys:manage]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema: { $ref: '#/components/schemas/ApiRequest_RevokeKey' }
-      responses:
-        '200':
-          description: "Key revoked."
-          content:
-            application/json:
-              schema: { $ref: '#/components/schemas/ApiResponse_KeyInfo' }
         '401': { $ref: '#/components/responses/UnauthorizedError' }
         '403': { $ref: '#/components/responses/ForbiddenError' }
         '404': { $ref: '#/components/responses/NotFoundError' }
@@ -419,9 +431,32 @@ components:
         workflow_id: { type: string, nullable: true }
         expires_at: { type: string, format: date-time, nullable: true }
 
+    RegisterIdentityRef:
+      type: object
+      required: [type, address]
+      description: "An identity reference attached to a client at registration time."
+      properties:
+        type: { type: string }
+        address: { type: string }
+
+    ClientPartyRef:
+      type: object
+      required: [accountId]
+      description: "A party (creator or owner) associated with a client."
+      properties:
+        accountId: { type: string, format: uuid }
+        address: { type: string, nullable: true }
+
+    ClientCreatorRef:
+      type: object
+      required: [address]
+      description: "Minimal creator reference exposed on a client profile."
+      properties:
+        address: { type: string }
+
     ClientProfile:
       type: object
-      required: [id, name, scopes, status, isSuperAdmin, createdAt, updatedAt]
+      required: [id, name, scopes, status, isSuperAdmin, keycloakClientId, createdAt, updatedAt]
       properties:
         id: { type: string, format: uuid }
         name: { type: string, example: "Acme Wallet" }
@@ -433,7 +468,7 @@ components:
         allowedOperations:
           type: object
           nullable: true
-          description: "Per-client operation restrictions. Structure is service-defined."
+          description: "Per-client operation restrictions, keyed by action. Structure is service-defined."
           additionalProperties:
             type: array
             items: { type: string }
@@ -441,10 +476,41 @@ components:
           description: "Free-form identity metadata associated with the client (structure is service-defined)."
         status: { $ref: '#/components/schemas/ClientStatus' }
         isSuperAdmin: { type: boolean }
+        keycloakClientId: { type: string, description: "The backing Keycloak client identifier." }
+        creator:
+          allOf:
+            - $ref: '#/components/schemas/ClientCreatorRef'
+          nullable: true
+          description: "The client's creator (address only)."
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
 
-    ClientList:
+    RegisterClientResponse:
+      type: object
+      required: [clientId, keycloakClientId, clientSecret, developerToken, name, status, creator, owner, scopes, createdAt]
+      description: |
+        Result of registering a client. `clientSecret` and `developerToken` are the
+        plaintext credentials, returned **only on this response**.
+      properties:
+        clientId: { type: string, format: uuid }
+        keycloakClientId: { type: string, description: "The backing Keycloak client identifier." }
+        clientSecret:
+          type: string
+          description: "Plaintext client secret. Returned **only on creation** and unrecoverable thereafter."
+        developerToken:
+          type: string
+          description: "Initial developer token minted for the client."
+          example: "fnt_AbCdEf..."
+        name: { type: string }
+        status: { type: string }
+        creator: { $ref: '#/components/schemas/ClientPartyRef' }
+        owner: { $ref: '#/components/schemas/ClientPartyRef' }
+        scopes:
+          type: array
+          items: { $ref: '#/components/schemas/ScopeEntry' }
+        createdAt: { type: string, format: date-time }
+
+    ListClientsResponse:
       type: object
       required: [clients]
       properties:
@@ -473,6 +539,10 @@ components:
             additionalProperties:
               type: array
               items: { type: string }
+        identities:
+          type: array
+          description: "Identity references to attach to the client."
+          items: { $ref: '#/components/schemas/RegisterIdentityRef' }
 
     GetClientRequest:
       type: object
@@ -489,13 +559,21 @@ components:
       type: object
       required: [clientId]
       description: |
-        Partial update. Supplying `scopes` replaces the full scope set (replace
-        semantics): scopes absent from the array are dropped, scopes present are
-        added / preserved / re-requested. Omit `scopes` to leave them untouched.
+        Partial update of client metadata. Absent fields are left unchanged. Scopes are
+        managed separately via `/v1/clients/scopes/update`.
       properties:
         clientId: { type: string, format: uuid }
         name: { type: string, minLength: 1, maxLength: 255 }
         description: { type: string, maxLength: 1000 }
+
+    UpdateClientScopesRequest:
+      type: object
+      required: [clientId, scopes]
+      description: |
+        Replace the client's scope set (replace semantics). Scopes absent from the array
+        are dropped; scopes present are added / preserved / re-requested.
+      properties:
+        clientId: { type: string, format: uuid }
         scopes:
           type: array
           items: { $ref: '#/components/schemas/Scope' }
@@ -507,69 +585,45 @@ components:
       properties:
         clientId: { type: string, format: uuid }
 
-    # -------------------- Keys --------------------
-
-    KeyStatus:
-      type: string
-      description: "Key lifecycle status as reported by the registry (e.g. `active`, `revoked`)."
-
-    KeyInfo:
-      type: object
-      required: [id, status]
-      description: "Key metadata. Plaintext is returned only at creation time."
-      properties:
-        id: { type: string, format: uuid }
-        name: { type: string, description: "Human-readable name for the key." }
-        status: { $ref: '#/components/schemas/KeyStatus' }
-        identities:
-          description: "Free-form identity metadata associated with the key (structure is service-defined)."
-        expiresAt: { type: string, format: date-time, nullable: true }
-        lastUsedAt: { type: string, format: date-time, nullable: true }
-        createdAt: { type: string, format: date-time, nullable: true }
-
-    CreateKeyRequest:
-      type: object
-      required: [clientId, name]
-      properties:
-        clientId: { type: string, format: uuid }
-        name: { type: string, minLength: 1, maxLength: 255, description: "Name for the API key." }
-        expiresInDays:
-          type: integer
-          minimum: 1
-          maximum: 365
-          description: "Number of days until the key expires (default: 90)."
-
-    CreateKeyResponse:
-      type: object
-      required: [key, keyInfo]
-      properties:
-        key:
-          type: string
-          description: |
-            Plaintext developer token. Returned **only on creation**. The server stores a
-            SHA-256 hash; the plaintext is unrecoverable.
-          example: "fnt_AbCdEf..."
-        keyInfo: { $ref: '#/components/schemas/KeyInfo' }
-
-    ListKeysRequest:
+    ReactivateClientRequest:
       type: object
       required: [clientId]
       properties:
         clientId: { type: string, format: uuid }
 
-    KeyList:
-      type: object
-      required: [keys]
-      properties:
-        keys:
-          type: array
-          items: { $ref: '#/components/schemas/KeyInfo' }
+    # -------------------- Secret rotation --------------------
 
-    RevokeKeyRequest:
+    RotateSecretRequest:
       type: object
-      required: [keyId]
+      required: [clientId]
       properties:
-        keyId: { type: string, format: uuid }
+        clientId: { type: string, format: uuid }
+        graceSeconds:
+          type: integer
+          description: "Seconds the previous secret remains valid after rotation. Omit for an immediate cutover."
+
+    RotateSecretResponse:
+      type: object
+      required: [clientId, keycloakClientId, clientSecret, developerToken, rotatedAt]
+      description: |
+        Result of rotating a client's secret. `clientSecret` and `developerToken` are the
+        new plaintext credentials, returned **only on this response**.
+      properties:
+        clientId: { type: string, format: uuid }
+        keycloakClientId: { type: string, description: "The backing Keycloak client identifier." }
+        clientSecret:
+          type: string
+          description: "New plaintext client secret. Returned **only on this response** and unrecoverable thereafter."
+        developerToken:
+          type: string
+          description: "New developer token minted for the client."
+          example: "fnt_AbCdEf..."
+        oldSecretValidUntil:
+          type: string
+          format: date-time
+          nullable: true
+          description: "Time until which the previous secret remains valid (present when `graceSeconds` was supplied)."
+        rotatedAt: { type: string, format: date-time }
 
     # -------------------- Envelopes --------------------
 
@@ -589,43 +643,39 @@ components:
       allOf:
         - $ref: '#/components/schemas/RequestContext'
         - properties: { payload: { $ref: '#/components/schemas/UpdateClientRequest' } }
+    ApiRequest_UpdateClientScopes:
+      allOf:
+        - $ref: '#/components/schemas/RequestContext'
+        - properties: { payload: { $ref: '#/components/schemas/UpdateClientScopesRequest' } }
+    ApiRequest_RotateSecret:
+      allOf:
+        - $ref: '#/components/schemas/RequestContext'
+        - properties: { payload: { $ref: '#/components/schemas/RotateSecretRequest' } }
     ApiRequest_DeactivateClient:
       allOf:
         - $ref: '#/components/schemas/RequestContext'
         - properties: { payload: { $ref: '#/components/schemas/DeactivateClientRequest' } }
-    ApiRequest_CreateKey:
+    ApiRequest_ReactivateClient:
       allOf:
         - $ref: '#/components/schemas/RequestContext'
-        - properties: { payload: { $ref: '#/components/schemas/CreateKeyRequest' } }
-    ApiRequest_ListKeys:
-      allOf:
-        - $ref: '#/components/schemas/RequestContext'
-        - properties: { payload: { $ref: '#/components/schemas/ListKeysRequest' } }
-    ApiRequest_RevokeKey:
-      allOf:
-        - $ref: '#/components/schemas/RequestContext'
-        - properties: { payload: { $ref: '#/components/schemas/RevokeKeyRequest' } }
+        - properties: { payload: { $ref: '#/components/schemas/ReactivateClientRequest' } }
 
+    ApiResponse_RegisterClient:
+      allOf:
+        - $ref: '#/components/schemas/ApiResponse'
+        - properties: { response: { $ref: '#/components/schemas/RegisterClientResponse' } }
     ApiResponse_ClientProfile:
       allOf:
         - $ref: '#/components/schemas/ApiResponse'
         - properties: { response: { $ref: '#/components/schemas/ClientProfile' } }
-    ApiResponse_ClientList:
+    ApiResponse_ListClients:
       allOf:
         - $ref: '#/components/schemas/ApiResponse'
-        - properties: { response: { $ref: '#/components/schemas/ClientList' } }
-    ApiResponse_CreateKey:
+        - properties: { response: { $ref: '#/components/schemas/ListClientsResponse' } }
+    ApiResponse_RotateSecret:
       allOf:
         - $ref: '#/components/schemas/ApiResponse'
-        - properties: { response: { $ref: '#/components/schemas/CreateKeyResponse' } }
-    ApiResponse_KeyInfo:
-      allOf:
-        - $ref: '#/components/schemas/ApiResponse'
-        - properties: { response: { $ref: '#/components/schemas/KeyInfo' } }
-    ApiResponse_KeyList:
-      allOf:
-        - $ref: '#/components/schemas/ApiResponse'
-        - properties: { response: { $ref: '#/components/schemas/KeyList' } }
+        - properties: { response: { $ref: '#/components/schemas/RotateSecretResponse' } }
 
   # -------------------- Responses --------------------
 

--- a/api/clients-interfaces.yaml
+++ b/api/clients-interfaces.yaml
@@ -51,7 +51,6 @@ paths:
         the plaintext secret cannot be recovered.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [clients:create]
       requestBody:
         required: true
@@ -92,7 +91,6 @@ paths:
       summary: "Get a single API client by ID"
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [clients:view]
       requestBody:
         required: true
@@ -116,7 +114,6 @@ paths:
       summary: "List API clients (scoped to the caller's account)"
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [clients:view]
       requestBody:
         required: true
@@ -143,7 +140,6 @@ paths:
         separately via `/v1/clients/scopes/update`.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [clients:manage]
       requestBody:
         required: true
@@ -172,7 +168,6 @@ paths:
         present are added / preserved / re-requested.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [clients:manage]
       requestBody:
         required: true
@@ -202,7 +197,6 @@ paths:
         returned **only on this response**.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [clients:manage]
       requestBody:
         required: true
@@ -240,7 +234,6 @@ paths:
         client lifecycle; requires the same scope as `register` by design.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [clients:create]
       requestBody:
         required: true
@@ -266,7 +259,6 @@ paths:
         Restore a previously deactivated client. Part of the client lifecycle.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [clients:create]
       requestBody:
         required: true
@@ -301,8 +293,7 @@ components:
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        developerToken: { type: string, description: "Caller's developer token (API key)." }
-        developerSignature: { type: string, description: "Optional HTTP Signature." }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
 
     ResponseContext:
       allOf:
@@ -733,9 +724,4 @@ components:
       type: http
       scheme: bearer
       bearerFormat: "JWT or Opaque"
-      description: "Developer API Key/Token in Authorization header."
-    developerSignature:
-      type: apiKey
-      in: header
-      name: Signature
-      description: "IETF HTTP Signature (RFC 9421) for message integrity."
+      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."

--- a/api/clients-interfaces.yaml
+++ b/api/clients-interfaces.yaml
@@ -13,8 +13,8 @@ info:
     - Is granted a set of **scopes** (see the RBAC vocabulary under
       `#/components/schemas/Scope`). Scopes are enforced on every endpoint; calls with
       an insufficient scope return `403 PERMISSION_DENIED`.
-    - May have `allowedOperations` restricting which token operations the client can
-      perform for each token class.
+    - May have `allowedOperations` restricting which operations the client can
+      perform, keyed by scope.
 
     All endpoints follow the standard envelope (`context`/`payload` → `context`/`response`).
 
@@ -64,14 +64,14 @@ paths:
                 version: "1.0"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "11111111-2222-3333-4444-555555555555"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
               payload:
                 name: "Acme Wallet"
                 description: "Production wallet integration for Acme Corp"
                 scopes: ["tokens:view", "tokens:create", "tokens:transact", "accounts:view"]
                 allowedOperations:
-                  USDC: ["mint", "transfer", "burn"]
-                  USDT: ["transfer"]
+                  "tokens:transact":
+                    "payload.operation": ["transfer", "burn"]
       responses:
         '200':
           description: "Client registered."
@@ -209,11 +209,11 @@ paths:
                 version: "1.0"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "22222222-3333-4444-5555-666666666666"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
               payload:
                 clientId: "c1a0f00d-aaaa-bbbb-cccc-000000000001"
-                label: "Production — Acme Wallet, primary"
-                expiresAt: "2027-04-07T00:00:00Z"
+                name: "Production — Acme Wallet, primary"
+                expiresInDays: 365
       responses:
         '200':
           description: "Key created. `key` is returned **only on this response**."
@@ -324,25 +324,6 @@ components:
         context: { $ref: '#/components/schemas/ResponseContext' }
         response: { type: object, example: {} }
 
-    PaginationRequest:
-      type: object
-      properties:
-        limit: { type: integer, default: 50, minimum: 1, maximum: 100 }
-        offset: { type: integer, default: 0, minimum: 0 }
-
-    PaginationResponse:
-      type: object
-      properties:
-        total: { type: integer }
-        limit: { type: integer }
-        offset: { type: integer }
-
-    SortRequest:
-      type: object
-      properties:
-        field: { type: string, enum: [createdAt, updatedAt, name], default: createdAt }
-        order: { type: string, enum: [asc, desc], default: desc }
-
     # -------------------- Scope vocabulary --------------------
 
     Scope:
@@ -413,55 +394,85 @@ components:
 
     ClientStatus:
       type: string
-      enum: [active, inactive]
+      description: "Client lifecycle status as reported by the registry (e.g. `active`)."
+
+    ScopeEntry:
+      type: object
+      required: [scope, status]
+      description: |
+        A single scope grant with approval-workflow bookkeeping. `active` entries
+        behave as a plain granted scope; `pending`/`rejected` entries carry request
+        metadata. Field names are snake_case as serialized by the service.
+      properties:
+        scope: { type: string }
+        status: { type: string, enum: [active, pending, rejected] }
+        requested_by: { type: string, nullable: true }
+        requested_by_name: { type: string, nullable: true }
+        requested_at: { type: string, format: date-time, nullable: true }
+        approved_by: { type: string, nullable: true }
+        approved_by_name: { type: string, nullable: true }
+        approved_at: { type: string, format: date-time, nullable: true }
+        rejected_by: { type: string, nullable: true }
+        rejected_by_name: { type: string, nullable: true }
+        rejected_at: { type: string, format: date-time, nullable: true }
+        reason: { type: string, nullable: true }
+        workflow_id: { type: string, nullable: true }
+        expires_at: { type: string, format: date-time, nullable: true }
 
     ClientProfile:
       type: object
-      required: [id, name, scopes, status]
+      required: [id, name, scopes, status, isSuperAdmin, createdAt, updatedAt]
       properties:
         id: { type: string, format: uuid }
         name: { type: string, example: "Acme Wallet" }
         description: { type: string, nullable: true }
         scopes:
           type: array
-          items: { $ref: '#/components/schemas/Scope' }
-          description: "Scopes granted to this client."
+          items: { $ref: '#/components/schemas/ScopeEntry' }
+          description: "Scopes granted to this client, each with approval-workflow status."
         allowedOperations:
           type: object
-          description: |
-            Per-token-class operation allow-list. Keys are token class names (e.g.,
-            `USDC`) or IDs, values are operation names (`mint`, `transfer`, `burn`, ...).
-            Empty/omitted means no class-level restrictions beyond the caller's scopes.
+          nullable: true
+          description: "Per-client operation restrictions. Structure is service-defined."
           additionalProperties:
             type: array
             items: { type: string }
+        identities:
+          description: "Free-form identity metadata associated with the client (structure is service-defined)."
         status: { $ref: '#/components/schemas/ClientStatus' }
+        isSuperAdmin: { type: boolean }
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
 
     ClientList:
       type: object
-      required: [clients, pagination]
+      required: [clients]
       properties:
         clients:
           type: array
           items: { $ref: '#/components/schemas/ClientProfile' }
-        pagination: { $ref: '#/components/schemas/PaginationResponse' }
 
     RegisterClientRequest:
       type: object
-      required: [name, scopes]
+      required: [name]
       properties:
-        name: { type: string }
-        description: { type: string, nullable: true }
+        name: { type: string, minLength: 1, maxLength: 255 }
+        description: { type: string, maxLength: 1000 }
         scopes:
           type: array
           items: { $ref: '#/components/schemas/Scope' }
+          description: "Scopes to assign to the client."
         allowedOperations:
           type: object
+          description: |
+            Per-scope operation restrictions. Outer key is a scope (e.g. `tokens:transact`);
+            inner key is a dot-path into the request body; value is the list of permitted
+            stringified scalars at that path. Unlisted scopes are unrestricted.
           additionalProperties:
-            type: array
-            items: { type: string }
+            type: object
+            additionalProperties:
+              type: array
+              items: { type: string }
 
     GetClientRequest:
       type: object
@@ -471,35 +482,24 @@ components:
 
     ListClientsRequest:
       type: object
-      properties:
-        filters:
-          type: object
-          description: "Optional filters — name, status."
-          properties:
-            name: { type: string }
-            status: { $ref: '#/components/schemas/ClientStatus' }
-          additionalProperties: true
-        pagination: { $ref: '#/components/schemas/PaginationRequest' }
-        sortBy: { $ref: '#/components/schemas/SortRequest' }
+      description: "No parameters — the list is scoped to the caller's account."
+      properties: {}
 
     UpdateClientRequest:
       type: object
       required: [clientId]
       description: |
-        Partial update. Supplying `scopes` replaces the full scope set; supplying
-        `allowedOperations` replaces the full allow-list for the listed classes.
+        Partial update. Supplying `scopes` replaces the full scope set (replace
+        semantics): scopes absent from the array are dropped, scopes present are
+        added / preserved / re-requested. Omit `scopes` to leave them untouched.
       properties:
         clientId: { type: string, format: uuid }
-        name: { type: string }
-        description: { type: string, nullable: true }
+        name: { type: string, minLength: 1, maxLength: 255 }
+        description: { type: string, maxLength: 1000 }
         scopes:
           type: array
           items: { $ref: '#/components/schemas/Scope' }
-        allowedOperations:
-          type: object
-          additionalProperties:
-            type: array
-            items: { type: string }
+          description: "Complete desired scope set (replace semantics)."
 
     DeactivateClientRequest:
       type: object
@@ -511,30 +511,33 @@ components:
 
     KeyStatus:
       type: string
-      enum: [active, revoked, expired]
+      description: "Key lifecycle status as reported by the registry (e.g. `active`, `revoked`)."
 
     KeyInfo:
       type: object
-      required: [id, clientId, status, createdAt]
+      required: [id, status]
       description: "Key metadata. Plaintext is returned only at creation time."
       properties:
         id: { type: string, format: uuid }
-        clientId: { type: string, format: uuid }
-        label: { type: string, nullable: true, description: "Human-readable label for the key." }
-        prefix: { type: string, nullable: true, description: "Non-secret prefix of the key (e.g., `dev_pk_abc12`), for display only." }
+        name: { type: string, description: "Human-readable name for the key." }
         status: { $ref: '#/components/schemas/KeyStatus' }
+        identities:
+          description: "Free-form identity metadata associated with the key (structure is service-defined)."
         expiresAt: { type: string, format: date-time, nullable: true }
         lastUsedAt: { type: string, format: date-time, nullable: true }
-        revokedAt: { type: string, format: date-time, nullable: true }
-        createdAt: { type: string, format: date-time }
+        createdAt: { type: string, format: date-time, nullable: true }
 
     CreateKeyRequest:
       type: object
-      required: [clientId]
+      required: [clientId, name]
       properties:
         clientId: { type: string, format: uuid }
-        label: { type: string, nullable: true }
-        expiresAt: { type: string, format: date-time, nullable: true }
+        name: { type: string, minLength: 1, maxLength: 255, description: "Name for the API key." }
+        expiresInDays:
+          type: integer
+          minimum: 1
+          maximum: 365
+          description: "Number of days until the key expires (default: 90)."
 
     CreateKeyResponse:
       type: object
@@ -545,7 +548,7 @@ components:
           description: |
             Plaintext developer token. Returned **only on creation**. The server stores a
             SHA-256 hash; the plaintext is unrecoverable.
-          example: "dev_pk_AbCdEf..."
+          example: "fnt_AbCdEf..."
         keyInfo: { $ref: '#/components/schemas/KeyInfo' }
 
     ListKeysRequest:
@@ -553,29 +556,20 @@ components:
       required: [clientId]
       properties:
         clientId: { type: string, format: uuid }
-        filters:
-          type: object
-          properties:
-            status: { $ref: '#/components/schemas/KeyStatus' }
-          additionalProperties: true
-        pagination: { $ref: '#/components/schemas/PaginationRequest' }
-        sortBy: { $ref: '#/components/schemas/SortRequest' }
 
     KeyList:
       type: object
-      required: [keys, pagination]
+      required: [keys]
       properties:
         keys:
           type: array
           items: { $ref: '#/components/schemas/KeyInfo' }
-        pagination: { $ref: '#/components/schemas/PaginationResponse' }
 
     RevokeKeyRequest:
       type: object
       required: [keyId]
       properties:
         keyId: { type: string, format: uuid }
-        reason: { type: string, nullable: true }
 
     # -------------------- Envelopes --------------------
 

--- a/api/clients-interfaces.yaml
+++ b/api/clients-interfaces.yaml
@@ -7,9 +7,9 @@ info:
     An **API client** represents a developer or application that integrates with the
     Finternet platform. Each client:
 
-    - Gets a `clientSecret` and an initial `developerToken` on registration, returned
-      **once**. The plaintext secret is not recoverable and must be captured by the
-      caller. Use `/v1/clients/rotate-secret` to roll it.
+    - Is backed by a Keycloak client. Registration returns the `clientSecret` and an
+      initial `developerToken` **once**. The plaintext secret is not recoverable and
+      must be captured by the caller. Use `/v1/clients/rotate-secret` to roll it.
     - Is granted a set of **scopes** (see the RBAC vocabulary under
       `#/components/schemas/Scope`). Scopes are enforced on every endpoint; calls with
       an insufficient scope return `403 FORBIDDEN`. Scopes are managed via
@@ -21,9 +21,10 @@ info:
 
     ### Rate limiting
 
-    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
-    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
-    the tier assigned to the calling client.
+    Every request is passed through a scope-tier sliding-window rate limiter. When the
+    limit is exceeded the service responds with `429 Too Many Requests` and a
+    `Retry-After` header indicating when the caller may retry.
+
   version: "1.0.0"
 
 servers:
@@ -45,9 +46,9 @@ paths:
       tags: [API Clients]
       summary: "Register a new API client"
       description: |
-        Create a new API client. Returns the `clientSecret` and an initial
-        `developerToken` **once**. Capture them now; the plaintext secret cannot be
-        recovered.
+        Create a new API client backed by a Keycloak client. Returns the
+        `clientSecret` and an initial `developerToken` **once**. Capture them now;
+        the plaintext secret cannot be recovered.
       security:
         - developerToken: []
         - developerSignature: []
@@ -475,7 +476,7 @@ components:
           description: "Free-form identity metadata associated with the client (structure is service-defined)."
         status: { $ref: '#/components/schemas/ClientStatus' }
         isSuperAdmin: { type: boolean }
-        keycloakClientId: { type: string, description: "Identifier of the client in the underlying identity provider." }
+        keycloakClientId: { type: string, description: "The backing Keycloak client identifier." }
         creator:
           allOf:
             - $ref: '#/components/schemas/ClientCreatorRef'
@@ -492,7 +493,7 @@ components:
         plaintext credentials, returned **only on this response**.
       properties:
         clientId: { type: string, format: uuid }
-        keycloakClientId: { type: string, description: "Identifier of the client in the underlying identity provider." }
+        keycloakClientId: { type: string, description: "The backing Keycloak client identifier." }
         clientSecret:
           type: string
           description: "Plaintext client secret. Returned **only on creation** and unrecoverable thereafter."
@@ -609,7 +610,7 @@ components:
         new plaintext credentials, returned **only on this response**.
       properties:
         clientId: { type: string, format: uuid }
-        keycloakClientId: { type: string, description: "Identifier of the client in the underlying identity provider." }
+        keycloakClientId: { type: string, description: "The backing Keycloak client identifier." }
         clientSecret:
           type: string
           description: "New plaintext client secret. Returned **only on this response** and unrecoverable thereafter."
@@ -680,7 +681,7 @@ components:
 
   responses:
     UnauthorizedError:
-      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
+      description: "Authentication failed."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -688,12 +689,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "The caller does not have the scope required by this endpoint."
+      description: "Scope check failed. The caller's developer token does not carry a scope required by this endpoint."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Missing required scope: clients:create" } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -712,7 +713,9 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
-      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }

--- a/api/clients-interfaces.yaml
+++ b/api/clients-interfaces.yaml
@@ -12,7 +12,7 @@ info:
       captured by the caller.
     - Is granted a set of **scopes** (see the RBAC vocabulary under
       `#/components/schemas/Scope`). Scopes are enforced on every endpoint; calls with
-      an insufficient scope return `403 PERMISSION_DENIED`.
+      an insufficient scope return `403 FORBIDDEN`.
     - May have `allowedOperations` restricting which operations the client can
       perform, keyed by scope.
 
@@ -73,7 +73,7 @@ paths:
                   "tokens:transact":
                     "payload.operation": ["transfer", "burn"]
       responses:
-        '200':
+        '201':
           description: "Client registered."
           content:
             application/json:
@@ -110,7 +110,7 @@ paths:
   /v1/clients/list:
     post:
       tags: [API Clients]
-      summary: "List API clients with filters, pagination, and sortBy"
+      summary: "List API clients (scoped to the caller's account)"
       security:
         - developerToken: []
         - developerSignature: []
@@ -133,7 +133,7 @@ paths:
   /v1/clients/update:
     post:
       tags: [API Clients]
-      summary: "Update an API client (name, description, scopes, allowed operations)"
+      summary: "Update an API client (name, description, scopes)"
       description: |
         Covers the previous `update-scopes` operation — any subset of fields may be
         supplied in `payload`. Absent fields are left unchanged.
@@ -215,7 +215,7 @@ paths:
                 name: "Production — Acme Wallet, primary"
                 expiresInDays: 365
       responses:
-        '200':
+        '201':
           description: "Key created. `key` is returned **only on this response**."
           content:
             application/json:
@@ -636,7 +636,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "AUTHENTICATION_FAILED", message: "Token invalid or expired." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
       description: "Scope check failed — the caller's developer token does not carry a scope required by this endpoint."
@@ -644,7 +644,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "PERMISSION_DENIED", message: "Missing required scope: clients:create" } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Missing required scope: clients:create" } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -660,7 +660,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "Invalid request parameters." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
       description: |
@@ -673,7 +673,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
 
   # -------------------- Security --------------------

--- a/api/clients-interfaces.yaml
+++ b/api/clients-interfaces.yaml
@@ -7,9 +7,9 @@ info:
     An **API client** represents a developer or application that integrates with the
     Finternet platform. Each client:
 
-    - Is backed by a Keycloak client. Registration returns the `clientSecret` and an
-      initial `developerToken` **once** — the plaintext secret is not recoverable and
-      must be captured by the caller. Use `/v1/clients/rotate-secret` to roll it.
+    - Gets a `clientSecret` and an initial `developerToken` on registration, returned
+      **once**. The plaintext secret is not recoverable and must be captured by the
+      caller. Use `/v1/clients/rotate-secret` to roll it.
     - Is granted a set of **scopes** (see the RBAC vocabulary under
       `#/components/schemas/Scope`). Scopes are enforced on every endpoint; calls with
       an insufficient scope return `403 FORBIDDEN`. Scopes are managed via
@@ -21,10 +21,9 @@ info:
 
     ### Rate limiting
 
-    Every request is passed through a scope-tier sliding-window rate limiter. When the
-    limit is exceeded the service responds with `429 Too Many Requests` and a
-    `Retry-After` header indicating when the caller may retry.
-
+    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
+    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
+    the tier assigned to the calling client.
   version: "1.0.0"
 
 servers:
@@ -46,9 +45,9 @@ paths:
       tags: [API Clients]
       summary: "Register a new API client"
       description: |
-        Create a new API client backed by a Keycloak client. Returns the
-        `clientSecret` and an initial `developerToken` **once** — capture them now,
-        the plaintext secret cannot be recovered.
+        Create a new API client. Returns the `clientSecret` and an initial
+        `developerToken` **once**. Capture them now; the plaintext secret cannot be
+        recovered.
       security:
         - developerToken: []
         - developerSignature: []
@@ -361,7 +360,7 @@ components:
         | workflows           | view / create / manage     |
         | internal            | view / create / manage     |
 
-        Wildcards: `tokens:*`, `accounts:*`, `*` — matched with priority
+        Wildcards: `tokens:*`, `accounts:*`, `*`, matched with priority
         (exact > prefix wildcard > suffix wildcard > full wildcard).
       enum:
         - "accounts:view"
@@ -476,7 +475,7 @@ components:
           description: "Free-form identity metadata associated with the client (structure is service-defined)."
         status: { $ref: '#/components/schemas/ClientStatus' }
         isSuperAdmin: { type: boolean }
-        keycloakClientId: { type: string, description: "The backing Keycloak client identifier." }
+        keycloakClientId: { type: string, description: "Identifier of the client in the underlying identity provider." }
         creator:
           allOf:
             - $ref: '#/components/schemas/ClientCreatorRef'
@@ -493,7 +492,7 @@ components:
         plaintext credentials, returned **only on this response**.
       properties:
         clientId: { type: string, format: uuid }
-        keycloakClientId: { type: string, description: "The backing Keycloak client identifier." }
+        keycloakClientId: { type: string, description: "Identifier of the client in the underlying identity provider." }
         clientSecret:
           type: string
           description: "Plaintext client secret. Returned **only on creation** and unrecoverable thereafter."
@@ -552,7 +551,7 @@ components:
 
     ListClientsRequest:
       type: object
-      description: "No parameters — the list is scoped to the caller's account."
+      description: "No parameters. The list is scoped to the caller's account."
       properties: {}
 
     UpdateClientRequest:
@@ -610,7 +609,7 @@ components:
         new plaintext credentials, returned **only on this response**.
       properties:
         clientId: { type: string, format: uuid }
-        keycloakClientId: { type: string, description: "The backing Keycloak client identifier." }
+        keycloakClientId: { type: string, description: "Identifier of the client in the underlying identity provider." }
         clientSecret:
           type: string
           description: "New plaintext client secret. Returned **only on this response** and unrecoverable thereafter."
@@ -681,7 +680,7 @@ components:
 
   responses:
     UnauthorizedError:
-      description: "Authentication failed."
+      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -689,12 +688,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "Scope check failed — the caller's developer token does not carry a scope required by this endpoint."
+      description: "The caller does not have the scope required by this endpoint."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Missing required scope: clients:create" } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -713,9 +712,7 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
-      description: |
-        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
-        response header indicates how long the caller should wait before retrying.
+      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }

--- a/api/clients-interfaces.yaml
+++ b/api/clients-interfaces.yaml
@@ -19,6 +19,13 @@ info:
 
     All endpoints follow the standard envelope (`context`/`payload` → `context`/`response`).
 
+    ### Authentication
+
+    * `context.developerToken`: the developer token of the calling application. Required on
+      every endpoint.
+    * `context.authorization`: the end user's session token. Required on the endpoints that
+      act on a signed-in user; each operation states when it is needed.
+
     ### Rate limiting
 
     Every request is passed through a scope-tier sliding-window rate limiter. When the
@@ -49,8 +56,8 @@ paths:
         Create a new API client backed by a Keycloak client. Returns the
         `clientSecret` and an initial `developerToken` **once**. Capture them now;
         the plaintext secret cannot be recovered.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       x-scopes: [clients:create]
       requestBody:
         required: true
@@ -63,7 +70,7 @@ paths:
                 version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "11111111-2222-3333-4444-555555555555"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
               payload:
                 name: "Acme Wallet"
                 description: "Production wallet integration for Acme Corp"
@@ -89,8 +96,7 @@ paths:
     post:
       tags: [API Clients]
       summary: "Get a single API client by ID"
-      security:
-        - developerToken: []
+      description: "Requires a user session token in `context.authorization`."
       x-scopes: [clients:view]
       requestBody:
         required: true
@@ -112,8 +118,7 @@ paths:
     post:
       tags: [API Clients]
       summary: "List API clients (scoped to the caller's account)"
-      security:
-        - developerToken: []
+      description: "Requires a user session token in `context.authorization`."
       x-scopes: [clients:view]
       requestBody:
         required: true
@@ -138,8 +143,8 @@ paths:
         Partial update of client metadata. Any subset of `name` / `description` may be
         supplied in `payload`; absent fields are left unchanged. Scopes are managed
         separately via `/v1/clients/scopes/update`.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       x-scopes: [clients:manage]
       requestBody:
         required: true
@@ -166,8 +171,8 @@ paths:
         Replace the scope set granted to the client. Supplying `scopes` replaces the
         full set (replace semantics): scopes absent from the array are dropped, scopes
         present are added / preserved / re-requested.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       x-scopes: [clients:manage]
       requestBody:
         required: true
@@ -195,8 +200,8 @@ paths:
         secret may remain valid for a grace period (`graceSeconds`); the effective
         cutover time is returned as `oldSecretValidUntil`. The new plaintext secret is
         returned **only on this response**.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       x-scopes: [clients:manage]
       requestBody:
         required: true
@@ -209,7 +214,7 @@ paths:
                 version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "33333333-4444-5555-6666-777777777777"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
               payload:
                 clientId: "c1a0f00d-aaaa-bbbb-cccc-000000000001"
                 graceSeconds: 3600
@@ -232,8 +237,8 @@ paths:
       description: |
         Deactivating a client immediately invalidates its credentials. Part of the
         client lifecycle; requires the same scope as `register` by design.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       x-scopes: [clients:create]
       requestBody:
         required: true
@@ -257,8 +262,8 @@ paths:
       summary: "Reactivate a deactivated API client"
       description: |
         Restore a previously deactivated client. Part of the client lifecycle.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       x-scopes: [clients:create]
       requestBody:
         required: true
@@ -287,13 +292,13 @@ components:
 
     Context:
       type: object
-      required: [id, version, ts, msgId]
+      required: [id, version, ts, msgId, developerToken]
       properties:
         id: { type: string, example: "api.clients.register" }
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
 
     ResponseContext:
       allOf:
@@ -311,6 +316,21 @@ components:
       required: [context, payload]
       properties:
         context: { $ref: '#/components/schemas/Context' }
+        payload: { type: object }
+    UserContext:
+      type: object
+      required: [id, version, ts, msgId, developerToken, authorization]
+      properties:
+        id: { type: string, example: "api.clients.register" }
+        version: { type: string, example: "v1" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
+    UserRequestContext:
+      type: object
+      required: [context, payload]
+      properties:
+        context: { $ref: '#/components/schemas/UserContext' }
         payload: { type: object }
 
     ApiResponse:
@@ -491,7 +511,7 @@ components:
         developerToken:
           type: string
           description: "Initial developer token minted for the client."
-          example: "fnt_AbCdEf..."
+          example: "c2Et..."
         name: { type: string }
         status: { type: string }
         creator: { $ref: '#/components/schemas/ClientPartyRef' }
@@ -608,7 +628,7 @@ components:
         developerToken:
           type: string
           description: "New developer token minted for the client."
-          example: "fnt_AbCdEf..."
+          example: "c2Et..."
         oldSecretValidUntil:
           type: string
           format: date-time
@@ -620,35 +640,35 @@ components:
 
     ApiRequest_RegisterClient:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties: { payload: { $ref: '#/components/schemas/RegisterClientRequest' } }
     ApiRequest_GetClient:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties: { payload: { $ref: '#/components/schemas/GetClientRequest' } }
     ApiRequest_ListClients:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties: { payload: { $ref: '#/components/schemas/ListClientsRequest' } }
     ApiRequest_UpdateClient:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties: { payload: { $ref: '#/components/schemas/UpdateClientRequest' } }
     ApiRequest_UpdateClientScopes:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties: { payload: { $ref: '#/components/schemas/UpdateClientScopesRequest' } }
     ApiRequest_RotateSecret:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties: { payload: { $ref: '#/components/schemas/RotateSecretRequest' } }
     ApiRequest_DeactivateClient:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties: { payload: { $ref: '#/components/schemas/DeactivateClientRequest' } }
     ApiRequest_ReactivateClient:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties: { payload: { $ref: '#/components/schemas/ReactivateClientRequest' } }
 
     ApiResponse_RegisterClient:
@@ -717,11 +737,3 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
 
-  # -------------------- Security --------------------
-
-  securitySchemes:
-    developerToken:
-      type: http
-      scheme: bearer
-      bearerFormat: "JWT or Opaque"
-      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."

--- a/api/delegations-interfaces.yaml
+++ b/api/delegations-interfaces.yaml
@@ -11,8 +11,9 @@ info:
     These endpoints let the authenticated end user inspect the delegations relevant to
     them (`/list`) and resolve the effective permissions on a specific token (`/check`).
 
-    Both endpoints require a user session token. All endpoints use the standard envelope
-    (`context`/`payload` → `context`/`response`) and are rate limited.
+    Both endpoints authenticate the end user (user JWT) in addition to the developer
+    token. All endpoints follow the standard envelope (`context`/`payload` →
+    `context`/`response`) and are subject to scope-tier rate limiting.
 
   version: "1.0.0"
 
@@ -128,7 +129,7 @@ components:
             - properties:
                 developerToken: { type: string, description: "Optional inline developer token; usually carried via the `Authorization` header." }
                 developerSignature: { type: string, description: "Optional inline developer signature." }
-                authorization: { type: string, description: "End user's session token. Required on both endpoints." }
+                authorization: { type: string, description: "End-user session JWT. Required: both endpoints authenticate the end user (user JWT) in addition to the developer token." }
 
     ResponseContext:
       type: object
@@ -266,7 +267,7 @@ components:
 
   responses:
     UnauthorizedError:
-      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
+      description: "Authentication failed."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -274,12 +275,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "The caller does not have the scope required by this endpoint."
+      description: "Scope check failed. The caller's developer token does not carry a scope required by this endpoint."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Missing required scope: delegations:view" } }
             response: {}
     BadRequestError:
       description: "Invalid request (e.g. missing or invalid `filter` for `list`, or missing `tokenId` for `check`)."
@@ -290,7 +291,9 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "filter must be one of granted_by_me, granted_to_me, pending." } }
             response: {}
     RateLimitedError:
-      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }

--- a/api/delegations-interfaces.yaml
+++ b/api/delegations-interfaces.yaml
@@ -39,7 +39,6 @@ paths:
         pending their approval.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [delegations:view]
       requestBody:
         required: true
@@ -77,7 +76,6 @@ paths:
         where the decision came from, plus any active deny rules affecting the token.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [delegations:view]
       requestBody:
         required: true
@@ -127,8 +125,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/Context'
             - properties:
-                developerToken: { type: string, description: "Optional inline developer token; usually carried via the `Authorization` header." }
-                developerSignature: { type: string, description: "Optional inline developer signature." }
+                developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
                 authorization: { type: string, description: "End-user session JWT. Required: both endpoints authenticate the end user (user JWT) in addition to the developer token." }
 
     ResponseContext:
@@ -311,9 +308,4 @@ components:
       type: http
       scheme: bearer
       bearerFormat: "JWT or Opaque"
-      description: "Developer API Key/Token in Authorization header."
-    developerSignature:
-      type: apiKey
-      in: header
-      name: Signature
-      description: "IETF HTTP Signature (RFC 9421) for message integrity."
+      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."

--- a/api/delegations-interfaces.yaml
+++ b/api/delegations-interfaces.yaml
@@ -272,7 +272,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "AUTHENTICATION_FAILED", message: "Token invalid or expired." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
       description: "Scope check failed — the caller's developer token does not carry a scope required by this endpoint."
@@ -280,7 +280,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "PERMISSION_DENIED", message: "Missing required scope: delegations:view" } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Missing required scope: delegations:view" } }
             response: {}
     BadRequestError:
       description: "Invalid request (e.g. missing or invalid `filter` for `list`, or missing `tokenId` for `check`)."
@@ -288,7 +288,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "filter must be one of granted_by_me, granted_to_me, pending." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "filter must be one of granted_by_me, granted_to_me, pending." } }
             response: {}
     RateLimitedError:
       description: |
@@ -301,7 +301,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
 
   # -------------------- Security --------------------

--- a/api/delegations-interfaces.yaml
+++ b/api/delegations-interfaces.yaml
@@ -11,9 +11,8 @@ info:
     These endpoints let the authenticated end user inspect the delegations relevant to
     them (`/list`) and resolve the effective permissions on a specific token (`/check`).
 
-    Both endpoints authenticate the end user (user JWT) in addition to the developer
-    token. All endpoints follow the standard envelope (`context`/`payload` →
-    `context`/`response`) and are subject to scope-tier rate limiting.
+    Both endpoints require a user session token. All endpoints use the standard envelope
+    (`context`/`payload` → `context`/`response`) and are rate limited.
 
   version: "1.0.0"
 
@@ -129,7 +128,7 @@ components:
             - properties:
                 developerToken: { type: string, description: "Optional inline developer token; usually carried via the `Authorization` header." }
                 developerSignature: { type: string, description: "Optional inline developer signature." }
-                authorization: { type: string, description: "End-user session JWT. Required — both endpoints authenticate the end user (user JWT) in addition to the developer token." }
+                authorization: { type: string, description: "End user's session token. Required on both endpoints." }
 
     ResponseContext:
       type: object
@@ -267,7 +266,7 @@ components:
 
   responses:
     UnauthorizedError:
-      description: "Authentication failed."
+      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -275,12 +274,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "Scope check failed — the caller's developer token does not carry a scope required by this endpoint."
+      description: "The caller does not have the scope required by this endpoint."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Missing required scope: delegations:view" } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
             response: {}
     BadRequestError:
       description: "Invalid request (e.g. missing or invalid `filter` for `list`, or missing `tokenId` for `check`)."
@@ -291,9 +290,7 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "filter must be one of granted_by_me, granted_to_me, pending." } }
             response: {}
     RateLimitedError:
-      description: |
-        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
-        response header indicates how long the caller should wait before retrying.
+      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }

--- a/api/delegations-interfaces.yaml
+++ b/api/delegations-interfaces.yaml
@@ -4,17 +4,16 @@ info:
   description: |
     API specification for **delegated authorisation** in UNITS.
 
-    A **delegation** records that one principal (the *delegator*) has granted another
-    principal (the *delegatee*) the right to act on their behalf for a specific set of
-    token operations, optionally constrained by token class, expiry, and per-operation
-    quotas.
+    A **delegation** records that one principal (the *grantor*) has granted another
+    principal (the *grantee*) a labelled permission over their tokens, subject to a
+    rule type and optional expiry. Delegations may also be issued as *deny* rules.
 
-    Delegations let an API client (e.g. a custodial wallet, an automated payment agent,
-    or a third-party application) execute privileged token operations against an end
-    user's account without ever holding that user's primary credentials.
+    These endpoints let the authenticated end user inspect the delegations relevant to
+    them (`/list`) and resolve the effective permissions on a specific token (`/check`).
 
-    All endpoints follow the standard envelope (`context`/`payload` → `context`/`response`)
-    and are subject to scope-tier rate limiting.
+    Both endpoints authenticate the end user (user JWT) in addition to the developer
+    token. All endpoints follow the standard envelope (`context`/`payload` →
+    `context`/`response`) and are subject to scope-tier rate limiting.
 
   version: "1.0.0"
 
@@ -33,11 +32,11 @@ paths:
   /v1/delegations/list:
     post:
       tags: [Delegations]
-      summary: "List delegations issued to or by a principal"
+      summary: "List delegations for the authenticated user"
       description: |
-        Returns the set of delegations matching the supplied filters. Either
-        `delegatorId` or `delegateeId` (or both) must be supplied — at least one
-        side of the relationship must be pinned.
+        Returns the delegations matching the supplied `filter` relative to the
+        authenticated end user: those they granted, those granted to them, or those
+        pending their approval.
       security:
         - developerToken: []
         - developerSignature: []
@@ -53,13 +52,10 @@ paths:
                 version: "1.0"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "11111111-2222-3333-4444-555555555555"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
               payload:
-                filters:
-                  delegatorId: "alice"
-                  status: "active"
-                pagination: { page: 1, pageSize: 20 }
-                sortBy: { field: "createdAt", order: "desc" }
+                filter: "granted_by_me"
       responses:
         '200':
           description: "Delegation list."
@@ -74,14 +70,11 @@ paths:
   /v1/delegations/check:
     post:
       tags: [Delegations]
-      summary: "Check whether a delegation grants a specific operation"
+      summary: "Check the effective permissions on a specific token"
       description: |
-        Resolve the *effective* permission of a `(delegatee, delegator, tokenClass,
-        operation)` tuple at request time. Returns whether the operation is permitted
-        and, if so, the surviving constraints (remaining quota, expiry).
-
-        This is the same primitive used by the platform's authorisation layer when an
-        API client attempts a token operation on behalf of another principal.
+        Resolve the *effective* permissions the authenticated user has on a specific
+        token at request time. Returns, per permission level, whether it is allowed and
+        where the decision came from, plus any active deny rules affecting the token.
       security:
         - developerToken: []
         - developerSignature: []
@@ -97,13 +90,10 @@ paths:
                 version: "1.0"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "22222222-3333-4444-5555-666666666666"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
               payload:
-                delegatorId: "alice"
-                delegateeId: "acme-wallet"
-                tokenClass: "USDC"
-                operation: "transfer"
-                amount: "100.00"
+                tokenId: "018f2c3d-4e5f-7890-abcd-1234567890ab"
       responses:
         '200':
           description: "Permission decision."
@@ -138,6 +128,8 @@ components:
             - $ref: '#/components/schemas/Context'
             - properties:
                 developerToken: { type: string, description: "Optional inline developer token; usually carried via the `Authorization` header." }
+                developerSignature: { type: string, description: "Optional inline developer signature." }
+                authorization: { type: string, description: "End-user session JWT. Required — both endpoints authenticate the end user (user JWT) in addition to the developer token." }
 
     ResponseContext:
       type: object
@@ -173,152 +165,83 @@ components:
                     message: { type: string }
             response: { type: object }
 
-    PaginationRequest:
-      type: object
-      properties:
-        page: { type: integer, minimum: 1, default: 1 }
-        pageSize: { type: integer, minimum: 1, maximum: 200, default: 20 }
-
-    PaginationResponse:
-      type: object
-      properties:
-        page: { type: integer }
-        pageSize: { type: integer }
-        totalItems: { type: integer }
-        totalPages: { type: integer }
-
-    SortRequest:
-      type: object
-      properties:
-        field: { type: string }
-        order: { type: string, enum: [asc, desc], default: desc }
-
     # -------------------- Delegation domain --------------------
 
-    DelegationStatus:
-      type: string
-      description: |
-        Lifecycle state of a delegation.
-        - `active` — currently in force.
-        - `expired` — past its `expiresAt`.
-        - `revoked` — explicitly revoked by the delegator.
-        - `exhausted` — quota fully consumed.
-      enum: [active, expired, revoked, exhausted]
-
-    OperationConstraint:
+    DelegationItem:
       type: object
-      description: "Per-operation cap (e.g. transfer up to 1000 USDC)."
-      required: [operation]
-      properties:
-        operation:
-          type: string
-          description: "Token operation name (e.g. `transfer`, `mint`, `burn`)."
-        maxAmount:
-          type: string
-          description: "Maximum cumulative amount permitted across all uses (string for big numbers). Null = uncapped."
-          nullable: true
-        maxCount:
-          type: integer
-          description: "Maximum number of invocations permitted. Null = uncapped."
-          nullable: true
-        usedAmount:
-          type: string
-          description: "Cumulative amount already consumed."
-          nullable: true
-        usedCount:
-          type: integer
-          description: "Number of invocations already consumed."
-          nullable: true
-
-    Delegation:
-      type: object
-      required: [id, delegatorId, delegateeId, status, createdAt]
+      required: [id, grantorAddress, granteeAddress, label, permission, ruleType, status, createdAt]
       properties:
         id: { type: string, format: uuid }
-        delegatorId:
-          type: string
-          description: "Principal granting the delegation (Finternet username, account ID, or DID)."
-        delegateeId:
-          type: string
-          description: "Principal receiving the delegation."
-        tokenClasses:
-          type: array
-          description: "Token classes covered by this delegation. Empty/omitted means *any* token class."
-          items: { type: string }
-        constraints:
-          type: array
-          description: "Per-operation quotas. Empty means delegated operations are uncapped."
-          items: { $ref: '#/components/schemas/OperationConstraint' }
-        scopes:
-          type: array
-          description: "RBAC scopes effectively granted to the delegatee for this delegator."
-          items: { type: string }
-        status: { $ref: '#/components/schemas/DelegationStatus' }
+        grantorAddress: { type: string, description: "Address of the principal that granted the delegation." }
+        granteeAddress: { type: string, description: "Address of the principal that received the delegation." }
+        label: { type: string }
+        permission: { type: string }
+        ruleType: { type: string }
+        status: { type: string }
         expiresAt: { type: string, format: date-time, nullable: true }
-        createdAt: { type: string, format: date-time }
+        requestedBy: { type: string, nullable: true }
+        approvedAt: { type: string, format: date-time, nullable: true }
         revokedAt: { type: string, format: date-time, nullable: true }
-        revocationReason: { type: string, nullable: true }
+        createdAt: { type: string, format: date-time }
 
-    DelegationList:
+    ListDelegationsResponse:
       type: object
-      required: [delegations, pagination]
+      required: [delegations, filter, count]
       properties:
         delegations:
           type: array
-          items: { $ref: '#/components/schemas/Delegation' }
-        pagination: { $ref: '#/components/schemas/PaginationResponse' }
+          items: { $ref: '#/components/schemas/DelegationItem' }
+        filter: { type: string, description: "Echoes the requested filter." }
+        count: { type: integer }
 
     ListDelegationsRequest:
       type: object
-      description: |
-        At least one of `filters.delegatorId` or `filters.delegateeId` must be supplied.
+      required: [filter]
       properties:
-        filters:
-          type: object
-          properties:
-            delegatorId: { type: string }
-            delegateeId: { type: string }
-            tokenClass: { type: string }
-            status: { $ref: '#/components/schemas/DelegationStatus' }
-          additionalProperties: true
-        pagination: { $ref: '#/components/schemas/PaginationRequest' }
-        sortBy: { $ref: '#/components/schemas/SortRequest' }
+        filter:
+          type: string
+          enum: [granted_by_me, granted_to_me, pending]
+          description: "Filter delegations: granted_by_me (I granted), granted_to_me (granted to me), pending (awaiting my approval)."
 
     CheckDelegationRequest:
       type: object
-      required: [delegatorId, delegateeId, operation]
+      required: [tokenId]
       properties:
-        delegatorId: { type: string }
-        delegateeId: { type: string }
-        tokenClass: { type: string, nullable: true }
-        operation: { type: string }
-        amount:
-          type: string
-          description: "Amount the delegatee intends to consume for this operation, used for quota checks."
-          nullable: true
-
-    DelegationDecision:
-      type: object
-      required: [permitted]
-      properties:
-        permitted: { type: boolean }
-        reason:
-          type: string
-          description: "Human-readable explanation when `permitted=false` (e.g. `EXPIRED`, `QUOTA_EXCEEDED`, `OPERATION_NOT_DELEGATED`)."
-          nullable: true
-        delegationId:
+        tokenId:
           type: string
           format: uuid
-          description: "ID of the delegation matched (when one applies)."
-          nullable: true
-        remaining:
+          description: "Token ID to check permissions for."
+
+    PermissionDetail:
+      type: object
+      required: [allowed, source]
+      properties:
+        allowed: { type: boolean }
+        source: { type: string, description: "Where the decision came from (e.g. direct grant, inherited)." }
+        delegationId: { type: string, format: uuid, nullable: true }
+        labelMatch: { type: string, nullable: true }
+
+    DenyRule:
+      type: object
+      required: [delegationId, label, permission]
+      properties:
+        delegationId: { type: string, format: uuid }
+        label: { type: string }
+        permission: { type: string }
+
+    PermissionCheckResponse:
+      type: object
+      required: [tokenId, permissions]
+      properties:
+        tokenId: { type: string, format: uuid }
+        permissions:
           type: object
-          description: "Surviving constraints after the proposed operation, when permitted."
-          nullable: true
-          properties:
-            amount: { type: string, nullable: true }
-            count: { type: integer, nullable: true }
-            expiresAt: { type: string, format: date-time, nullable: true }
+          description: "Map of permission level to its authorization state."
+          additionalProperties: { $ref: '#/components/schemas/PermissionDetail' }
+        denyRules:
+          type: array
+          description: "Active deny rules affecting the token."
+          items: { $ref: '#/components/schemas/DenyRule' }
 
     # -------------------- Envelopes --------------------
 
@@ -334,11 +257,11 @@ components:
     ApiResponse_DelegationList:
       allOf:
         - $ref: '#/components/schemas/ApiResponse'
-        - properties: { response: { $ref: '#/components/schemas/DelegationList' } }
+        - properties: { response: { $ref: '#/components/schemas/ListDelegationsResponse' } }
     ApiResponse_DelegationCheck:
       allOf:
         - $ref: '#/components/schemas/ApiResponse'
-        - properties: { response: { $ref: '#/components/schemas/DelegationDecision' } }
+        - properties: { response: { $ref: '#/components/schemas/PermissionCheckResponse' } }
 
   # -------------------- Responses --------------------
 
@@ -360,12 +283,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "PERMISSION_DENIED", message: "Missing required scope: delegations:view" } }
             response: {}
     BadRequestError:
-      description: "Invalid request (e.g. neither delegator nor delegatee specified for `list`)."
+      description: "Invalid request (e.g. missing or invalid `filter` for `list`, or missing `tokenId` for `check`)."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "At least one of delegatorId or delegateeId must be supplied." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "filter must be one of granted_by_me, granted_to_me, pending." } }
             response: {}
     RateLimitedError:
       description: |

--- a/api/delegations-interfaces.yaml
+++ b/api/delegations-interfaces.yaml
@@ -11,9 +11,14 @@ info:
     These endpoints let the authenticated end user inspect the delegations relevant to
     them (`/list`) and resolve the effective permissions on a specific token (`/check`).
 
-    Both endpoints authenticate the end user (user JWT) in addition to the developer
-    token. All endpoints follow the standard envelope (`context`/`payload` →
-    `context`/`response`) and are subject to scope-tier rate limiting.
+    All endpoints follow the standard envelope (`context`/`payload` → `context`/`response`).
+
+    ### Authentication
+
+    * `context.developerToken`: the developer token of the calling application. Required on
+      every endpoint.
+    * `context.authorization`: the end user's session token. Required on the endpoints that
+      act on a signed-in user; each operation states when it is needed.
 
   version: "1.0.0"
 
@@ -37,8 +42,8 @@ paths:
         Returns the delegations matching the supplied `filter` relative to the
         authenticated end user: those they granted, those granted to them, or those
         pending their approval.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       x-scopes: [delegations:view]
       requestBody:
         required: true
@@ -51,7 +56,7 @@ paths:
                 version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "11111111-2222-3333-4444-555555555555"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 filter: "granted_by_me"
@@ -74,8 +79,8 @@ paths:
         Resolve the *effective* permissions the authenticated user has on a specific
         token at request time. Returns, per permission level, whether it is allowed and
         where the decision came from, plus any active deny rules affecting the token.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       x-scopes: [delegations:view]
       requestBody:
         required: true
@@ -88,7 +93,7 @@ paths:
                 version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "22222222-3333-4444-5555-666666666666"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 tokenId: "018f2c3d-4e5f-7890-abcd-1234567890ab"
@@ -110,7 +115,7 @@ components:
 
     Context:
       type: object
-      required: [id, version, ts, msgId]
+      required: [id, version, ts, msgId, developerToken]
       properties:
         id: { type: string, description: "Stable API identifier (e.g. `api.delegations.list`)." }
         version: { type: string, description: "API version." }
@@ -125,7 +130,25 @@ components:
           allOf:
             - $ref: '#/components/schemas/Context'
             - properties:
-                developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
+                developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
+                authorization: { type: string, description: "End-user session JWT. Required: both endpoints authenticate the end user (user JWT) in addition to the developer token." }
+    UserContext:
+      type: object
+      required: [id, version, ts, msgId, developerToken, authorization]
+      properties:
+        id: { type: string, description: "Stable API identifier (e.g. `api.delegations.list`)." }
+        version: { type: string, description: "API version." }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+    UserRequestContext:
+      type: object
+      required: [context, payload]
+      properties:
+        context:
+          allOf:
+            - $ref: '#/components/schemas/UserContext'
+            - properties:
+                developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
                 authorization: { type: string, description: "End-user session JWT. Required: both endpoints authenticate the end user (user JWT) in addition to the developer token." }
 
     ResponseContext:
@@ -244,11 +267,11 @@ components:
 
     ApiRequest_ListDelegations:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties: { payload: { $ref: '#/components/schemas/ListDelegationsRequest' } }
     ApiRequest_CheckDelegation:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties: { payload: { $ref: '#/components/schemas/CheckDelegationRequest' } }
 
     ApiResponse_DelegationList:
@@ -301,11 +324,3 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
 
-  # -------------------- Security --------------------
-
-  securitySchemes:
-    developerToken:
-      type: http
-      scheme: bearer
-      bearerFormat: "JWT or Opaque"
-      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."

--- a/api/delegations-interfaces.yaml
+++ b/api/delegations-interfaces.yaml
@@ -49,7 +49,7 @@ paths:
             example:
               context:
                 id: "api.delegations.list"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "11111111-2222-3333-4444-555555555555"
                 developerToken: "fnt_..."
@@ -87,7 +87,7 @@ paths:
             example:
               context:
                 id: "api.delegations.check"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-04-07T10:00:00Z"
                 msgId: "22222222-3333-4444-5555-666666666666"
                 developerToken: "fnt_..."
@@ -139,7 +139,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/Context'
             - properties:
-                status: { type: string, enum: [success, failed] }
+                status: { type: string, enum: [successful, failed] }
 
     ApiResponse:
       allOf:

--- a/api/key-management-interfaces.yaml
+++ b/api/key-management-interfaces.yaml
@@ -4,8 +4,12 @@ info:
   description: |
     The official API specification for the Finternet Key Management service.
 
+    These endpoints manage the account's **Vault Transit** signing key
+    (`units-signing-<accountId>`) and expose a two-phase, OTP-gated signing
+    operation used to produce user-authorized ULIP envelopes.
+
     ### Protocol-Agnostic Envelope
-    All API interactions use a standard JSON envelope.
+    Most interactions use the standard JSON envelope.
 
     **Request Envelope:**
     ```json
@@ -32,32 +36,26 @@ info:
     }
     ```
 
+    > **Note — `POST /v1/account/sign` is a special case.** Its body is not the
+    > plain `{context, payload}` envelope: `context` additionally carries the
+    > required `method` and `account_did` routing fields, and `username`/`otp`
+    > are **top-level** fields (siblings of `context`/`payload`), not part of
+    > `payload`. See that operation for the exact shape.
+
     ### Authentication and Authorization
-    This API uses a two-level authorization model:
+    Every Key Management endpoint is gated by **platform-level (developer)
+    authentication only**:
 
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
+    * `context.developerToken`: the B2B developer's API key/token (may also be
+      supplied via the `Authorization: Bearer <token>` header). The operating
+      account is resolved from the token owner's address — there is **no**
+      end-user JWT middleware and **no** per-endpoint scope check on these routes.
 
-    2.  **User-Level (End-User) Authorization:**
-        * `context.authorization`: The end-user's JWT session token (required for all key operations).
-
-    ### Key Types Supported
-    - `ethereum`: ECDSA secp256k1 keys for Ethereum
-    - `solana`: Ed25519 keys for Solana
-    - `base`: ECDSA secp256k1 keys for Base chain
-
-    ### RBAC Scopes
-
-    | Endpoint | Required scope |
-    |----------|----------------|
-    | `POST /v1/keys/generate` | `keys:manage` |
-    | `POST /v1/keys/sign` | `keys:sign` |
-    | `POST /v1/keys/public` | `keys:view` |
-
-    Calls failing the scope check return `403 PERMISSION_DENIED`.
+    For `POST /v1/account/sign`, end-user authorization is instead proven
+    **in-band** via a two-phase OTP challenge (see that operation), not via a
+    session token.
 
     ### Rate limiting
-
     Endpoints are protected by a scope-tier sliding-window rate limiter; on breach
     the response is `429 Too Many Requests` with a `Retry-After` header.
 
@@ -69,186 +67,297 @@ servers:
     description: "Local Development"
 tags:
   - name: "Key Management"
-    description: "Endpoints for cryptographic key generation, signing, and retrieval."
+    description: "Endpoints for provisioning, listing, rotating and using the account's Vault Transit signing key."
 
 # ===============================================================
 #   PATHS
 # ===============================================================
 
 paths:
-  /v1/keys/generate:
+  /v1/account/keys/create:
     post:
       tags:
         - "Key Management"
-      summary: "Generate a new signing key"
-      description: "Generates a new cryptographic signing key for the authenticated user. The key is stored securely in Vault and associated with the user's account."
+      summary: "Create the account's Vault Transit signing key"
+      description: |
+        Provisions the account's Ed25519 Vault Transit signing key
+        (`units-signing-<accountId>`) and persists a `key_reference` row.
+
+        The operation is **idempotent**: signup already provisions this key, so a
+        repeat call returns the existing key instead of colliding. The operating
+        account is derived from the developer token's owner — the request payload
+        is not read.
+      operationId: createKey
       security:
         - developerToken: []
-        - userToken: []
+        - developerSignature: []
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_GenerateKeyRequest'
-            examples:
-              EthereumKey:
-                summary: "Generate Ethereum key"
-                value:
-                  context:
-                    id: "api.keys.generate"
-                    version: "1.0"
-                    ts: "2025-11-25T12:00:00Z"
-                    msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                    developerToken: "dev-token-12345"
-                    authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-                  payload:
-                    keyType: "ethereum"
-              SolanaKey:
-                summary: "Generate Solana key"
-                value:
-                  context:
-                    id: "api.keys.generate"
-                    version: "1.0"
-                    ts: "2025-11-25T12:00:00Z"
-                    msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
-                    developerToken: "dev-token-12345"
-                    authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-                  payload:
-                    keyType: "solana"
+              $ref: '#/components/schemas/ApiRequest_Empty'
+            example:
+              context:
+                id: "api.account.keys.create"
+                version: "1.0"
+                ts: "2026-04-07T12:00:00Z"
+                msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+                developerToken: "fnt_..."
+              payload: {}
       responses:
-        '200':
-          description: "Key generated successfully."
+        '201':
+          description: "Signing key created (or already provisioned)."
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse_KeyReference'
+                $ref: '#/components/schemas/ApiResponse_CreateKeyResult'
               example:
                 context:
-                  id: "api.keys.generate"
+                  id: "api.account.keys.create"
                   version: "1.0"
-                  ts: "2025-11-25T12:00:01Z"
+                  ts: "2026-04-07T12:00:01Z"
                   msgId: "c1b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "successful"
                 response:
-                  keyReference: "019ab8e9-0636-74fd-b5c4-192fc68b71e3-ethereum-12345678-1234-1234-1234-123456789abc"
-                  publicKey: "0x04..."
-                  keyType: "ethereum"
-                  createdAt: "2025-11-25T12:00:01Z"
+                  key_id: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
+                  public_key: "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+                  did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+                  key_source: "vault_transit"
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /v1/keys/sign:
+  /v1/account/keys:
+    get:
+      tags:
+        - "Key Management"
+      summary: "List the account's keys"
+      description: |
+        Returns all `key_reference` rows bound to the calling account (resolved
+        from the developer token owner). The DID for each row is derived from its
+        public key. This is a read-only `GET`; no request body is sent.
+      operationId: listKeys
+      security:
+        - developerToken: []
+        - developerSignature: []
+      responses:
+        '200':
+          description: "List of the account's keys."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_ListKeysResult'
+              example:
+                context:
+                  id: "api.account.keys.list"
+                  version: "1.0"
+                  ts: "2026-04-07T12:05:01Z"
+                  msgId: "d1e2f3a4-b5c6-7890-1234-567890abcdef"
+                  status: "successful"
+                response:
+                  keys:
+                    - id: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
+                      key_type: "ed25519"
+                      key_source: "vault_transit"
+                      public_key: "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+                      did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+                      status: "active"
+                      created_at: "2026-04-07T11:59:00Z"
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/account/keys/rotate:
     post:
       tags:
         - "Key Management"
-      summary: "Sign a message hash"
-      description: "Signs a pre-hashed message using the user's specified key. The signing operation is performed securely in Vault using the user's authenticated session."
+      summary: "Rotate the account's signing key (NOT IMPLEMENTED)"
+      description: |
+        **Not implemented.** Correct rotation must mint a new Vault key version,
+        supersede the old `key_reference`, and propagate the new pubkey-derived
+        DID to the registry and peers — a cross-instance change that requires a
+        dedicated design. The endpoint therefore fails closed and always responds
+        with **HTTP 501** and error code `NOT_IMPLEMENTED`.
+      operationId: rotateKey
       security:
         - developerToken: []
-        - userToken: []
+        - developerSignature: []
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_SignMessageRequest'
+              $ref: '#/components/schemas/ApiRequest_Empty'
             example:
               context:
-                id: "api.keys.sign"
+                id: "api.account.keys.rotate"
                 version: "1.0"
-                ts: "2025-11-25T12:05:00Z"
-                msgId: "d1e2f3a4-b5c6-7890-1234-567890abcdef"
-                developerToken: "dev-token-12345"
-                authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-              payload:
-                keyReference: "019ab8e9-0636-74fd-b5c4-192fc68b71e3-ethereum-12345678-1234-1234-1234-123456789abc"
-                hash: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+                ts: "2026-04-07T12:10:00Z"
+                msgId: "e1f2a3b4-c5d6-7890-1234-567890abcdef"
+                developerToken: "fnt_..."
+              payload: {}
       responses:
-        '200':
-          description: "Message signed successfully."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse_SignatureResponse'
-              example:
-                context:
-                  id: "api.keys.sign"
-                  version: "1.0"
-                  ts: "2025-11-25T12:05:01Z"
-                  msgId: "e1f2a3b4-c5d6-7890-1234-567890abcdef"
-                  status: "successful"
-                response:
-                  signature: "0x3045022100..."
-        '400':
-          $ref: '#/components/responses/BadRequestError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '404':
-          description: "Key reference not found."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+        '501':
+          $ref: '#/components/responses/NotImplementedError'
 
-  /v1/keys/public:
+  /v1/account/sign:
     post:
       tags:
         - "Key Management"
-      summary: "Get public key"
-      description: "Retrieves the public key for a given key reference. This is a read-only operation."
+      summary: "Sign a ULIP envelope (two-phase OTP)"
+      description: |
+        Produces a Vault Transit signature over a ULIP envelope for the account
+        identified by `context.account_did`. End-user authorization is proven
+        in-band via a **two-phase OTP** flow — there is no session JWT on this
+        route.
+
+        **Request shape (special).** The body is NOT the plain envelope:
+        - `context` carries the standard fields **plus** required `method` and
+          `account_did`.
+        - `payload` is the method-specific body to be wrapped and signed.
+        - `username` and `otp` are **top-level** fields (siblings of `context`
+          and `payload`), NOT inside `payload`.
+
+        **Phase 1 — request without `otp`:** the contact in `username` (which must
+        belong to `account_did`) is sent an OTP. Responds `200` with
+        `{ "status": "otp_sent", ... }`.
+
+        **Phase 2 — resubmit with `otp`:** the OTP is verified, the envelope is
+        signed, and the response returns the signed `envelope`, the stable
+        `key_id` (the `key_references` UUID), and the `method`.
+      operationId: sign
       security:
         - developerToken: []
-        - userToken: []
+        - developerSignature: []
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_GetPublicKeyRequest'
-            example:
-              context:
-                id: "api.keys.public"
-                version: "1.0"
-                ts: "2025-11-25T12:10:00Z"
-                msgId: "f1a2b3c4-d5e6-7890-1234-567890abcdef"
-                developerToken: "dev-token-12345"
-                authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-              payload:
-                keyReference: "019ab8e9-0636-74fd-b5c4-192fc68b71e3-ethereum-12345678-1234-1234-1234-123456789abc"
+              $ref: '#/components/schemas/SignRequest'
+            examples:
+              Phase1_SendOtp:
+                summary: "Phase 1 — omit otp to trigger an OTP send"
+                value:
+                  context:
+                    id: "api.account.sign"
+                    version: "1.0"
+                    ts: "2026-04-07T12:15:00Z"
+                    msgId: "f1a2b3c4-d5e6-7890-1234-567890abcdef"
+                    developerToken: "fnt_..."
+                    method: "lock.request"
+                    account_did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+                  payload:
+                    amount: "100.00"
+                    token_class: "USD"
+                  username: "alice@example.com"
+              Phase2_CompleteSigning:
+                summary: "Phase 2 — resubmit with the received otp to sign"
+                value:
+                  context:
+                    id: "api.account.sign"
+                    version: "1.0"
+                    ts: "2026-04-07T12:15:30Z"
+                    msgId: "a2b3c4d5-e6f7-8901-2345-67890abcdef1"
+                    developerToken: "fnt_..."
+                    method: "lock.request"
+                    account_did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+                  payload:
+                    amount: "100.00"
+                    token_class: "USD"
+                  username: "alice@example.com"
+                  otp: "123456"
       responses:
         '200':
-          description: "Public key retrieved successfully."
+          description: |
+            Response depends on the phase:
+            - **Phase 1 (no `otp`)**: OTP-sent acknowledgement.
+            - **Phase 2 (with `otp`)**: the signed envelope.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse_PublicKeyResponse'
-              example:
-                context:
-                  id: "api.keys.public"
-                  version: "1.0"
-                  ts: "2025-11-25T12:10:01Z"
-                  msgId: "a2b3c4d5-e6f7-8901-2345-67890abcdef"
-                  status: "successful"
-                response:
-                  publicKey: "0x04..."
-                  address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1"
+                oneOf:
+                  - $ref: '#/components/schemas/ApiResponse_SignOtpSent'
+                  - $ref: '#/components/schemas/ApiResponse_SignEnvelope'
+              examples:
+                Phase1_OtpSent:
+                  summary: "Phase 1 response"
+                  value:
+                    context:
+                      id: "api.account.sign"
+                      version: "1.0"
+                      ts: "2026-04-07T12:15:01Z"
+                      msgId: "f1a2b3c4-d5e6-7890-1234-567890abcdef"
+                      status: "successful"
+                    response:
+                      status: "otp_sent"
+                      message: "OTP sent. Resubmit with the otp field to complete signing."
+                Phase2_Signed:
+                  summary: "Phase 2 response"
+                  value:
+                    context:
+                      id: "api.account.sign"
+                      version: "1.0"
+                      ts: "2026-04-07T12:15:31Z"
+                      msgId: "a2b3c4d5-e6f7-8901-2345-67890abcdef1"
+                      status: "successful"
+                    response:
+                      envelope:
+                        context:
+                          ulip_version: "v1"
+                          method: "lock.request"
+                          txn_id: "b7f1c2d3-4e5f-6789-0123-456789abcdef"
+                          op_seq: 0
+                          caller_instance: ""
+                          callee_instance: ""
+                          sent_at: "2026-04-07T12:15:31Z"
+                        payload:
+                          type_url: ""
+                          value:
+                            amount: "100.00"
+                            token_class: "USD"
+                        signature:
+                          signer_instance: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
+                          key_name: "units-signing-019ab8e9-0636-74fd-b5c4-192fc68b71e3"
+                          algorithm: "ed25519"
+                          signature: "3045022100abcdef..."
+                      key_id: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
+                      method: "lock.request"
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '404':
-          description: "Key reference not found."
+          description: |
+            OTP contact does not match the account, proof failed, or OTP invalid
+            (also returned for developer-token auth failure).
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
+              schema: { $ref: '#/components/schemas/ApiError' }
+              example:
+                context:
+                  id: "api.account.sign"
+                  version: "1.0"
+                  ts: "2026-04-07T12:15:30Z"
+                  msgId: "a2b3c4d5-e6f7-8901-2345-67890abcdef1"
+                  status: "failed"
+                  error:
+                    code: "UNAUTHORIZED"
+                    message: "OTP invalid"
+                response: {}
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -264,25 +373,36 @@ components:
       type: object
       required: [id, version, ts, msgId]
       properties:
-        id: { type: string, example: "api.keys.generate" }
+        id: { type: string, example: "api.account.keys.create" }
         version: { type: string, example: "1.0" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true }
-        developerToken: { type: string, example: "dev-token-12345", nullable: true }
-        authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's JWT session token" }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "B2B Developer API Key/Token" }
+        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "B2B Developer Signature (RFC 9421)" }
+        authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token (unused by key-management routes)." }
 
     ResponseContext:
       type: object
       required: [id, version, ts, msgId, status]
       properties:
-        id: { type: string, example: "api.keys.generate" }
+        id: { type: string, example: "api.account.keys.create" }
         version: { type: string, example: "1.0" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true }
         status: { type: string, enum: [successful, failed, pending] }
-        error: { $ref: '#/components/schemas/ErrorPayload', nullable: true }
+        error:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/ErrorPayload'
+
+    Signature:
+      type: object
+      required: [key_id, jws]
+      properties:
+        key_id: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
+        jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object." }
 
     ErrorPayload:
       type: object
@@ -290,13 +410,6 @@ components:
       properties:
         code: { type: string, example: "INVALID_INPUT" }
         message: { type: string }
-        fields:
-          type: array
-          items:
-            type: object
-            properties:
-              field: { type: string }
-              message: { type: string }
 
     # --- Base Request/Response Schemas ---
     RequestContext:
@@ -305,6 +418,10 @@ components:
       properties:
         context: { $ref: '#/components/schemas/Context' }
         payload: { type: object }
+        signature:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Signature'
 
     ApiResponse:
       type: object
@@ -321,126 +438,197 @@ components:
         response: { type: object, description: "Always empty on error.", example: {} }
 
     # --- Specific Request Envelopes ---
-    ApiRequest_GenerateKeyRequest:
-      allOf:
-        - $ref: '#/components/schemas/RequestContext'
-        - properties:
-            payload: { $ref: '#/components/schemas/GenerateKeyRequest' }
+    ApiRequest_Empty: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { type: object } } } ] }
 
-    ApiRequest_SignMessageRequest:
-      allOf:
-        - $ref: '#/components/schemas/RequestContext'
-        - properties:
-            payload: { $ref: '#/components/schemas/SignMessageRequest' }
-
-    ApiRequest_GetPublicKeyRequest:
-      allOf:
-        - $ref: '#/components/schemas/RequestContext'
-        - properties:
-            payload: { $ref: '#/components/schemas/GetPublicKeyRequest' }
+    # The /v1/account/sign body is intentionally NOT built on RequestContext:
+    # context carries extra routing fields and username/otp are top-level.
+    SignContext:
+      type: object
+      required: [id, version, ts, msgId, method, account_did]
+      description: "Standard envelope context PLUS the required routing fields method and account_did."
+      properties:
+        id: { type: string, example: "api.account.sign" }
+        version: { type: string, example: "1.0" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        developerToken: { type: string, example: "fnt_...", nullable: true }
+        developerSignature: { type: string, nullable: true }
+        method:
+          type: string
+          example: "lock.request"
+          description: "ULIP method to sign for; populates the signed envelope's context.method."
+        account_did:
+          type: string
+          example: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+          description: "DID of the account whose Vault Transit signing key produces the signature."
+    SignRequest:
+      type: object
+      required: [context, payload, username]
+      properties:
+        context: { $ref: '#/components/schemas/SignContext' }
+        payload:
+          type: object
+          description: "Method-specific body to be wrapped and signed (becomes the ULIP payload value)."
+        username:
+          type: string
+          example: "alice@example.com"
+          description: |
+            Contact (email, or +E.164 mobile) that must belong to `account_did`.
+            The OTP is sent here. TOP-LEVEL field — not part of `payload`.
+        otp:
+          type: string
+          nullable: true
+          example: "123456"
+          description: |
+            Omit for phase 1 (send OTP); provide to complete signing in phase 2.
+            TOP-LEVEL field — not part of `payload`.
 
     # --- Specific Response Envelopes ---
-    ApiResponse_KeyReference:
+    ApiResponse_CreateKeyResult:
       allOf:
         - $ref: '#/components/schemas/ApiResponse'
         - properties:
-            response: { $ref: '#/components/schemas/KeyReference' }
+            response: { $ref: '#/components/schemas/CreateKeyResult' }
 
-    ApiResponse_SignatureResponse:
+    ApiResponse_ListKeysResult:
       allOf:
         - $ref: '#/components/schemas/ApiResponse'
         - properties:
-            response: { $ref: '#/components/schemas/SignatureResponse' }
+            response: { $ref: '#/components/schemas/ListKeysResult' }
 
-    ApiResponse_PublicKeyResponse:
+    ApiResponse_SignOtpSent:
       allOf:
         - $ref: '#/components/schemas/ApiResponse'
         - properties:
-            response: { $ref: '#/components/schemas/PublicKeyResponse' }
+            response: { $ref: '#/components/schemas/SignOtpSentResponse' }
+
+    ApiResponse_SignEnvelope:
+      allOf:
+        - $ref: '#/components/schemas/ApiResponse'
+        - properties:
+            response: { $ref: '#/components/schemas/SignEnvelopeResponse' }
 
     # --- Core Data Schemas (Payloads) ---
-    GenerateKeyRequest:
+    CreateKeyResult:
       type: object
-      required: [keyType]
+      required: [key_id, public_key, did, key_source]
       properties:
-        keyType:
+        key_id:
           type: string
-          enum: [ethereum, solana, base]
-          description: "Type of cryptographic key to generate"
+          description: "Vault key identifier for the signing key."
+          example: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
+        public_key:
+          type: string
+          description: "Hex-encoded Ed25519 public key."
+          example: "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+        did:
+          type: string
+          description: "did:key derived from the public key."
+          example: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+        key_source:
+          type: string
+          example: "vault_transit"
 
-    SignMessageRequest:
+    KeyInfo:
       type: object
-      required: [keyReference, hash]
+      required: [id, key_type, key_source, public_key, did, status, created_at]
       properties:
-        keyReference:
-          type: string
-          description: "Reference to the key to use for signing"
-          example: "019ab8e9-0636-74fd-b5c4-192fc68b71e3-ethereum-12345678-1234-1234-1234-123456789abc"
-        hash:
-          type: string
-          description: "Pre-hashed message to sign (hex-encoded)"
-          example: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        id: { type: string, format: uuid, description: "key_references row UUID." }
+        key_type: { type: string, example: "ed25519" }
+        key_source: { type: string, example: "vault_transit", description: "vault_transit or external." }
+        public_key: { type: string, description: "Hex-encoded public key." }
+        did: { type: string, description: "did:key derived from the public key (empty if the key is malformed)." }
+        status: { type: string, example: "active" }
+        created_at: { type: string, format: date-time }
 
-    GetPublicKeyRequest:
+    ListKeysResult:
       type: object
-      required: [keyReference]
+      required: [keys]
       properties:
-        keyReference:
-          type: string
-          description: "Reference to the key"
-          example: "019ab8e9-0636-74fd-b5c4-192fc68b71e3-ethereum-12345678-1234-1234-1234-123456789abc"
+        keys:
+          type: array
+          items: { $ref: '#/components/schemas/KeyInfo' }
 
-    KeyReference:
+    SignOtpSentResponse:
       type: object
+      required: [status, message]
       properties:
-        keyReference:
-          type: string
-          description: "Unique reference to the generated key"
-        publicKey:
-          type: string
-          description: "Public key in hex format"
-        keyType:
-          type: string
-          enum: [ethereum, solana, base]
-        createdAt:
-          type: string
-          format: date-time
+        status: { type: string, enum: [otp_sent], example: "otp_sent" }
+        message: { type: string, example: "OTP sent. Resubmit with the otp field to complete signing." }
 
-    SignatureResponse:
+    SignEnvelopeResponse:
       type: object
+      required: [envelope, key_id, method]
       properties:
-        signature:
+        envelope: { $ref: '#/components/schemas/SignedEnvelope' }
+        key_id:
           type: string
-          description: "Cryptographic signature in hex format"
-          example: "0x3045022100..."
+          format: uuid
+          description: "Stable key_references UUID for the signing key."
+          example: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
+        method: { type: string, example: "lock.request" }
 
-    PublicKeyResponse:
+    SignedEnvelope:
       type: object
+      required: [context, payload, signature]
       properties:
-        publicKey:
-          type: string
-          description: "Public key in hex format"
-        address:
-          type: string
-          description: "Blockchain address derived from the public key"
+        context: { $ref: '#/components/schemas/UlipContext' }
+        payload: { $ref: '#/components/schemas/UlipPayload' }
+        signature: { $ref: '#/components/schemas/UlipSignature' }
+
+    UlipContext:
+      type: object
+      description: "Cross-cutting ULIP envelope metadata."
+      properties:
+        ulip_version: { type: string, example: "v1" }
+        method: { type: string, example: "lock.request" }
+        txn_id: { type: string, example: "b7f1c2d3-4e5f-6789-0123-456789abcdef" }
+        op_seq: { type: integer, format: int32, example: 0 }
+        caller_instance: { type: string }
+        callee_instance: { type: string }
+        sent_at: { type: string, format: date-time }
+        trace_id: { type: string, nullable: true }
+        in_response_to: { type: string, nullable: true }
+        extensions:
+          type: object
+          nullable: true
+          additionalProperties: { type: string }
+
+    UlipPayload:
+      type: object
+      description: "Method-specific body with a TypeURL discriminator (mimics google.protobuf.Any)."
+      properties:
+        type_url: { type: string, example: "" }
+        value:
+          type: object
+          description: "The signed method body (arbitrary JSON)."
+
+    UlipSignature:
+      type: object
+      description: "Signature block as returned by /v1/account/sign (key_name replaces the versioned vault key id)."
+      properties:
+        signer_instance: { type: string }
+        key_name: { type: string, example: "units-signing-019ab8e9-0636-74fd-b5c4-192fc68b71e3" }
+        algorithm: { type: string, example: "ed25519" }
+        signature: { type: string, description: "Signature bytes, base64-encoded on the wire." }
 
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. Invalid Developer Token OR invalid User JWT."
+      description: "Authentication failed. The developer token is missing, invalid, or expired."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
             context:
-              id: "api.keys.generate"
+              id: "api.account.keys.create"
               version: "1.0"
-              ts: "2025-11-25T12:00:00Z"
+              ts: "2026-04-07T12:00:00Z"
               msgId: "..."
               status: "failed"
               error:
                 code: "UNAUTHORIZED"
-                message: "Unauthorized. The JWT is missing, invalid, or expired"
+                message: "invalid developer token"
             response: {}
 
     BadRequestError:
@@ -450,14 +638,45 @@ components:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
             context:
-              id: "api.keys.generate"
+              id: "api.account.sign"
               version: "1.0"
-              ts: "2025-11-25T12:00:00Z"
+              ts: "2026-04-07T12:15:00Z"
               msgId: "..."
               status: "failed"
               error:
-                code: "INVALID_INPUT"
-                message: "EntityID is required"
+                code: "BAD_REQUEST"
+                message: "context.account_did is required"
+            response: {}
+
+    NotImplementedError:
+      description: "The operation is not implemented (HTTP 501)."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context:
+              id: "api.account.keys.rotate"
+              version: "1.0"
+              ts: "2026-04-07T12:10:00Z"
+              msgId: "..."
+              status: "failed"
+              error:
+                code: "NOT_IMPLEMENTED"
+                message: "key rotation is not yet supported"
+            response: {}
+
+    RateLimitedError:
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
+      headers:
+        Retry-After:
+          schema: { type: integer, description: "Seconds to wait before retrying." }
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
             response: {}
 
     InternalServerError:
@@ -467,9 +686,9 @@ components:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
             context:
-              id: "api.keys.generate"
+              id: "api.account.keys.create"
               version: "1.0"
-              ts: "2025-11-25T12:00:00Z"
+              ts: "2026-04-07T12:00:00Z"
               msgId: "..."
               status: "failed"
               error:
@@ -479,18 +698,21 @@ components:
 
   # -------------------- Security --------------------
   securitySchemes:
+    # The server checks the HTTP header first and falls back to the context object.
+
     developerToken:
       type: http
       scheme: bearer
       bearerFormat: "JWT or Opaque"
       description: |
         A JWT or Opaque token that identifies the calling B2B developer/backend service.
-        This is passed in the `context.developerToken` field.
+        Passed in the standard `Authorization: Bearer <token>` header, or as a fallback in
+        `context.developerToken`. The operating account is resolved from the token owner.
 
-    userToken:
-      type: http
-      scheme: bearer
-      bearerFormat: "JWT"
+    developerSignature:
+      type: apiKey
+      in: header
+      name: Signature
       description: |
-        The end-user's JWT session token obtained from the login endpoint.
-        This is passed in the `context.authorization` field.
+        The IETF HTTP Signature (RFC 9421) used by B2B developers for message integrity
+        and non-repudiation. Passed in the `Signature` header.

--- a/api/key-management-interfaces.yaml
+++ b/api/key-management-interfaces.yaml
@@ -676,7 +676,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
 
     InternalServerError:

--- a/api/key-management-interfaces.yaml
+++ b/api/key-management-interfaces.yaml
@@ -120,10 +120,10 @@ paths:
                   msgId: "c1b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "successful"
                 response:
-                  key_id: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
-                  public_key: "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+                  keyId: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
+                  publicKey: "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
                   did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
-                  key_source: "vault_transit"
+                  keySource: "vault_transit"
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':
@@ -163,12 +163,12 @@ paths:
                 response:
                   keys:
                     - id: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
-                      key_type: "ed25519"
-                      key_source: "vault_transit"
-                      public_key: "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+                      keyType: "ed25519"
+                      keySource: "vault_transit"
+                      publicKey: "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
                       did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
                       status: "active"
-                      created_at: "2026-04-07T11:59:00Z"
+                      createdAt: "2026-04-07T11:59:00Z"
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '429':
@@ -240,7 +240,7 @@ paths:
 
         **Phase 2 — resubmit with `otp`:** the OTP is verified, the envelope is
         signed, and the response returns the signed `envelope`, the stable
-        `key_id` (the `key_references` UUID), and the `method`.
+        `keyId` (the `key_references` UUID), and the `method`.
       operationId: sign
       security:
         - developerToken: []
@@ -343,7 +343,7 @@ paths:
                           key_name: "units-signing-019ab8e9-0636-74fd-b5c4-192fc68b71e3"
                           algorithm: "ed25519"
                           signature: "3045022100abcdef..."
-                      key_id: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
+                      keyId: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
                       method: "lock.request"
         '400':
           $ref: '#/components/responses/BadRequestError'
@@ -408,9 +408,9 @@ components:
 
     Signature:
       type: object
-      required: [key_id, jws]
+      required: [keyId, jws]
       properties:
-        key_id: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
+        keyId: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
         jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object." }
 
     ErrorPayload:
@@ -520,13 +520,13 @@ components:
     # --- Core Data Schemas (Payloads) ---
     CreateKeyResult:
       type: object
-      required: [key_id, public_key, did, key_source]
+      required: [keyId, publicKey, did, keySource]
       properties:
-        key_id:
+        keyId:
           type: string
           description: "Vault key identifier for the signing key."
           example: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
-        public_key:
+        publicKey:
           type: string
           description: "Hex-encoded Ed25519 public key."
           example: "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
@@ -534,21 +534,21 @@ components:
           type: string
           description: "did:key derived from the public key."
           example: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
-        key_source:
+        keySource:
           type: string
           example: "vault_transit"
 
     KeyInfo:
       type: object
-      required: [id, key_type, key_source, public_key, did, status, created_at]
+      required: [id, keyType, keySource, publicKey, did, status, createdAt]
       properties:
         id: { type: string, format: uuid, description: "key_references row UUID." }
-        key_type: { type: string, example: "ed25519" }
-        key_source: { type: string, example: "vault_transit", description: "vault_transit or external." }
-        public_key: { type: string, description: "Hex-encoded public key." }
+        keyType: { type: string, example: "ed25519" }
+        keySource: { type: string, example: "vault_transit", description: "vault_transit or external." }
+        publicKey: { type: string, description: "Hex-encoded public key." }
         did: { type: string, description: "did:key derived from the public key (empty if the key is malformed)." }
         status: { type: string, example: "active" }
-        created_at: { type: string, format: date-time }
+        createdAt: { type: string, format: date-time }
 
     ListKeysResult:
       type: object
@@ -567,10 +567,10 @@ components:
 
     SignEnvelopeResponse:
       type: object
-      required: [envelope, key_id, method]
+      required: [envelope, keyId, method]
       properties:
         envelope: { $ref: '#/components/schemas/SignedEnvelope' }
-        key_id:
+        keyId:
           type: string
           format: uuid
           description: "Stable key_references UUID for the signing key."

--- a/api/key-management-interfaces.yaml
+++ b/api/key-management-interfaces.yaml
@@ -715,8 +715,7 @@ components:
       bearerFormat: "JWT or Opaque"
       description: |
         A JWT or Opaque token that identifies the calling B2B developer/backend service.
-        Passed in the standard `Authorization: Bearer <token>` header, or as a fallback in
-        `context.developerToken`. The operating account is resolved from the token owner.
+        The operating account is resolved from the token owner.
 
     developerSignature:
       type: apiKey

--- a/api/key-management-interfaces.yaml
+++ b/api/key-management-interfaces.yaml
@@ -15,12 +15,12 @@ info:
 
     ### Authentication
 
-    * `context.developerToken`: the calling application's developer token. Required on
+    * `context.developerToken`: the developer token of the calling application. Required on
       every endpoint.
-    * `context.authorization`: the end user's session token. Required by
-      `/v1/account/keys/create`.
-    * `POST /v1/account/sign` takes no session token. The account holder authorises the
-      signature in band, by confirming a one-time code sent to their registered contact.
+    * `context.authorization`: the end user's session token. Required on the endpoints that
+      act on a signed-in user; each operation states when it is needed.
+    * `signature` (top level): the end user's JWS over the payload, for operations that must
+      be signed by the user.
 
     ### Rate limiting
     Endpoints are protected by a scope-tier sliding-window rate limiter; on breach
@@ -49,10 +49,10 @@ paths:
       description: |
         Provision the signing key for the signed-in user's account. The payload is empty.
         The call is idempotent: an account that already has a signing key gets the existing
-        key back. Requires a user session token.
+        key back.
+
+        Requires a user session token in `context.authorization`.
       operationId: createKey
-      security:
-        - developerToken: []
       requestBody:
         required: true
         content:
@@ -65,7 +65,7 @@ paths:
                 version: "v1"
                 ts: "2026-04-07T12:00:00Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload: {}
       responses:
@@ -104,8 +104,6 @@ paths:
         Return the keys bound to the account. This is a read-only `GET`, so no request
         body is sent.
       operationId: listKeys
-      security:
-        - developerToken: []
       responses:
         '200':
           description: "List of the account's keys."
@@ -161,8 +159,6 @@ paths:
         Step 2, resubmit with `otp`: the code is verified and the signed envelope is
         returned along with the `keyId` that produced the signature.
       operationId: sign
-      security:
-        - developerToken: []
       requestBody:
         required: true
         content:
@@ -178,7 +174,7 @@ paths:
                     version: "v1"
                     ts: "2026-04-07T12:15:00Z"
                     msgId: "f1a2b3c4-d5e6-7890-1234-567890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     method: "lock.request"
                     account_did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
                   payload:
@@ -195,7 +191,7 @@ paths:
                     version: "v1"
                     ts: "2026-04-07T12:15:30Z"
                     msgId: "a2b3c4d5-e6f7-8901-2345-67890abcdef1"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     method: "lock.request"
                     account_did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
                   payload:
@@ -294,14 +290,13 @@ components:
     # --- API Envelope Schemas ---
     Context:
       type: object
-      required: [id, version, ts, msgId]
+      required: [id, version, ts, msgId, developerToken]
       properties:
         id: { type: string, example: "api.account.keys.create" }
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        transactionId: { type: string, format: uuid, nullable: true }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End user's session token." }
 
     ResponseContext:
@@ -344,6 +339,26 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/Signature'
+    UserContext:
+      type: object
+      required: [id, version, ts, msgId, developerToken, authorization]
+      properties:
+        id: { type: string, example: "api.account.keys.create" }
+        version: { type: string, example: "v1" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
+        authorization: { type: string, example: "Bearer eyJ...", description: "End user's session token." }
+    UserRequestContext:
+      type: object
+      required: [context, payload]
+      properties:
+        context: { $ref: '#/components/schemas/UserContext' }
+        payload: { type: object }
+        signature:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Signature'
 
     ApiResponse:
       type: object
@@ -360,20 +375,20 @@ components:
         response: { type: object, description: "Always empty on error.", example: {} }
 
     # --- Specific Request Envelopes ---
-    ApiRequest_Empty: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { type: object } } } ] }
+    ApiRequest_Empty: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { type: object } } } ] }
 
     # The /v1/account/sign body is intentionally NOT built on RequestContext:
     # context carries extra routing fields and username/otp are top-level.
     SignContext:
       type: object
-      required: [method, account_did]
+      required: [method, account_did, developerToken]
       description: "The standard context plus the required `method` and `account_did`. Only those two are enforced on this endpoint."
       properties:
         id: { type: string, example: "api.account.sign" }
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
         method:
           type: string
           example: "lock.request"
@@ -591,11 +606,3 @@ components:
                 code: "INTERNAL_ERROR"
                 message: "An unexpected error occurred"
             response: {}
-
-  # -------------------- Security --------------------
-  securitySchemes:
-    developerToken:
-      type: http
-      scheme: bearer
-      bearerFormat: "JWT or Opaque"
-      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."

--- a/api/key-management-interfaces.yaml
+++ b/api/key-management-interfaces.yaml
@@ -22,14 +22,10 @@ info:
     * `POST /v1/account/sign` takes no session token. The account holder authorises the
       signature in band, by confirming a one-time code sent to their registered contact.
 
-    Each endpoint requires the scope listed under `x-scopes`; calls without it return
-    `403`.
-
     ### Rate limiting
+    Endpoints are protected by a scope-tier sliding-window rate limiter; on breach
+    the response is `429 Too Many Requests` with a `Retry-After` header.
 
-    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
-    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
-    the tier assigned to the calling client.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -58,7 +54,6 @@ paths:
       security:
         - developerToken: []
         - developerSignature: []
-      x-scopes: [keys:create]
       requestBody:
         required: true
         content:
@@ -92,11 +87,56 @@ paths:
                   keyId: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
                   publicKey: "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
                   did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
-        '400': { $ref: '#/components/responses/BadRequestError' }
-        '401': { $ref: '#/components/responses/UnauthorizedError' }
-        '403': { $ref: '#/components/responses/ForbiddenError' }
-        '429': { $ref: '#/components/responses/RateLimitedError' }
-        '500': { $ref: '#/components/responses/InternalServerError' }
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/account/keys:
+    get:
+      tags:
+        - "Key Management"
+      summary: "List the account's keys"
+      description: |
+        Return the keys bound to the account. This is a read-only `GET`, so no request
+        body is sent.
+      operationId: listKeys
+      security:
+        - developerToken: []
+        - developerSignature: []
+      responses:
+        '200':
+          description: "List of the account's keys."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_ListKeysResult'
+              example:
+                context:
+                  id: "api.account.keys.list"
+                  version: "v1"
+                  ts: "2026-04-07T12:05:01Z"
+                  msgId: "d1e2f3a4-b5c6-7890-1234-567890abcdef"
+                  status: "successful"
+                response:
+                  keys:
+                    - id: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
+                      keyType: "ed25519"
+                      keySource: "external"
+                      publicKey: "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+                      did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+                      status: "active"
+                      createdAt: "2026-04-07T11:59:00Z"
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /v1/account/sign:
     post:
@@ -126,7 +166,6 @@ paths:
       security:
         - developerToken: []
         - developerSignature: []
-      x-scopes: [keys:manage]
       requestBody:
         required: true
         content:
@@ -223,9 +262,12 @@ paths:
                           signature: "3045022100abcdef..."
                       keyId: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
                       method: "lock.request"
-        '400': { $ref: '#/components/responses/BadRequestError' }
+        '400':
+          $ref: '#/components/responses/BadRequestError'
         '401':
-          description: "Authentication failed, `username` is not a contact of the account, or the code is not valid."
+          description: |
+            OTP contact does not match the account, proof failed, or OTP invalid
+            (also returned for developer-token auth failure).
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
@@ -240,9 +282,10 @@ paths:
                     code: "UNAUTHORIZED"
                     message: "OTP invalid"
                 response: {}
-        '403': { $ref: '#/components/responses/ForbiddenError' }
-        '429': { $ref: '#/components/responses/RateLimitedError' }
-        '500': { $ref: '#/components/responses/InternalServerError' }
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
 # ===============================================================
 #   COMPONENTS
@@ -369,6 +412,12 @@ components:
         - properties:
             response: { $ref: '#/components/schemas/CreateKeyResult' }
 
+    ApiResponse_ListKeysResult:
+      allOf:
+        - $ref: '#/components/schemas/ApiResponse'
+        - properties:
+            response: { $ref: '#/components/schemas/ListKeysResult' }
+
     ApiResponse_SignOtpSent:
       allOf:
         - $ref: '#/components/schemas/ApiResponse'
@@ -398,6 +447,26 @@ components:
           type: string
           description: "did:key derived from the public key."
           example: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+
+    KeyInfo:
+      type: object
+      required: [id, keyType, keySource, publicKey, did, status, createdAt]
+      properties:
+        id: { type: string, format: uuid }
+        keyType: { type: string, example: "ed25519" }
+        keySource: { type: string, example: "external", description: "How the key is held." }
+        publicKey: { type: string, description: "Hex-encoded public key." }
+        did: { type: string, description: "did:key derived from the public key (empty if the key is malformed)." }
+        status: { type: string, example: "active" }
+        createdAt: { type: string, format: date-time }
+
+    ListKeysResult:
+      type: object
+      required: [keys]
+      properties:
+        keys:
+          type: array
+          items: { $ref: '#/components/schemas/KeyInfo' }
 
     SignOtpSentResponse:
       type: object
@@ -464,7 +533,7 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
+      description: "Authentication failed. The developer token is missing, invalid, or expired."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -478,23 +547,6 @@ components:
               error:
                 code: "UNAUTHORIZED"
                 message: "invalid developer token"
-            response: {}
-
-    ForbiddenError:
-      description: "The caller does not have the scope required by this endpoint."
-      content:
-        application/json:
-          schema: { $ref: '#/components/schemas/ApiError' }
-          example:
-            context:
-              id: "api.account.keys.create"
-              version: "v1"
-              ts: "2026-04-07T12:00:00Z"
-              msgId: "..."
-              status: "failed"
-              error:
-                code: "CLIENT_INSUFFICIENT_SCOPE"
-                message: "service account does not have required scope: keys:create"
             response: {}
 
     BadRequestError:
@@ -515,7 +567,9 @@ components:
             response: {}
 
     RateLimitedError:
-      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }

--- a/api/key-management-interfaces.yaml
+++ b/api/key-management-interfaces.yaml
@@ -100,7 +100,7 @@ paths:
             example:
               context:
                 id: "api.account.keys.create"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-04-07T12:00:00Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -115,7 +115,7 @@ paths:
               example:
                 context:
                   id: "api.account.keys.create"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-04-07T12:00:01Z"
                   msgId: "c1b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "successful"
@@ -156,7 +156,7 @@ paths:
               example:
                 context:
                   id: "api.account.keys.list"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-04-07T12:05:01Z"
                   msgId: "d1e2f3a4-b5c6-7890-1234-567890abcdef"
                   status: "successful"
@@ -200,7 +200,7 @@ paths:
             example:
               context:
                 id: "api.account.keys.rotate"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-04-07T12:10:00Z"
                 msgId: "e1f2a3b4-c5d6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -227,7 +227,10 @@ paths:
         **Request shape (special).** The body is NOT the plain envelope:
         - `context` carries the standard fields **plus** required `method` and
           `account_did`.
-        - `payload` is the method-specific body to be wrapped and signed.
+        - `payload` is the operation body to be wrapped and signed. **It MUST be
+          byte-identical to the `payload` you then submit to `POST /v1/token/transact`**
+          — the signature is computed over exactly this object, so any mismatch
+          invalidates it.
         - `username` and `otp` are **top-level** fields (siblings of `context`
           and `payload`), NOT inside `payload`.
 
@@ -254,30 +257,34 @@ paths:
                 value:
                   context:
                     id: "api.account.sign"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-04-07T12:15:00Z"
                     msgId: "f1a2b3c4-d5e6-7890-1234-567890abcdef"
                     developerToken: "fnt_..."
                     method: "lock.request"
                     account_did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
                   payload:
-                    amount: "100.00"
-                    token_class: "USD"
+                    operation: "transfer"
+                    tokenId: "a1b2c3d4-e5f6-7890-abcd-1234567890ab"
+                    to: "bob"
+                    value: "100000000"
                   username: "alice@example.com"
               Phase2_CompleteSigning:
                 summary: "Phase 2 — resubmit with the received otp to sign"
                 value:
                   context:
                     id: "api.account.sign"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-04-07T12:15:30Z"
                     msgId: "a2b3c4d5-e6f7-8901-2345-67890abcdef1"
                     developerToken: "fnt_..."
                     method: "lock.request"
                     account_did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
                   payload:
-                    amount: "100.00"
-                    token_class: "USD"
+                    operation: "transfer"
+                    tokenId: "a1b2c3d4-e5f6-7890-abcd-1234567890ab"
+                    to: "bob"
+                    value: "100000000"
                   username: "alice@example.com"
                   otp: "123456"
       responses:
@@ -298,7 +305,7 @@ paths:
                   value:
                     context:
                       id: "api.account.sign"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2026-04-07T12:15:01Z"
                       msgId: "f1a2b3c4-d5e6-7890-1234-567890abcdef"
                       status: "successful"
@@ -310,7 +317,7 @@ paths:
                   value:
                     context:
                       id: "api.account.sign"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2026-04-07T12:15:31Z"
                       msgId: "a2b3c4d5-e6f7-8901-2345-67890abcdef1"
                       status: "successful"
@@ -327,8 +334,10 @@ paths:
                         payload:
                           type_url: ""
                           value:
-                            amount: "100.00"
-                            token_class: "USD"
+                            operation: "transfer"
+                            tokenId: "a1b2c3d4-e5f6-7890-abcd-1234567890ab"
+                            to: "bob"
+                            value: "100000000"
                         signature:
                           signer_instance: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
                           key_name: "units-signing-019ab8e9-0636-74fd-b5c4-192fc68b71e3"
@@ -348,7 +357,7 @@ paths:
               example:
                 context:
                   id: "api.account.sign"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-04-07T12:15:30Z"
                   msgId: "a2b3c4d5-e6f7-8901-2345-67890abcdef1"
                   status: "failed"
@@ -374,7 +383,7 @@ components:
       required: [id, version, ts, msgId]
       properties:
         id: { type: string, example: "api.account.keys.create" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true }
@@ -387,7 +396,7 @@ components:
       required: [id, version, ts, msgId, status]
       properties:
         id: { type: string, example: "api.account.keys.create" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true }
@@ -444,11 +453,11 @@ components:
     # context carries extra routing fields and username/otp are top-level.
     SignContext:
       type: object
-      required: [id, version, ts, msgId, method, account_did]
-      description: "Standard envelope context PLUS the required routing fields method and account_did."
+      required: [method, account_did]
+      description: "Standard envelope context PLUS the required routing fields method and account_did. Only method and account_did are enforced by the sign handler; id/version/ts/msgId are optional here."
       properties:
         id: { type: string, example: "api.account.sign" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         developerToken: { type: string, example: "fnt_...", nullable: true }
@@ -622,7 +631,7 @@ components:
           example:
             context:
               id: "api.account.keys.create"
-              version: "1.0"
+              version: "v1"
               ts: "2026-04-07T12:00:00Z"
               msgId: "..."
               status: "failed"
@@ -639,7 +648,7 @@ components:
           example:
             context:
               id: "api.account.sign"
-              version: "1.0"
+              version: "v1"
               ts: "2026-04-07T12:15:00Z"
               msgId: "..."
               status: "failed"
@@ -656,7 +665,7 @@ components:
           example:
             context:
               id: "api.account.keys.rotate"
-              version: "1.0"
+              version: "v1"
               ts: "2026-04-07T12:10:00Z"
               msgId: "..."
               status: "failed"
@@ -687,7 +696,7 @@ components:
           example:
             context:
               id: "api.account.keys.create"
-              version: "1.0"
+              version: "v1"
               ts: "2026-04-07T12:00:00Z"
               msgId: "..."
               status: "failed"

--- a/api/key-management-interfaces.yaml
+++ b/api/key-management-interfaces.yaml
@@ -2,63 +2,34 @@ openapi: 3.0.4
 info:
   title: "Finternet API - Key Management Service"
   description: |
-    The official API specification for the Finternet Key Management service.
+    API specification for the account's platform-managed signing key and for signing
+    operations authorised by the account holder.
 
-    These endpoints manage the account's **Vault Transit** signing key
-    (`units-signing-<accountId>`) and expose a two-phase, OTP-gated signing
-    operation used to produce user-authorized ULIP envelopes.
+    Most endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
+    On failure `context.status` is `failed`, `context.error` carries a `code` and a
+    `message`, and `response` is empty.
 
-    ### Protocol-Agnostic Envelope
-    Most interactions use the standard JSON envelope.
+    > `POST /v1/account/sign` is a special case: `context` also carries the required
+    > `method` and `account_did` fields, and `username`/`otp` are top level fields,
+    > siblings of `context` and `payload`. See that operation for the exact shape.
 
-    **Request Envelope:**
-    ```json
-    {
-      "context": { ... },
-      "payload": { ... },
-      "signature": { ... } // Optional
-    }
-    ```
+    ### Authentication
 
-    **Response Envelope (Success):**
-    ```json
-    {
-      "context": { ..., "status": "successful" },
-      "response": { ... }
-    }
-    ```
+    * `context.developerToken`: the calling application's developer token. Required on
+      every endpoint.
+    * `context.authorization`: the end user's session token. Required by
+      `/v1/account/keys/create`.
+    * `POST /v1/account/sign` takes no session token. The account holder authorises the
+      signature in band, by confirming a one-time code sent to their registered contact.
 
-    **Response Envelope (Error):**
-    ```json
-    {
-      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." }},
-      "response": {} // Empty on error
-    }
-    ```
-
-    > **Note — `POST /v1/account/sign` is a special case.** Its body is not the
-    > plain `{context, payload}` envelope: `context` additionally carries the
-    > required `method` and `account_did` routing fields, and `username`/`otp`
-    > are **top-level** fields (siblings of `context`/`payload`), not part of
-    > `payload`. See that operation for the exact shape.
-
-    ### Authentication and Authorization
-    Every Key Management endpoint is gated by **platform-level (developer)
-    authentication only**:
-
-    * `context.developerToken`: the B2B developer's API key/token (may also be
-      supplied via the `Authorization: Bearer <token>` header). The operating
-      account is resolved from the token owner's address — there is **no**
-      end-user JWT middleware and **no** per-endpoint scope check on these routes.
-
-    For `POST /v1/account/sign`, end-user authorization is instead proven
-    **in-band** via a two-phase OTP challenge (see that operation), not via a
-    session token.
+    Each endpoint requires the scope listed under `x-scopes`; calls without it return
+    `403`.
 
     ### Rate limiting
-    Endpoints are protected by a scope-tier sliding-window rate limiter; on breach
-    the response is `429 Too Many Requests` with a `Retry-After` header.
 
+    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
+    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
+    the tier assigned to the calling client.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -67,7 +38,7 @@ servers:
     description: "Local Development"
 tags:
   - name: "Key Management"
-    description: "Endpoints for provisioning, listing, rotating and using the account's Vault Transit signing key."
+    description: "Provision the account's signing key and use it to sign operations."
 
 # ===============================================================
 #   PATHS
@@ -78,19 +49,16 @@ paths:
     post:
       tags:
         - "Key Management"
-      summary: "Create the account's Vault Transit signing key"
+      summary: "Create the account's signing key"
       description: |
-        Provisions the account's Ed25519 Vault Transit signing key
-        (`units-signing-<accountId>`) and persists a `key_reference` row.
-
-        The operation is **idempotent**: signup already provisions this key, so a
-        repeat call returns the existing key instead of colliding. The operating
-        account is derived from the developer token's owner — the request payload
-        is not read.
+        Provision the signing key for the signed-in user's account. The payload is empty.
+        The call is idempotent: an account that already has a signing key gets the existing
+        key back. Requires a user session token.
       operationId: createKey
       security:
         - developerToken: []
         - developerSignature: []
+      x-scopes: [keys:create]
       requestBody:
         required: true
         content:
@@ -104,10 +72,11 @@ paths:
                 ts: "2026-04-07T12:00:00Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
               payload: {}
       responses:
         '201':
-          description: "Signing key created (or already provisioned)."
+          description: "Signing key created, or returned unchanged if it already existed."
           content:
             application/json:
               schema:
@@ -123,128 +92,41 @@ paths:
                   keyId: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
                   publicKey: "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
                   did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
-                  keySource: "vault_transit"
-        '400':
-          $ref: '#/components/responses/BadRequestError'
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-  /v1/account/keys:
-    get:
-      tags:
-        - "Key Management"
-      summary: "List the account's keys"
-      description: |
-        Returns all `key_reference` rows bound to the calling account (resolved
-        from the developer token owner). The DID for each row is derived from its
-        public key. This is a read-only `GET`; no request body is sent.
-      operationId: listKeys
-      security:
-        - developerToken: []
-        - developerSignature: []
-      responses:
-        '200':
-          description: "List of the account's keys."
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse_ListKeysResult'
-              example:
-                context:
-                  id: "api.account.keys.list"
-                  version: "v1"
-                  ts: "2026-04-07T12:05:01Z"
-                  msgId: "d1e2f3a4-b5c6-7890-1234-567890abcdef"
-                  status: "successful"
-                response:
-                  keys:
-                    - id: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
-                      keyType: "ed25519"
-                      keySource: "vault_transit"
-                      publicKey: "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
-                      did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
-                      status: "active"
-                      createdAt: "2026-04-07T11:59:00Z"
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-  /v1/account/keys/rotate:
-    post:
-      tags:
-        - "Key Management"
-      summary: "Rotate the account's signing key (NOT IMPLEMENTED)"
-      description: |
-        **Not implemented.** Correct rotation must mint a new Vault key version,
-        supersede the old `key_reference`, and propagate the new pubkey-derived
-        DID to the registry and peers — a cross-instance change that requires a
-        dedicated design. The endpoint therefore fails closed and always responds
-        with **HTTP 501** and error code `NOT_IMPLEMENTED`.
-      operationId: rotateKey
-      security:
-        - developerToken: []
-        - developerSignature: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ApiRequest_Empty'
-            example:
-              context:
-                id: "api.account.keys.rotate"
-                version: "v1"
-                ts: "2026-04-07T12:10:00Z"
-                msgId: "e1f2a3b4-c5d6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
-              payload: {}
-      responses:
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
-        '501':
-          $ref: '#/components/responses/NotImplementedError'
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+        '500': { $ref: '#/components/responses/InternalServerError' }
 
   /v1/account/sign:
     post:
       tags:
         - "Key Management"
-      summary: "Sign a ULIP envelope (two-phase OTP)"
+      summary: "Sign an operation with the account's key"
       description: |
-        Produces a Vault Transit signature over a ULIP envelope for the account
-        identified by `context.account_did`. End-user authorization is proven
-        in-band via a **two-phase OTP** flow — there is no session JWT on this
-        route.
+        Sign an operation with the signing key of the account identified by
+        `context.account_did`. The account holder authorises the signature by confirming a
+        one-time code, so this endpoint takes no session token.
 
-        **Request shape (special).** The body is NOT the plain envelope:
-        - `context` carries the standard fields **plus** required `method` and
+        Request shape (special):
+
+        * `context` carries the standard fields plus the required `method` and
           `account_did`.
-        - `payload` is the operation body to be wrapped and signed. **It MUST be
-          byte-identical to the `payload` you then submit to `POST /v1/token/transact`**
-          — the signature is computed over exactly this object, so any mismatch
-          invalidates it.
-        - `username` and `otp` are **top-level** fields (siblings of `context`
-          and `payload`), NOT inside `payload`.
+        * `payload` is the operation body to be signed. It must be byte identical to the
+          `payload` later submitted to `POST /v1/token/transact`, because the signature is
+          computed over exactly this object.
+        * `username` and `otp` are top level fields, siblings of `context` and `payload`.
 
-        **Phase 1 — request without `otp`:** the contact in `username` (which must
-        belong to `account_did`) is sent an OTP. Responds `200` with
-        `{ "status": "otp_sent", ... }`.
+        Step 1, request without `otp`: a code is sent to `username`, which must be a
+        contact of the account. Responds `200` with `status: otp_sent`.
 
-        **Phase 2 — resubmit with `otp`:** the OTP is verified, the envelope is
-        signed, and the response returns the signed `envelope`, the stable
-        `keyId` (the `key_references` UUID), and the `method`.
+        Step 2, resubmit with `otp`: the code is verified and the signed envelope is
+        returned along with the `keyId` that produced the signature.
       operationId: sign
       security:
         - developerToken: []
         - developerSignature: []
+      x-scopes: [keys:manage]
       requestBody:
         required: true
         content:
@@ -253,7 +135,7 @@ paths:
               $ref: '#/components/schemas/SignRequest'
             examples:
               Phase1_SendOtp:
-                summary: "Phase 1 — omit otp to trigger an OTP send"
+                summary: "Step 1: omit otp to have a code sent"
                 value:
                   context:
                     id: "api.account.sign"
@@ -270,7 +152,7 @@ paths:
                     value: "100000000"
                   username: "alice@example.com"
               Phase2_CompleteSigning:
-                summary: "Phase 2 — resubmit with the received otp to sign"
+                summary: "Step 2: resubmit with the code to sign"
                 value:
                   context:
                     id: "api.account.sign"
@@ -289,10 +171,7 @@ paths:
                   otp: "123456"
       responses:
         '200':
-          description: |
-            Response depends on the phase:
-            - **Phase 1 (no `otp`)**: OTP-sent acknowledgement.
-            - **Phase 2 (with `otp`)**: the signed envelope.
+          description: "Acknowledgement that the code was sent (step 1), or the signed envelope (step 2)."
           content:
             application/json:
               schema:
@@ -301,7 +180,7 @@ paths:
                   - $ref: '#/components/schemas/ApiResponse_SignEnvelope'
               examples:
                 Phase1_OtpSent:
-                  summary: "Phase 1 response"
+                  summary: "Step 1 response"
                   value:
                     context:
                       id: "api.account.sign"
@@ -313,7 +192,7 @@ paths:
                       status: "otp_sent"
                       message: "OTP sent. Resubmit with the otp field to complete signing."
                 Phase2_Signed:
-                  summary: "Phase 2 response"
+                  summary: "Step 2 response"
                   value:
                     context:
                       id: "api.account.sign"
@@ -340,17 +219,13 @@ paths:
                             value: "100000000"
                         signature:
                           signer_instance: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
-                          key_name: "units-signing-019ab8e9-0636-74fd-b5c4-192fc68b71e3"
                           algorithm: "ed25519"
                           signature: "3045022100abcdef..."
                       keyId: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
                       method: "lock.request"
-        '400':
-          $ref: '#/components/responses/BadRequestError'
+        '400': { $ref: '#/components/responses/BadRequestError' }
         '401':
-          description: |
-            OTP contact does not match the account, proof failed, or OTP invalid
-            (also returned for developer-token auth failure).
+          description: "Authentication failed, `username` is not a contact of the account, or the code is not valid."
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
@@ -365,10 +240,9 @@ paths:
                     code: "UNAUTHORIZED"
                     message: "OTP invalid"
                 response: {}
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+        '500': { $ref: '#/components/responses/InternalServerError' }
 
 # ===============================================================
 #   COMPONENTS
@@ -387,9 +261,9 @@ components:
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "B2B Developer API Key/Token" }
-        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "B2B Developer Signature (RFC 9421)" }
-        authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token (unused by key-management routes)." }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "The calling application's developer token." }
+        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "Signature over the request (RFC 9421)." }
+        authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End user's session token." }
 
     ResponseContext:
       type: object
@@ -411,7 +285,7 @@ components:
       required: [keyId, jws]
       properties:
         keyId: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
-        jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object." }
+        jws: { type: string, example: "eyJ...", description: "End user's JWS over the payload object." }
 
     ErrorPayload:
       type: object
@@ -454,7 +328,7 @@ components:
     SignContext:
       type: object
       required: [method, account_did]
-      description: "Standard envelope context PLUS the required routing fields method and account_did. Only method and account_did are enforced by the sign handler; id/version/ts/msgId are optional here."
+      description: "The standard context plus the required `method` and `account_did`. Only those two are enforced on this endpoint."
       properties:
         id: { type: string, example: "api.account.sign" }
         version: { type: string, example: "v1" }
@@ -465,11 +339,11 @@ components:
         method:
           type: string
           example: "lock.request"
-          description: "ULIP method to sign for; populates the signed envelope's context.method."
+          description: "The operation being signed. Becomes `context.method` in the signed envelope."
         account_did:
           type: string
           example: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
-          description: "DID of the account whose Vault Transit signing key produces the signature."
+          description: "DID of the account whose key produces the signature."
     SignRequest:
       type: object
       required: [context, payload, username]
@@ -477,20 +351,16 @@ components:
         context: { $ref: '#/components/schemas/SignContext' }
         payload:
           type: object
-          description: "Method-specific body to be wrapped and signed (becomes the ULIP payload value)."
+          description: "The operation body to be signed."
         username:
           type: string
           example: "alice@example.com"
-          description: |
-            Contact (email, or +E.164 mobile) that must belong to `account_did`.
-            The OTP is sent here. TOP-LEVEL field — not part of `payload`.
+          description: "Contact of the account (email, or mobile in E.164 format) that receives the code. Top level field, not part of `payload`."
         otp:
           type: string
           nullable: true
           example: "123456"
-          description: |
-            Omit for phase 1 (send OTP); provide to complete signing in phase 2.
-            TOP-LEVEL field — not part of `payload`.
+          description: "Omit on step 1; supply on step 2 to complete signing. Top level field, not part of `payload`."
 
     # --- Specific Response Envelopes ---
     ApiResponse_CreateKeyResult:
@@ -498,12 +368,6 @@ components:
         - $ref: '#/components/schemas/ApiResponse'
         - properties:
             response: { $ref: '#/components/schemas/CreateKeyResult' }
-
-    ApiResponse_ListKeysResult:
-      allOf:
-        - $ref: '#/components/schemas/ApiResponse'
-        - properties:
-            response: { $ref: '#/components/schemas/ListKeysResult' }
 
     ApiResponse_SignOtpSent:
       allOf:
@@ -520,11 +384,11 @@ components:
     # --- Core Data Schemas (Payloads) ---
     CreateKeyResult:
       type: object
-      required: [keyId, publicKey, did, keySource]
+      required: [keyId, publicKey, did]
       properties:
         keyId:
           type: string
-          description: "Vault key identifier for the signing key."
+          description: "Identifier of the signing key."
           example: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
         publicKey:
           type: string
@@ -534,29 +398,6 @@ components:
           type: string
           description: "did:key derived from the public key."
           example: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
-        keySource:
-          type: string
-          example: "vault_transit"
-
-    KeyInfo:
-      type: object
-      required: [id, keyType, keySource, publicKey, did, status, createdAt]
-      properties:
-        id: { type: string, format: uuid, description: "key_references row UUID." }
-        keyType: { type: string, example: "ed25519" }
-        keySource: { type: string, example: "vault_transit", description: "vault_transit or external." }
-        publicKey: { type: string, description: "Hex-encoded public key." }
-        did: { type: string, description: "did:key derived from the public key (empty if the key is malformed)." }
-        status: { type: string, example: "active" }
-        createdAt: { type: string, format: date-time }
-
-    ListKeysResult:
-      type: object
-      required: [keys]
-      properties:
-        keys:
-          type: array
-          items: { $ref: '#/components/schemas/KeyInfo' }
 
     SignOtpSentResponse:
       type: object
@@ -573,7 +414,7 @@ components:
         keyId:
           type: string
           format: uuid
-          description: "Stable key_references UUID for the signing key."
+          description: "Identifier of the key that produced the signature."
           example: "019ab8e9-0636-74fd-b5c4-192fc68b71e3"
         method: { type: string, example: "lock.request" }
 
@@ -587,7 +428,7 @@ components:
 
     UlipContext:
       type: object
-      description: "Cross-cutting ULIP envelope metadata."
+      description: "Envelope metadata."
       properties:
         ulip_version: { type: string, example: "v1" }
         method: { type: string, example: "lock.request" }
@@ -605,26 +446,25 @@ components:
 
     UlipPayload:
       type: object
-      description: "Method-specific body with a TypeURL discriminator (mimics google.protobuf.Any)."
+      description: "The signed operation body."
       properties:
         type_url: { type: string, example: "" }
         value:
           type: object
-          description: "The signed method body (arbitrary JSON)."
+          description: "The signed body, as submitted in the request `payload`."
 
     UlipSignature:
       type: object
-      description: "Signature block as returned by /v1/account/sign (key_name replaces the versioned vault key id)."
       properties:
         signer_instance: { type: string }
-        key_name: { type: string, example: "units-signing-019ab8e9-0636-74fd-b5c4-192fc68b71e3" }
+        key_name: { type: string, description: "Name of the key that produced the signature." }
         algorithm: { type: string, example: "ed25519" }
         signature: { type: string, description: "Signature bytes, base64-encoded on the wire." }
 
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. The developer token is missing, invalid, or expired."
+      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -640,8 +480,25 @@ components:
                 message: "invalid developer token"
             response: {}
 
+    ForbiddenError:
+      description: "The caller does not have the scope required by this endpoint."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context:
+              id: "api.account.keys.create"
+              version: "v1"
+              ts: "2026-04-07T12:00:00Z"
+              msgId: "..."
+              status: "failed"
+              error:
+                code: "CLIENT_INSUFFICIENT_SCOPE"
+                message: "service account does not have required scope: keys:create"
+            response: {}
+
     BadRequestError:
-      description: "Invalid request parameters."
+      description: "Invalid request."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -653,31 +510,12 @@ components:
               msgId: "..."
               status: "failed"
               error:
-                code: "BAD_REQUEST"
+                code: "INVALID_INPUT"
                 message: "context.account_did is required"
             response: {}
 
-    NotImplementedError:
-      description: "The operation is not implemented (HTTP 501)."
-      content:
-        application/json:
-          schema: { $ref: '#/components/schemas/ApiError' }
-          example:
-            context:
-              id: "api.account.keys.rotate"
-              version: "v1"
-              ts: "2026-04-07T12:10:00Z"
-              msgId: "..."
-              status: "failed"
-              error:
-                code: "NOT_IMPLEMENTED"
-                message: "key rotation is not yet supported"
-            response: {}
-
     RateLimitedError:
-      description: |
-        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
-        response header indicates how long the caller should wait before retrying.
+      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }
@@ -707,20 +545,16 @@ components:
 
   # -------------------- Security --------------------
   securitySchemes:
-    # The server checks the HTTP header first and falls back to the context object.
-
     developerToken:
       type: http
       scheme: bearer
       bearerFormat: "JWT or Opaque"
-      description: |
-        A JWT or Opaque token that identifies the calling B2B developer/backend service.
-        The operating account is resolved from the token owner.
+      description: "Token identifying the calling application, sent as `context.developerToken`."
 
     developerSignature:
       type: apiKey
       in: header
       name: Signature
       description: |
-        The IETF HTTP Signature (RFC 9421) used by B2B developers for message integrity
-        and non-repudiation. Passed in the `Signature` header.
+        Optional request signature (RFC 9421) for message integrity and non-repudiation,
+        sent in the `Signature` header.

--- a/api/key-management-interfaces.yaml
+++ b/api/key-management-interfaces.yaml
@@ -53,7 +53,6 @@ paths:
       operationId: createKey
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -107,7 +106,6 @@ paths:
       operationId: listKeys
       security:
         - developerToken: []
-        - developerSignature: []
       responses:
         '200':
           description: "List of the account's keys."
@@ -165,7 +163,6 @@ paths:
       operationId: sign
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -304,8 +301,7 @@ components:
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "The calling application's developer token." }
-        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "Signature over the request (RFC 9421)." }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End user's session token." }
 
     ResponseContext:
@@ -377,8 +373,7 @@ components:
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        developerToken: { type: string, example: "fnt_...", nullable: true }
-        developerSignature: { type: string, nullable: true }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
         method:
           type: string
           example: "lock.request"
@@ -603,12 +598,4 @@ components:
       type: http
       scheme: bearer
       bearerFormat: "JWT or Opaque"
-      description: "Token identifying the calling application, sent as `context.developerToken`."
-
-    developerSignature:
-      type: apiKey
-      in: header
-      name: Signature
-      description: |
-        Optional request signature (RFC 9421) for message integrity and non-repudiation,
-        sent in the `Signature` header.
+      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."

--- a/api/registry-interfaces.yaml
+++ b/api/registry-interfaces.yaml
@@ -727,59 +727,6 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
 
   # -------------------- Federation --------------------
-  /v1/registry/lookup-address:
-    post:
-      tags:
-        - "Federation"
-      summary: "Resolve an on-chain address to a UNITS account"
-      description: |
-        Resolve an on-chain `(chainId, address)` pair to the owning UNITS account —
-        returning its DID, home instance, and account ID. Developer-token gated.
-      security:
-        - developerToken: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ApiRequest_LookupAddressRequest'
-            example:
-              context:
-                id: "api.registry.lookup.address"
-                version: "v1"
-                ts: "2026-02-17T10:00:00Z"
-                msgId: "e7f8a9b0-c1d2-3456-7890-456789012345"
-                developerToken: "fnt_..."
-              payload:
-                chainId: "eip155:1"
-                address: "0x1111111111111111111111111111111111111111"
-      responses:
-        '200':
-          description: "Address resolved"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse_LookupAddress'
-              example:
-                context:
-                  id: "api.registry.lookup.address"
-                  version: "v1"
-                  ts: "2026-02-17T10:00:00Z"
-                  msgId: "e7f8a9b0-c1d2-3456-7890-456789012345"
-                  status: "successful"
-                response:
-                  did: "did:units:acct:550e8400-e29b-41d4-a716-446655440000"
-                  home_instance: "https://foundry.finternetlab.io"
-                  account_id: "550e8400-e29b-41d4-a716-446655440000"
-        '400':
-          $ref: '#/components/responses/BadRequestError'
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '404':
-          $ref: '#/components/responses/NotFoundError'
-
   /v1/registry/forwarding/{did}:
     get:
       tags:
@@ -1430,37 +1377,6 @@ components:
 
     # --- Federation Schemas ---
 
-    LookupAddressRequest:
-      type: object
-      required: [chainId, address]
-      additionalProperties: false
-      properties:
-        chainId:
-          type: string
-          minLength: 1
-          description: "CAIP-2 chain identifier"
-          example: "eip155:1"
-        address:
-          type: string
-          minLength: 1
-          description: "On-chain address to resolve"
-          example: "0x1111111111111111111111111111111111111111"
-
-    LookupAddress:
-      type: object
-      required: [did, home_instance, account_id]
-      description: "Resolved UNITS account for an on-chain address"
-      properties:
-        did:
-          type: string
-          description: "Decentralized identifier of the owning account"
-        home_instance:
-          type: string
-          description: "Home UNITS instance URL for the account"
-        account_id:
-          type: string
-          description: "Internal UNITS account ID"
-
     ForwardingPointerResponse:
       type: object
       required: [did, new_home_id, installed_at, grace_until, signed_record]
@@ -1712,18 +1628,6 @@ components:
         - $ref: '#/components/schemas/ApiResponse'
         - properties:
             response: { $ref: '#/components/schemas/WalletProviderList' }
-
-    ApiRequest_LookupAddressRequest:
-      allOf:
-        - $ref: '#/components/schemas/RequestContext'
-        - properties:
-            payload: { $ref: '#/components/schemas/LookupAddressRequest' }
-
-    ApiResponse_LookupAddress:
-      allOf:
-        - $ref: '#/components/schemas/ApiResponse'
-        - properties:
-            response: { $ref: '#/components/schemas/LookupAddress' }
 
     ApiResponse_ForwardingPointer:
       allOf:

--- a/api/registry-interfaces.yaml
+++ b/api/registry-interfaces.yaml
@@ -40,7 +40,6 @@ info:
 
     1.  **Platform-Level (Developer) Authentication:**
         * `context.developerToken`: The B2B Developer's API Key/Token.
-        * `context.developerSignature`: The B2B Developer's signature.
 
     2.  **Admin-Level Authorization:**
         * Write operations (register, update) require admin privileges.
@@ -114,7 +113,6 @@ paths:
         for routing balance queries and transaction operations to the appropriate adapter service(s).
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -249,7 +247,6 @@ paths:
         Use this to add/remove adapters, change priorities, or deactivate a chain.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -441,7 +438,6 @@ paths:
         Uses `rdns` (EIP-6963 standard) as the universal, library-agnostic identifier.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -553,7 +549,6 @@ paths:
       description: "Update a wallet provider's status, supported chains, or metadata."
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -793,7 +788,6 @@ paths:
         end-user token) and rate limited.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: false
         description: "No business payload; the envelope carries only the standard context."
@@ -1117,8 +1111,7 @@ components:
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        developerToken: { type: string, nullable: true, description: "B2B Developer API Key/Token" }
-        developerSignature: { type: string, nullable: true, description: "B2B Developer Signature" }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
     ResponseContext:
       type: object
       required: [id, version, ts, msgId, status]
@@ -1737,12 +1730,7 @@ components:
       type: http
       scheme: bearer
       bearerFormat: "JWT or Opaque"
-      description: "B2B Developer API Key/Token in Authorization header."
-    developerSignature:
-      type: apiKey
-      in: header
-      name: Signature
-      description: "IETF HTTP Signature (RFC 9421) for message integrity."
+      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."
     userToken:
       type: http
       scheme: bearer

--- a/api/registry-interfaces.yaml
+++ b/api/registry-interfaces.yaml
@@ -35,15 +35,12 @@ info:
     }
     ```
 
-    ### Authentication and Authorization
-    This API uses the same two-level authorization model as the other UNITS services:
+    ### Authentication
 
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
-
-    2.  **Admin-Level Authorization:**
-        * Write operations (register, update) require admin privileges.
-        * Read operations (get, search) require developer authentication only.
+    * `context.developerToken`: the developer token of the calling application. Required on
+      every endpoint.
+    * `context.authorization`: the end user's session token. Required on the endpoints that
+      act on a signed-in user; each operation states when it is needed.
 
     ### RBAC Scopes
 
@@ -111,8 +108,8 @@ paths:
       description: |
         Register a blockchain network in the chain registry. Includes adapter configuration
         for routing balance queries and transaction operations to the appropriate adapter service(s).
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -128,7 +125,7 @@ paths:
                     version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     networkId: "eip155:1"
                     name: "Ethereum Mainnet"
@@ -153,7 +150,7 @@ paths:
                     version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef0"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     networkId: "eip155:137"
                     name: "Polygon Mainnet"
@@ -178,7 +175,7 @@ paths:
                     version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef01"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     networkId: "eip155:11155111"
                     name: "Sepolia Testnet"
@@ -245,8 +242,8 @@ paths:
       description: |
         Update a chain's configuration: adapters, status, or metadata.
         Use this to add/remove adapters, change priorities, or deactivate a chain.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -262,7 +259,7 @@ paths:
                     version: "v1"
                     ts: "2026-02-17T11:00:00Z"
                     msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef012"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     networkId: "eip155:1"
                     name: "Ethereum"
@@ -277,7 +274,7 @@ paths:
                     version: "v1"
                     ts: "2026-02-17T11:00:00Z"
                     msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef0123"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     networkId: "eip155:11155111"
                     status: "INACTIVE"
@@ -302,9 +299,7 @@ paths:
       tags:
         - "Chain Registry"
       summary: "Get chain details"
-      description: "Retrieve detailed information about a specific chain by its network ID."
-      security:
-        - developerToken: []
+      description: "Retrieve detailed information about a specific chain by its network ID. Requires a user session token in `context.authorization`."
       requestBody:
         required: true
         content:
@@ -317,7 +312,7 @@ paths:
                 version: "v1"
                 ts: "2026-02-17T10:00:00Z"
                 msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef01234"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
               payload:
                 networkId: "eip155:1"
       responses:
@@ -337,9 +332,7 @@ paths:
       tags:
         - "Chain Registry"
       summary: "Search chains"
-      description: "Search and list registered chains with filters."
-      security:
-        - developerToken: []
+      description: "Search and list registered chains with filters. Requires a user session token in `context.authorization`."
       requestBody:
         required: true
         content:
@@ -355,7 +348,7 @@ paths:
                     version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "a7b8c9d0-e1f2-3456-7890-abcdef012345"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     filters:
                       status: "ACTIVE"
@@ -374,7 +367,7 @@ paths:
                     version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "b8c9d0e1-f2a3-4567-8901-bcdef0123456"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     filters:
                       chainFamily: "evm"
@@ -436,8 +429,8 @@ paths:
         Register a wallet application in the provider registry. This is a policy allow-list
         consumed by App Backends, not enforced by UNITS directly.
         Uses `rdns` (EIP-6963 standard) as the universal, library-agnostic identifier.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -453,7 +446,7 @@ paths:
                     version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "c9d0e1f2-a3b4-5678-9012-cdef01234567"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     name: "MetaMask"
                     rdns: "io.metamask"
@@ -473,7 +466,7 @@ paths:
                     version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "d0e1f2a3-b4c5-6789-0123-def012345678"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     name: "Coinbase Wallet"
                     rdns: "com.coinbase.wallet"
@@ -492,7 +485,7 @@ paths:
                     version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "e1f2a3b4-c5d6-7890-1234-ef0123456789"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     name: "Trust Wallet"
                     rdns: "com.trustwallet.app"
@@ -546,9 +539,7 @@ paths:
       tags:
         - "Wallet Provider Registry"
       summary: "Update wallet provider"
-      description: "Update a wallet provider's status, supported chains, or metadata."
-      security:
-        - developerToken: []
+      description: "Update a wallet provider's status, supported chains, or metadata. Requires a user session token in `context.authorization`."
       requestBody:
         required: true
         content:
@@ -564,7 +555,7 @@ paths:
                     version: "v1"
                     ts: "2026-02-17T11:00:00Z"
                     msgId: "f2a3b4c5-d6e7-8901-2345-f01234567890"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     rdns: "io.metamask"
                     supportedChains: ["eip155:1", "eip155:137", "eip155:8453", "eip155:42161", "eip155:56", "eip155:10", "eip155:59144"]
@@ -576,7 +567,7 @@ paths:
                     version: "v1"
                     ts: "2026-02-17T11:00:00Z"
                     msgId: "a3b4c5d6-e7f8-9012-3456-012345678901"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     rdns: "com.suspicious.wallet"
                     status: "BLOCKED"
@@ -601,9 +592,7 @@ paths:
       tags:
         - "Wallet Provider Registry"
       summary: "Get wallet provider details"
-      description: "Retrieve detailed information about a specific wallet provider by its rdns identifier."
-      security:
-        - developerToken: []
+      description: "Retrieve detailed information about a specific wallet provider by its rdns identifier. Requires a user session token in `context.authorization`."
       requestBody:
         required: true
         content:
@@ -616,7 +605,7 @@ paths:
                 version: "v1"
                 ts: "2026-02-17T10:00:00Z"
                 msgId: "b4c5d6e7-f8a9-0123-4567-123456789012"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
               payload:
                 rdns: "io.metamask"
       responses:
@@ -636,9 +625,7 @@ paths:
       tags:
         - "Wallet Provider Registry"
       summary: "Search wallet providers"
-      description: "Search and list registered wallet providers with filters."
-      security:
-        - developerToken: []
+      description: "Search and list registered wallet providers with filters. Requires a user session token in `context.authorization`."
       requestBody:
         required: true
         content:
@@ -654,7 +641,7 @@ paths:
                     version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "c5d6e7f8-a9b0-1234-5678-234567890123"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     filters:
                       status: "ACTIVE"
@@ -669,7 +656,7 @@ paths:
                     version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "d6e7f8a9-b0c1-2345-6789-345678901234"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     filters:
                       "supportedChains": "eip155:1"
@@ -732,8 +719,6 @@ paths:
         (federation home migration). Callers holding a stale home reference use this to
         discover the account's new home instance and the signed forwarding record.
         Developer-token gated.
-      security:
-        - developerToken: []
       parameters:
         - name: did
           in: path
@@ -786,8 +771,6 @@ paths:
         the new document version, and the signature. No request payload; the operator
         trigger carries only the standard envelope context. Developer-token gated (no
         end-user token) and rate limited.
-      security:
-        - developerToken: []
       requestBody:
         required: false
         description: "No business payload; the envelope carries only the standard context."
@@ -801,7 +784,7 @@ paths:
                 version: "v1"
                 ts: "2026-02-17T10:00:00Z"
                 msgId: "a9b0c1d2-e3f4-5678-9012-678901234567"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
               payload: {}
       responses:
         '200':
@@ -839,8 +822,6 @@ paths:
         descriptor advertising the programs this instance supports (per-program asset
         models, primitive methods, templates, and operation plans), its signing keys, and
         the point in time it was generated. Developer-token gated.
-      security:
-        - developerToken: []
       responses:
         '200':
           description: "Signed capability document."
@@ -883,10 +864,9 @@ paths:
       description: |
         Register a new adapter service instance in the adapter registry. Each adapter
         declares the chains it serves via `chainIds[]`. The AdapterOrchestrator uses this
-        table for priority-based routing. Requires Developer + User auth.
-      security:
-        - developerToken: []
-        - userToken: []
+        table for priority-based routing.
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -899,7 +879,7 @@ paths:
                 version: "v1"
                 ts: "2026-03-05T10:00:00Z"
                 msgId: "f5a6b7c8-d9e0-1234-f012-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 adapterId: "alchemy_chain_adapter"
@@ -954,10 +934,9 @@ paths:
       summary: "Update an adapter"
       description: |
         Update an adapter's configuration. Only the fields provided in the payload are
-        updated. Requires Developer + User auth.
-      security:
-        - developerToken: []
-        - userToken: []
+        updated.
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -970,7 +949,7 @@ paths:
                 version: "v1"
                 ts: "2026-03-05T11:00:00Z"
                 msgId: "a6b7c8d9-e0f1-2345-0123-67890abcdef0"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 adapterId: "alchemy_chain_adapter"
@@ -997,10 +976,7 @@ paths:
       tags:
         - "Adapter Registry"
       summary: "Get adapter details"
-      description: "Retrieve details of a specific adapter by its adapter ID. Requires Developer + User auth."
-      security:
-        - developerToken: []
-        - userToken: []
+      description: "Retrieve details of a specific adapter by its adapter ID. Requires Developer + User auth. Requires a user session token in `context.authorization`."
       requestBody:
         required: true
         content:
@@ -1013,7 +989,7 @@ paths:
                 version: "v1"
                 ts: "2026-03-05T10:00:00Z"
                 msgId: "b7c8d9e0-f1a2-3456-1234-7890abcdef01"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 adapterId: "alchemy_chain_adapter"
@@ -1034,10 +1010,7 @@ paths:
       tags:
         - "Adapter Registry"
       summary: "Search adapters"
-      description: "Search and list registered adapters with filters and pagination. Requires Developer + User auth."
-      security:
-        - developerToken: []
-        - userToken: []
+      description: "Search and list registered adapters with filters and pagination. Requires Developer + User auth. Requires a user session token in `context.authorization`."
       requestBody:
         required: true
         content:
@@ -1050,7 +1023,7 @@ paths:
                 version: "v1"
                 ts: "2026-03-05T10:00:00Z"
                 msgId: "c8d9e0f1-a2b3-4567-2345-890abcdef012"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 filters:
@@ -1105,13 +1078,13 @@ components:
     # --- Shared Envelope Schemas ---
     Context:
       type: object
-      required: [id, version, ts, msgId]
+      required: [id, version, ts, msgId, developerToken]
       properties:
         id: { type: string, example: "api.registry.chains.get" }
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
     ResponseContext:
       type: object
       required: [id, version, ts, msgId, status]
@@ -1134,6 +1107,21 @@ components:
       required: [context, payload]
       properties:
         context: { $ref: '#/components/schemas/Context' }
+        payload: { type: object }
+    UserContext:
+      type: object
+      required: [id, version, ts, msgId, developerToken, authorization]
+      properties:
+        id: { type: string, example: "api.registry.chains.get" }
+        version: { type: string, example: "v1" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
+    UserRequestContext:
+      type: object
+      required: [context, payload]
+      properties:
+        context: { $ref: '#/components/schemas/UserContext' }
         payload: { type: object }
     ApiResponse:
       type: object
@@ -1552,25 +1540,25 @@ components:
 
     ApiRequest_RegisterChainRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/RegisterChainRequest' }
 
     ApiRequest_UpdateChainRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/UpdateChainRequest' }
 
     ApiRequest_GetChainRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/GetChainRequest' }
 
     ApiRequest_SearchChainsRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/SearchChainsRequest' }
 
@@ -1588,25 +1576,25 @@ components:
 
     ApiRequest_RegisterWalletProviderRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/RegisterWalletProviderRequest' }
 
     ApiRequest_UpdateWalletProviderRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/UpdateWalletProviderRequest' }
 
     ApiRequest_GetWalletProviderRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/GetWalletProviderRequest' }
 
     ApiRequest_SearchWalletProvidersRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/SearchWalletProvidersRequest' }
 
@@ -1642,25 +1630,25 @@ components:
 
     ApiRequest_RegisterAdapterRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/RegisterAdapterRequest' }
 
     ApiRequest_UpdateAdapterRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/UpdateAdapterRequest' }
 
     ApiRequest_GetAdapterRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/GetAdapterRequest' }
 
     ApiRequest_SearchAdapterRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/SearchAdapterRequest' }
 
@@ -1723,18 +1711,3 @@ components:
           example:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
-
-  # -------------------- Security --------------------
-  securitySchemes:
-    developerToken:
-      type: http
-      scheme: bearer
-      bearerFormat: "JWT or Opaque"
-      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."
-    userToken:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
-      description: |
-        End-user JWT session token, passed in `context.authorization` as `Bearer <token>`.
-        Required by the adapter registry endpoints (register, update, get, search).

--- a/api/registry-interfaces.yaml
+++ b/api/registry-interfaces.yaml
@@ -89,7 +89,7 @@ tags:
       require both Developer and end-user authentication.
   - name: "Federation"
     description: |
-      Federation address resolution. Resolves an on-chain (chain_id, address) pair to the
+      Federation address resolution. Resolves an on-chain (chainId, address) pair to the
       owning UNITS account, its DID, and home instance. Developer-token gated.
   - name: "Instance"
     description: |
@@ -733,7 +733,7 @@ paths:
         - "Federation"
       summary: "Resolve an on-chain address to a UNITS account"
       description: |
-        Resolve an on-chain `(chain_id, address)` pair to the owning UNITS account —
+        Resolve an on-chain `(chainId, address)` pair to the owning UNITS account —
         returning its DID, home instance, and account ID. Developer-token gated.
       security:
         - developerToken: []
@@ -751,7 +751,7 @@ paths:
                 msgId: "e7f8a9b0-c1d2-3456-7890-456789012345"
                 developerToken: "fnt_..."
               payload:
-                chain_id: "eip155:1"
+                chainId: "eip155:1"
                 address: "0x1111111111111111111111111111111111111111"
       responses:
         '200':
@@ -1432,10 +1432,10 @@ components:
 
     LookupAddressRequest:
       type: object
-      required: [chain_id, address]
+      required: [chainId, address]
       additionalProperties: false
       properties:
-        chain_id:
+        chainId:
           type: string
           minLength: 1
           description: "CAIP-2 chain identifier"

--- a/api/registry-interfaces.yaml
+++ b/api/registry-interfaces.yaml
@@ -127,7 +127,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.chains.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
                     developerToken: "fnt_..."
@@ -152,7 +152,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.chains.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef0"
                     developerToken: "fnt_..."
@@ -177,7 +177,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.chains.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef01"
                     developerToken: "fnt_..."
@@ -206,7 +206,7 @@ paths:
               example:
                 context:
                   id: "api.registry.chains.register"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-02-17T10:00:00Z"
                   msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
                   status: "successful"
@@ -262,7 +262,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.chains.update"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-02-17T11:00:00Z"
                     msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef012"
                     developerToken: "fnt_..."
@@ -277,7 +277,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.chains.update"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-02-17T11:00:00Z"
                     msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef0123"
                     developerToken: "fnt_..."
@@ -317,7 +317,7 @@ paths:
             example:
               context:
                 id: "api.registry.chains.get"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-02-17T10:00:00Z"
                 msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef01234"
                 developerToken: "fnt_..."
@@ -355,7 +355,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.chains.search"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "a7b8c9d0-e1f2-3456-7890-abcdef012345"
                     developerToken: "fnt_..."
@@ -374,7 +374,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.chains.search"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "b8c9d0e1-f2a3-4567-8901-bcdef0123456"
                     developerToken: "fnt_..."
@@ -394,7 +394,7 @@ paths:
               example:
                 context:
                   id: "api.registry.chains.search"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-02-17T10:00:00Z"
                   msgId: "a7b8c9d0-e1f2-3456-7890-abcdef012345"
                   status: "successful"
@@ -454,7 +454,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.wallets.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "c9d0e1f2-a3b4-5678-9012-cdef01234567"
                     developerToken: "fnt_..."
@@ -474,7 +474,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.wallets.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "d0e1f2a3-b4c5-6789-0123-def012345678"
                     developerToken: "fnt_..."
@@ -493,7 +493,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.wallets.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "e1f2a3b4-c5d6-7890-1234-ef0123456789"
                     developerToken: "fnt_..."
@@ -517,7 +517,7 @@ paths:
               example:
                 context:
                   id: "api.registry.wallets.register"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-02-17T10:00:00Z"
                   msgId: "c9d0e1f2-a3b4-5678-9012-cdef01234567"
                   status: "successful"
@@ -566,7 +566,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.wallets.update"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-02-17T11:00:00Z"
                     msgId: "f2a3b4c5-d6e7-8901-2345-f01234567890"
                     developerToken: "fnt_..."
@@ -578,7 +578,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.wallets.update"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-02-17T11:00:00Z"
                     msgId: "a3b4c5d6-e7f8-9012-3456-012345678901"
                     developerToken: "fnt_..."
@@ -618,7 +618,7 @@ paths:
             example:
               context:
                 id: "api.registry.wallets.get"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-02-17T10:00:00Z"
                 msgId: "b4c5d6e7-f8a9-0123-4567-123456789012"
                 developerToken: "fnt_..."
@@ -656,7 +656,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.wallets.search"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "c5d6e7f8-a9b0-1234-5678-234567890123"
                     developerToken: "fnt_..."
@@ -671,7 +671,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.wallets.search"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "d6e7f8a9-b0c1-2345-6789-345678901234"
                     developerToken: "fnt_..."
@@ -691,7 +691,7 @@ paths:
               example:
                 context:
                   id: "api.registry.wallets.search"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-02-17T10:00:00Z"
                   msgId: "c5d6e7f8-a9b0-1234-5678-234567890123"
                   status: "successful"
@@ -746,7 +746,7 @@ paths:
             example:
               context:
                 id: "api.registry.lookup.address"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-02-17T10:00:00Z"
                 msgId: "e7f8a9b0-c1d2-3456-7890-456789012345"
                 developerToken: "fnt_..."
@@ -763,7 +763,7 @@ paths:
               example:
                 context:
                   id: "api.registry.lookup.address"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-02-17T10:00:00Z"
                   msgId: "e7f8a9b0-c1d2-3456-7890-456789012345"
                   status: "successful"
@@ -810,7 +810,7 @@ paths:
               example:
                 context:
                   id: "api.registry.forwarding.get"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-02-17T10:00:00Z"
                   msgId: "f8a9b0c1-d2e3-4567-8901-567890123456"
                   status: "successful"
@@ -857,7 +857,7 @@ paths:
             example:
               context:
                 id: "api.registry.capability.publish"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-02-17T10:00:00Z"
                 msgId: "a9b0c1d2-e3f4-5678-9012-678901234567"
                 developerToken: "fnt_..."
@@ -872,7 +872,7 @@ paths:
               example:
                 context:
                   id: "api.registry.capability.publish"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-02-17T10:00:01Z"
                   msgId: "a9b0c1d2-e3f4-5678-9012-678901234567"
                   status: "successful"
@@ -910,7 +910,7 @@ paths:
               example:
                 context:
                   id: "api.instance.capabilities.get"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-02-17T10:00:00Z"
                   msgId: "b0c1d2e3-f4a5-6789-0123-789012345678"
                   status: "successful"
@@ -955,7 +955,7 @@ paths:
             example:
               context:
                 id: "api.adapter.register"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-03-05T10:00:00Z"
                 msgId: "f5a6b7c8-d9e0-1234-f012-567890abcdef"
                 developerToken: "fnt_..."
@@ -980,7 +980,7 @@ paths:
               example:
                 context:
                   id: "api.adapter.register"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-03-05T10:00:00Z"
                   msgId: "f5a6b7c8-d9e0-1234-f012-567890abcdef"
                   status: "successful"
@@ -1026,7 +1026,7 @@ paths:
             example:
               context:
                 id: "api.adapter.update"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-03-05T11:00:00Z"
                 msgId: "a6b7c8d9-e0f1-2345-0123-67890abcdef0"
                 developerToken: "fnt_..."
@@ -1069,7 +1069,7 @@ paths:
             example:
               context:
                 id: "api.adapter.get"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-03-05T10:00:00Z"
                 msgId: "b7c8d9e0-f1a2-3456-1234-7890abcdef01"
                 developerToken: "fnt_..."
@@ -1106,7 +1106,7 @@ paths:
             example:
               context:
                 id: "api.adapter.search"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-03-05T10:00:00Z"
                 msgId: "c8d9e0f1-a2b3-4567-2345-890abcdef012"
                 developerToken: "fnt_..."
@@ -1131,7 +1131,7 @@ paths:
               example:
                 context:
                   id: "api.adapter.search"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-03-05T10:00:00Z"
                   msgId: "c8d9e0f1-a2b3-4567-2345-890abcdef012"
                   status: "successful"
@@ -1167,7 +1167,7 @@ components:
       required: [id, version, ts, msgId]
       properties:
         id: { type: string, example: "api.registry.chains.get" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         developerToken: { type: string, nullable: true, description: "B2B Developer API Key/Token" }

--- a/api/registry-interfaces.yaml
+++ b/api/registry-interfaces.yaml
@@ -62,6 +62,9 @@ info:
     | `POST /v1/adapter/update` | `registry-adapters:manage` |
     | `POST /v1/adapter/get` | `registry-adapters:view` |
     | `POST /v1/adapter/search` | `registry-adapters:view` |
+    | `POST /v1/registry/capability/publish` | *(operator — developer token; no user scope)* |
+    | `GET /v1/registry/forwarding/{did}` | *(developer token)* |
+    | `GET /v1/instance/capabilities` | *(developer token)* |
 
     ### Rate limiting
 
@@ -88,6 +91,12 @@ tags:
     description: |
       Federation address resolution. Resolves an on-chain (chain_id, address) pair to the
       owning UNITS account, its DID, and home instance. Developer-token gated.
+  - name: "Instance"
+    description: |
+      Instance capability publishing and discovery. The signed capability document
+      advertises the programs an instance supports (asset models, primitive methods,
+      templates, operation plans), its signing keys, and when it was generated.
+      Operator / federation-infra endpoints, documented for completeness.
 
 # ===============================================================
 #   PATHS
@@ -771,6 +780,159 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
 
+  /v1/registry/forwarding/{did}:
+    get:
+      tags:
+        - "Federation"
+      summary: "Get the forwarding pointer for a migrated DID"
+      description: |
+        Return the forwarding pointer for an account DID whose home instance has changed
+        (federation home migration). Callers holding a stale home reference use this to
+        discover the account's new home instance and the signed forwarding record.
+        Developer-token gated.
+      security:
+        - developerToken: []
+      parameters:
+        - name: did
+          in: path
+          required: true
+          description: "Decentralized identifier of the account to resolve a forwarding pointer for."
+          schema:
+            type: string
+            example: "did:units:acct:550e8400-e29b-41d4-a716-446655440000"
+      responses:
+        '200':
+          description: "Forwarding pointer found."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_ForwardingPointer'
+              example:
+                context:
+                  id: "api.registry.forwarding.get"
+                  version: "1.0"
+                  ts: "2026-02-17T10:00:00Z"
+                  msgId: "f8a9b0c1-d2e3-4567-8901-567890123456"
+                  status: "successful"
+                response:
+                  did: "did:units:acct:550e8400-e29b-41d4-a716-446655440000"
+                  new_home_id: "990e8400-e29b-41d4-a716-446655440099"
+                  installed_at: "2026-02-15T09:30:00Z"
+                  grace_until: "2026-05-15T09:30:00Z"
+                  signed_record:
+                    payload: "eyJ..."
+                    signature: "z58DAdFfa9SkqZMVPxAQp..."
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          description: "No forwarding pointer exists for the given DID."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+
+  # -------------------- Instance --------------------
+  /v1/registry/capability/publish:
+    post:
+      tags:
+        - "Instance"
+      summary: "Publish this instance's signed capability document"
+      description: |
+        Operator endpoint. Re-computes and publishes the instance's signed capability
+        document to the federation registry, returning the published instance identifier,
+        the new document version, and the signature. No request payload — the operator
+        trigger carries only the standard envelope context. Developer-token gated (no
+        end-user token) and rate limited.
+      security:
+        - developerToken: []
+        - developerSignature: []
+      requestBody:
+        required: false
+        description: "No business payload; the envelope carries only the standard context."
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestContext'
+            example:
+              context:
+                id: "api.registry.capability.publish"
+                version: "1.0"
+                ts: "2026-02-17T10:00:00Z"
+                msgId: "a9b0c1d2-e3f4-5678-9012-678901234567"
+                developerToken: "fnt_..."
+              payload: {}
+      responses:
+        '200':
+          description: "Capability document published."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_CapabilityPublish'
+              example:
+                context:
+                  id: "api.registry.capability.publish"
+                  version: "1.0"
+                  ts: "2026-02-17T10:00:01Z"
+                  msgId: "a9b0c1d2-e3f4-5678-9012-678901234567"
+                  status: "successful"
+                response:
+                  instance: "https://foundry.finternetlab.io"
+                  version: 7
+                  signature: "z58DAdFfa9SkqZMVPxAQp..."
+                  published_at: "2026-02-17T10:00:01Z"
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+
+  /v1/instance/capabilities:
+    get:
+      tags:
+        - "Instance"
+      summary: "Get this instance's signed capability document"
+      description: |
+        Return the instance's current signed capability document — the free-form, signed
+        descriptor advertising the programs this instance supports (per-program asset
+        models, primitive methods, templates, and operation plans), its signing keys, and
+        the point in time it was generated. Developer-token gated.
+      security:
+        - developerToken: []
+      responses:
+        '200':
+          description: "Signed capability document."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_CapabilityDocument'
+              example:
+                context:
+                  id: "api.instance.capabilities.get"
+                  version: "1.0"
+                  ts: "2026-02-17T10:00:00Z"
+                  msgId: "b0c1d2e3-f4a5-6789-0123-789012345678"
+                  status: "successful"
+                response:
+                  instance: "https://foundry.finternetlab.io"
+                  as_of: "2026-02-17T09:59:00Z"
+                  signing_keys:
+                    - kid: "key-1"
+                      kty: "OKP"
+                      crv: "Ed25519"
+                      x: "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+                  programs:
+                    token:
+                      asset_models: ["fungible", "nft"]
+                      primitive_methods: ["mint", "transfer", "burn"]
+                      templates: ["erc20", "erc721"]
+                      operation_plans: ["transfer", "atomic_swap"]
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+
   # -------------------- Adapter Registry --------------------
   /v1/adapter/register:
     post:
@@ -1299,6 +1461,67 @@ components:
           type: string
           description: "Internal UNITS account ID"
 
+    ForwardingPointerResponse:
+      type: object
+      required: [did, new_home_id, installed_at, grace_until, signed_record]
+      description: "Forwarding pointer for an account whose home instance has migrated."
+      properties:
+        did:
+          type: string
+          description: "Decentralized identifier of the migrated account."
+          example: "did:units:acct:550e8400-e29b-41d4-a716-446655440000"
+        new_home_id:
+          type: string
+          description: "Identifier of the account's new home instance."
+          example: "990e8400-e29b-41d4-a716-446655440099"
+        installed_at:
+          type: string
+          format: date-time
+          description: "When the forwarding pointer was installed."
+        grace_until:
+          type: string
+          format: date-time
+          description: "End of the grace period during which the pointer is honoured."
+        signed_record:
+          type: object
+          additionalProperties: true
+          description: "The signed forwarding record proving the home migration."
+
+    # --- Instance Capability Schemas ---
+
+    CapabilityPublishResponse:
+      type: object
+      required: [instance, version, signature, published_at]
+      description: "Result of publishing the instance's signed capability document."
+      properties:
+        instance:
+          type: string
+          description: "Identifier of the instance whose capability document was published."
+          example: "https://foundry.finternetlab.io"
+        version:
+          type: integer
+          description: "Version number assigned to the published capability document."
+          example: 7
+        signature:
+          type: string
+          description: "Signature over the published capability document."
+          example: "z58DAdFfa9SkqZMVPxAQp..."
+        published_at:
+          type: string
+          description: "Timestamp at which the document was published (RFC 3339)."
+          example: "2026-02-17T10:00:01Z"
+
+    CapabilityDocument:
+      type: object
+      additionalProperties: true
+      description: |
+        Signed capability document for an instance. A free-form, signed descriptor whose
+        shape is intentionally open (`additionalProperties: true`) and NOT constrained by
+        this API. Top-level fields include `instance`, `as_of`, and `signing_keys`, plus
+        one section per supported program — each advertising its asset models, primitive
+        methods, templates, and operation plans. Consumers must treat unknown fields as
+        forward-compatible additions.
+
     # --- Adapter Registry Schemas ---
 
     Adapter:
@@ -1502,6 +1725,24 @@ components:
         - properties:
             response: { $ref: '#/components/schemas/LookupAddress' }
 
+    ApiResponse_ForwardingPointer:
+      allOf:
+        - $ref: '#/components/schemas/ApiResponse'
+        - properties:
+            response: { $ref: '#/components/schemas/ForwardingPointerResponse' }
+
+    ApiResponse_CapabilityPublish:
+      allOf:
+        - $ref: '#/components/schemas/ApiResponse'
+        - properties:
+            response: { $ref: '#/components/schemas/CapabilityPublishResponse' }
+
+    ApiResponse_CapabilityDocument:
+      allOf:
+        - $ref: '#/components/schemas/ApiResponse'
+        - properties:
+            response: { $ref: '#/components/schemas/CapabilityDocument' }
+
     ApiRequest_RegisterAdapterRequest:
       allOf:
         - $ref: '#/components/schemas/RequestContext'
@@ -1546,7 +1787,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "AUTHENTICATION_FAILED", message: "Token invalid or expired." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
       description: "Forbidden. Insufficient permissions."
@@ -1554,7 +1795,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "PERMISSION_DENIED", message: "Insufficient permissions." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions." } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -1570,7 +1811,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "Invalid request parameters." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
       description: |
@@ -1583,7 +1824,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
 
   # -------------------- Security --------------------

--- a/api/registry-interfaces.yaml
+++ b/api/registry-interfaces.yaml
@@ -2,49 +2,25 @@ openapi: 3.0.4
 info:
   title: "Finternet API - Registry Service"
   description: |
-    API specification for the Finternet Registry service — chain and wallet provider registries.
+    API specification for the Finternet Registry service: chain and wallet provider registries.
 
     These registries are centrally managed by UNITS and consumed by App Backends.
     Token class registry endpoints are defined in `token-interfaces.yaml` under `/v1/registry/tokenclasses/*`.
 
-    ### Protocol-Agnostic Envelope
-    All API interactions use a standard JSON envelope.
+    ### Envelope
 
-    **Request Envelope:**
-    ```json
-    {
-      "context": { ... },
-      "payload": { ... },
-      "signature": { ... } // Optional
-    }
-    ```
+    All endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
+    On failure `context.status` is `failed`, `context.error` carries a `code` and a
+    `message`, and `response` is empty.
 
-    **Response Envelope (Success):**
-    ```json
-    {
-      "context": { ..., "status": "successful" },
-      "response": { ... }
-    }
-    ```
+    ### Authentication
 
-    **Response Envelope (Error):**
-    ```json
-    {
-      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." }},
-      "response": {} // Empty on error
-    }
-    ```
-
-    ### Authentication and Authorization
-    This API uses the same two-level authorization model as the other UNITS services:
-
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
-        * `context.developerSignature`: The B2B Developer's signature.
-
-    2.  **Admin-Level Authorization:**
-        * Write operations (register, update) require admin privileges.
-        * Read operations (get, search) require developer authentication only.
+    * `context.developerToken`: the calling application's developer token. Required on
+      every endpoint.
+    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
+      `Signature` header.
+    * `context.authorization`: the end user's session token, required by the endpoints
+      that act on a signed-in user. Each operation states when it is needed.
 
     ### RBAC Scopes
 
@@ -62,15 +38,15 @@ info:
     | `POST /v1/adapter/update` | `registry-adapters:manage` |
     | `POST /v1/adapter/get` | `registry-adapters:view` |
     | `POST /v1/adapter/search` | `registry-adapters:view` |
-    | `POST /v1/registry/capability/publish` | *(operator — developer token; no user scope)* |
+    | `POST /v1/registry/capability/publish` | *(developer token only)* |
     | `GET /v1/registry/forwarding/{did}` | *(developer token)* |
     | `GET /v1/instance/capabilities` | *(developer token)* |
 
     ### Rate limiting
 
-    Requests are subject to a scope-tier sliding-window rate limiter. When the limit
-    is exceeded the service responds with `429 Too Many Requests` and a `Retry-After`
-    header (see the `RateLimitedError` response component).
+    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
+    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
+    the tier assigned to the calling client.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -84,9 +60,8 @@ tags:
     description: "Endpoints for wallet provider registry management. Policy allow-list for wallet apps."
   - name: "Adapter Registry"
     description: |
-      Endpoints for adapter service registry management. The AdapterOrchestrator uses
-      this table for priority-based routing of chain operations. All adapter endpoints
-      require both Developer and end-user authentication.
+      Endpoints for adapter service registry management. Used to route chain operations
+      to adapters by priority. All adapter endpoints require a user session token.
   - name: "Federation"
     description: |
       Federation address resolution. Resolves an on-chain (chainId, address) pair to the
@@ -238,6 +213,8 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '409':
           description: "Chain with this networkId already exists"
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/chains/update:
     post:
@@ -245,7 +222,7 @@ paths:
         - "Chain Registry"
       summary: "Update chain registry entry"
       description: |
-        Update a chain's configuration — adapters, status, or metadata.
+        Update a chain's configuration: adapters, status, or metadata.
         Use this to add/remove adapters, change priorities, or deactivate a chain.
       security:
         - developerToken: []
@@ -299,6 +276,8 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '404':
           $ref: '#/components/responses/NotFoundError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/chains/get:
     post:
@@ -334,6 +313,10 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/chains/search:
     post:
@@ -428,6 +411,10 @@ paths:
                     offset: 0
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   # -------------------- Wallet Provider Registry --------------------
   /v1/registry/wallets/register:
@@ -437,7 +424,7 @@ paths:
       summary: "Register a wallet provider"
       description: |
         Register a wallet application in the provider registry. This is a policy allow-list
-        consumed by App Backends — not enforced by UNITS directly.
+        consumed by the calling application and not enforced by UNITS directly.
         Uses `rdns` (EIP-6963 standard) as the universal, library-agnostic identifier.
       security:
         - developerToken: []
@@ -544,6 +531,8 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '409':
           description: "Wallet provider with this rdns already exists"
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/wallets/update:
     post:
@@ -600,6 +589,8 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '404':
           $ref: '#/components/responses/NotFoundError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/wallets/get:
     post:
@@ -635,6 +626,10 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/wallets/search:
     post:
@@ -725,6 +720,10 @@ paths:
                     offset: 0
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   # -------------------- Federation --------------------
   /v1/registry/forwarding/{did}:
@@ -778,6 +777,8 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   # -------------------- Instance --------------------
   /v1/registry/capability/publish:
@@ -788,9 +789,8 @@ paths:
       description: |
         Operator endpoint. Re-computes and publishes the instance's signed capability
         document to the federation registry, returning the published instance identifier,
-        the new document version, and the signature. No request payload — the operator
-        trigger carries only the standard envelope context. Developer-token gated (no
-        end-user token) and rate limited.
+        the new document version, and the signature. There is no request payload. No user
+        session token is required.
       security:
         - developerToken: []
         - developerSignature: []
@@ -841,10 +841,10 @@ paths:
         - "Instance"
       summary: "Get this instance's signed capability document"
       description: |
-        Return the instance's current signed capability document — the free-form, signed
-        descriptor advertising the programs this instance supports (per-program asset
-        models, primitive methods, templates, and operation plans), its signing keys, and
-        the point in time it was generated. Developer-token gated.
+        Return the instance's current signed capability document: the signed descriptor
+        advertising the programs this instance supports (per-program asset models,
+        primitive methods, templates, and operation plans), its signing keys, and the time
+        it was generated. No user session token is required.
       security:
         - developerToken: []
       responses:
@@ -879,6 +879,8 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   # -------------------- Adapter Registry --------------------
   /v1/adapter/register:
@@ -889,7 +891,7 @@ paths:
       description: |
         Register a new adapter service instance in the adapter registry. Each adapter
         declares the chains it serves via `chainIds[]`. The AdapterOrchestrator uses this
-        table for priority-based routing. Requires Developer + User auth.
+        table for priority-based routing. Requires a user session token.
       security:
         - developerToken: []
         - userToken: []
@@ -952,6 +954,8 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '409':
           description: "Adapter with this adapterId already exists"
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/adapter/update:
     post:
@@ -960,7 +964,7 @@ paths:
       summary: "Update an adapter"
       description: |
         Update an adapter's configuration. Only the fields provided in the payload are
-        updated. Requires Developer + User auth.
+        updated. Requires a user session token.
       security:
         - developerToken: []
         - userToken: []
@@ -997,13 +1001,15 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '404':
           $ref: '#/components/responses/NotFoundError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/adapter/get:
     post:
       tags:
         - "Adapter Registry"
       summary: "Get adapter details"
-      description: "Retrieve details of a specific adapter by its adapter ID. Requires Developer + User auth."
+      description: "Retrieve details of a specific adapter by its adapter ID. Requires a user session token."
       security:
         - developerToken: []
         - userToken: []
@@ -1034,13 +1040,17 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/adapter/search:
     post:
       tags:
         - "Adapter Registry"
       summary: "Search adapters"
-      description: "Search and list registered adapters with filters and pagination. Requires Developer + User auth."
+      description: "Search and list registered adapters with filters and pagination. Requires a user session token."
       security:
         - developerToken: []
         - userToken: []
@@ -1101,6 +1111,10 @@ paths:
                     offset: 0
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
 # ===============================================================
 #   COMPONENTS
@@ -1210,8 +1224,8 @@ components:
           additionalProperties: true
         identities:
           description: |
-            Optional identities associated with the chain. Untyped (interface{}) in the
-            service — any JSON value; the concrete shape is not constrained by the API.
+            Optional identities associated with the chain. Any JSON value; the shape is not
+            constrained by the API.
         createdAt:
           type: string
           format: date-time
@@ -1309,8 +1323,8 @@ components:
           additionalProperties: true
         identities:
           description: |
-            Optional identities associated with the wallet provider. Untyped (interface{})
-            in the service — any JSON value; the concrete shape is not constrained by the API.
+            Optional identities associated with the wallet provider. Any JSON value; the shape
+            is not constrained by the API.
         createdAt:
           type: string
           format: date-time
@@ -1434,7 +1448,7 @@ components:
         Signed capability document for an instance. A free-form, signed descriptor whose
         shape is intentionally open (`additionalProperties: true`) and NOT constrained by
         this API. Top-level fields include `instance`, `as_of`, and `signing_keys`, plus
-        one section per supported program — each advertising its asset models, primitive
+        one section per supported program, each advertising its asset models, primitive
         methods, templates, and operation plans. Consumers must treat unknown fields as
         forward-compatible additions.
 
@@ -1477,8 +1491,8 @@ components:
           description: "Adapter-specific configuration (e.g. url, timeouts)"
         identities:
           description: |
-            Optional adapter identities. Untyped (interface{}) in the service — any JSON
-            value; the concrete shape is not constrained by the API.
+            Optional adapter identities. Any JSON value; the shape is not constrained by the
+            API.
         createdAt:
           type: string
           format: date-time
@@ -1686,7 +1700,7 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed."
+      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -1694,12 +1708,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "Forbidden. Insufficient permissions."
+      description: "The caller does not have the scope required by this endpoint."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -1718,9 +1732,7 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
-      description: |
-        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
-        response header indicates how long the caller should wait before retrying.
+      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }
@@ -1748,5 +1760,5 @@ components:
       scheme: bearer
       bearerFormat: JWT
       description: |
-        End-user JWT session token, passed in `context.authorization` as `Bearer <token>`.
-        Required by the adapter registry endpoints (register, update, get, search).
+        End user's session token, obtained from `/v1/account/login` and passed in
+        `context.authorization` as `Bearer <token>`.

--- a/api/registry-interfaces.yaml
+++ b/api/registry-interfaces.yaml
@@ -7,20 +7,44 @@ info:
     These registries are centrally managed by UNITS and consumed by App Backends.
     Token class registry endpoints are defined in `token-interfaces.yaml` under `/v1/registry/tokenclasses/*`.
 
-    ### Envelope
+    ### Protocol-Agnostic Envelope
+    All API interactions use a standard JSON envelope.
 
-    All endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
-    On failure `context.status` is `failed`, `context.error` carries a `code` and a
-    `message`, and `response` is empty.
+    **Request Envelope:**
+    ```json
+    {
+      "context": { ... },
+      "payload": { ... },
+      "signature": { ... } // Optional
+    }
+    ```
 
-    ### Authentication
+    **Response Envelope (Success):**
+    ```json
+    {
+      "context": { ..., "status": "successful" },
+      "response": { ... }
+    }
+    ```
 
-    * `context.developerToken`: the calling application's developer token. Required on
-      every endpoint.
-    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
-      `Signature` header.
-    * `context.authorization`: the end user's session token, required by the endpoints
-      that act on a signed-in user. Each operation states when it is needed.
+    **Response Envelope (Error):**
+    ```json
+    {
+      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." }},
+      "response": {} // Empty on error
+    }
+    ```
+
+    ### Authentication and Authorization
+    This API uses the same two-level authorization model as the other UNITS services:
+
+    1.  **Platform-Level (Developer) Authentication:**
+        * `context.developerToken`: The B2B Developer's API Key/Token.
+        * `context.developerSignature`: The B2B Developer's signature.
+
+    2.  **Admin-Level Authorization:**
+        * Write operations (register, update) require admin privileges.
+        * Read operations (get, search) require developer authentication only.
 
     ### RBAC Scopes
 
@@ -38,15 +62,15 @@ info:
     | `POST /v1/adapter/update` | `registry-adapters:manage` |
     | `POST /v1/adapter/get` | `registry-adapters:view` |
     | `POST /v1/adapter/search` | `registry-adapters:view` |
-    | `POST /v1/registry/capability/publish` | *(developer token only)* |
+    | `POST /v1/registry/capability/publish` | *(operator: developer token; no user scope)* |
     | `GET /v1/registry/forwarding/{did}` | *(developer token)* |
     | `GET /v1/instance/capabilities` | *(developer token)* |
 
     ### Rate limiting
 
-    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
-    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
-    the tier assigned to the calling client.
+    Requests are subject to a scope-tier sliding-window rate limiter. When the limit
+    is exceeded the service responds with `429 Too Many Requests` and a `Retry-After`
+    header (see the `RateLimitedError` response component).
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -60,8 +84,9 @@ tags:
     description: "Endpoints for wallet provider registry management. Policy allow-list for wallet apps."
   - name: "Adapter Registry"
     description: |
-      Endpoints for adapter service registry management. Used to route chain operations
-      to adapters by priority. All adapter endpoints require a user session token.
+      Endpoints for adapter service registry management. The AdapterOrchestrator uses
+      this table for priority-based routing of chain operations. All adapter endpoints
+      require both Developer and end-user authentication.
   - name: "Federation"
     description: |
       Federation address resolution. Resolves an on-chain (chainId, address) pair to the
@@ -213,8 +238,6 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '409':
           description: "Chain with this networkId already exists"
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/chains/update:
     post:
@@ -276,8 +299,6 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '404':
           $ref: '#/components/responses/NotFoundError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/chains/get:
     post:
@@ -313,10 +334,6 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/chains/search:
     post:
@@ -411,10 +428,6 @@ paths:
                     offset: 0
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   # -------------------- Wallet Provider Registry --------------------
   /v1/registry/wallets/register:
@@ -424,7 +437,7 @@ paths:
       summary: "Register a wallet provider"
       description: |
         Register a wallet application in the provider registry. This is a policy allow-list
-        consumed by the calling application and not enforced by UNITS directly.
+        consumed by App Backends, not enforced by UNITS directly.
         Uses `rdns` (EIP-6963 standard) as the universal, library-agnostic identifier.
       security:
         - developerToken: []
@@ -531,8 +544,6 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '409':
           description: "Wallet provider with this rdns already exists"
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/wallets/update:
     post:
@@ -589,8 +600,6 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '404':
           $ref: '#/components/responses/NotFoundError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/wallets/get:
     post:
@@ -626,10 +635,6 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/wallets/search:
     post:
@@ -720,10 +725,6 @@ paths:
                     offset: 0
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   # -------------------- Federation --------------------
   /v1/registry/forwarding/{did}:
@@ -777,8 +778,6 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   # -------------------- Instance --------------------
   /v1/registry/capability/publish:
@@ -789,8 +788,9 @@ paths:
       description: |
         Operator endpoint. Re-computes and publishes the instance's signed capability
         document to the federation registry, returning the published instance identifier,
-        the new document version, and the signature. There is no request payload. No user
-        session token is required.
+        the new document version, and the signature. No request payload; the operator
+        trigger carries only the standard envelope context. Developer-token gated (no
+        end-user token) and rate limited.
       security:
         - developerToken: []
         - developerSignature: []
@@ -841,10 +841,10 @@ paths:
         - "Instance"
       summary: "Get this instance's signed capability document"
       description: |
-        Return the instance's current signed capability document: the signed descriptor
-        advertising the programs this instance supports (per-program asset models,
-        primitive methods, templates, and operation plans), its signing keys, and the time
-        it was generated. No user session token is required.
+        Return the instance's current signed capability document: the free-form, signed
+        descriptor advertising the programs this instance supports (per-program asset
+        models, primitive methods, templates, and operation plans), its signing keys, and
+        the point in time it was generated. Developer-token gated.
       security:
         - developerToken: []
       responses:
@@ -879,8 +879,6 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   # -------------------- Adapter Registry --------------------
   /v1/adapter/register:
@@ -891,7 +889,7 @@ paths:
       description: |
         Register a new adapter service instance in the adapter registry. Each adapter
         declares the chains it serves via `chainIds[]`. The AdapterOrchestrator uses this
-        table for priority-based routing. Requires a user session token.
+        table for priority-based routing. Requires Developer + User auth.
       security:
         - developerToken: []
         - userToken: []
@@ -954,8 +952,6 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '409':
           description: "Adapter with this adapterId already exists"
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/adapter/update:
     post:
@@ -964,7 +960,7 @@ paths:
       summary: "Update an adapter"
       description: |
         Update an adapter's configuration. Only the fields provided in the payload are
-        updated. Requires a user session token.
+        updated. Requires Developer + User auth.
       security:
         - developerToken: []
         - userToken: []
@@ -1001,15 +997,13 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '404':
           $ref: '#/components/responses/NotFoundError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/adapter/get:
     post:
       tags:
         - "Adapter Registry"
       summary: "Get adapter details"
-      description: "Retrieve details of a specific adapter by its adapter ID. Requires a user session token."
+      description: "Retrieve details of a specific adapter by its adapter ID. Requires Developer + User auth."
       security:
         - developerToken: []
         - userToken: []
@@ -1040,17 +1034,13 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/adapter/search:
     post:
       tags:
         - "Adapter Registry"
       summary: "Search adapters"
-      description: "Search and list registered adapters with filters and pagination. Requires a user session token."
+      description: "Search and list registered adapters with filters and pagination. Requires Developer + User auth."
       security:
         - developerToken: []
         - userToken: []
@@ -1111,10 +1101,6 @@ paths:
                     offset: 0
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
 # ===============================================================
 #   COMPONENTS
@@ -1224,8 +1210,8 @@ components:
           additionalProperties: true
         identities:
           description: |
-            Optional identities associated with the chain. Any JSON value; the shape is not
-            constrained by the API.
+            Optional identities associated with the chain. Untyped (interface{}) in the
+            service, any JSON value; the concrete shape is not constrained by the API.
         createdAt:
           type: string
           format: date-time
@@ -1323,8 +1309,8 @@ components:
           additionalProperties: true
         identities:
           description: |
-            Optional identities associated with the wallet provider. Any JSON value; the shape
-            is not constrained by the API.
+            Optional identities associated with the wallet provider. Untyped (interface{})
+            in the service, any JSON value; the concrete shape is not constrained by the API.
         createdAt:
           type: string
           format: date-time
@@ -1491,8 +1477,8 @@ components:
           description: "Adapter-specific configuration (e.g. url, timeouts)"
         identities:
           description: |
-            Optional adapter identities. Any JSON value; the shape is not constrained by the
-            API.
+            Optional adapter identities. Untyped (interface{}) in the service, any JSON
+            value; the concrete shape is not constrained by the API.
         createdAt:
           type: string
           format: date-time
@@ -1700,7 +1686,7 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
+      description: "Authentication failed."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -1708,12 +1694,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "The caller does not have the scope required by this endpoint."
+      description: "Forbidden. Insufficient permissions."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions." } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -1732,7 +1718,9 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
-      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }
@@ -1760,5 +1748,5 @@ components:
       scheme: bearer
       bearerFormat: JWT
       description: |
-        End user's session token, obtained from `/v1/account/login` and passed in
-        `context.authorization` as `Bearer <token>`.
+        End-user JWT session token, passed in `context.authorization` as `Bearer <token>`.
+        Required by the adapter registry endpoints (register, update, get, search).

--- a/api/registry-interfaces.yaml
+++ b/api/registry-interfaces.yaml
@@ -50,14 +50,18 @@ info:
 
     | Endpoint | Required scope |
     |----------|----------------|
-    | `POST /v1/registry/chains/register` | `chains:manage` |
-    | `POST /v1/registry/chains/update` | `chains:manage` |
-    | `POST /v1/registry/chains/get` | `chains:view` |
-    | `POST /v1/registry/chains/search` | `chains:view` |
-    | `POST /v1/registry/wallets/register` | `wallets:manage` |
-    | `POST /v1/registry/wallets/update` | `wallets:manage` |
-    | `POST /v1/registry/wallets/get` | `wallets:view` |
-    | `POST /v1/registry/wallets/search` | `wallets:view` |
+    | `POST /v1/registry/chains/register` | `registry-chains:create` |
+    | `POST /v1/registry/chains/update` | `registry-chains:manage` |
+    | `POST /v1/registry/chains/get` | `registry-chains:view` |
+    | `POST /v1/registry/chains/search` | `registry-chains:view` |
+    | `POST /v1/registry/wallets/register` | `registry-wallets:create` |
+    | `POST /v1/registry/wallets/update` | `registry-wallets:manage` |
+    | `POST /v1/registry/wallets/get` | `registry-wallets:view` |
+    | `POST /v1/registry/wallets/search` | `registry-wallets:view` |
+    | `POST /v1/adapter/register` | `registry-adapters:create` |
+    | `POST /v1/adapter/update` | `registry-adapters:manage` |
+    | `POST /v1/adapter/get` | `registry-adapters:view` |
+    | `POST /v1/adapter/search` | `registry-adapters:view` |
 
     ### Rate limiting
 
@@ -75,6 +79,15 @@ tags:
     description: "Endpoints for chain registry management. Routes chain IDs to adapter services."
   - name: "Wallet Provider Registry"
     description: "Endpoints for wallet provider registry management. Policy allow-list for wallet apps."
+  - name: "Adapter Registry"
+    description: |
+      Endpoints for adapter service registry management. The AdapterOrchestrator uses
+      this table for priority-based routing of chain operations. All adapter endpoints
+      require both Developer and end-user authentication.
+  - name: "Federation"
+    description: |
+      Federation address resolution. Resolves an on-chain (chain_id, address) pair to the
+      owning UNITS account, its DID, and home instance. Developer-token gated.
 
 # ===============================================================
 #   PATHS
@@ -108,21 +121,12 @@ paths:
                     version: "1.0"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     networkId: "eip155:1"
                     name: "Ethereum Mainnet"
                     chainFamily: "evm"
                     isTestnet: false
-                    adapters:
-                      - url: "https://adapter-alchemy.finternet.io"
-                        type: "alchemy"
-                        priority: 1
-                        status: "active"
-                      - url: "https://adapter-kwala.finternet.io"
-                        type: "kwala"
-                        priority: 2
-                        status: "active"
                     metadata:
                       iconUrl: "https://assets.finternet.io/chains/ethereum.svg"
                       explorers:
@@ -142,17 +146,12 @@ paths:
                     version: "1.0"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef0"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     networkId: "eip155:137"
                     name: "Polygon Mainnet"
                     chainFamily: "evm"
                     isTestnet: false
-                    adapters:
-                      - url: "https://adapter-alchemy.finternet.io"
-                        type: "alchemy"
-                        priority: 1
-                        status: "active"
                     metadata:
                       iconUrl: "https://assets.finternet.io/chains/polygon.svg"
                       explorers:
@@ -172,17 +171,12 @@ paths:
                     version: "1.0"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef01"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     networkId: "eip155:11155111"
                     name: "Sepolia Testnet"
                     chainFamily: "evm"
                     isTestnet: true
-                    adapters:
-                      - url: "https://adapter-alchemy-testnet.finternet.io"
-                        type: "alchemy"
-                        priority: 1
-                        status: "active"
                     metadata:
                       iconUrl: "https://assets.finternet.io/chains/ethereum.svg"
                       explorers:
@@ -214,15 +208,6 @@ paths:
                   chainFamily: "evm"
                   isTestnet: false
                   status: "ACTIVE"
-                  adapters:
-                    - url: "https://adapter-alchemy.finternet.io"
-                      type: "alchemy"
-                      priority: 1
-                      status: "active"
-                    - url: "https://adapter-kwala.finternet.io"
-                      type: "kwala"
-                      priority: 2
-                      status: "active"
                   metadata:
                     iconUrl: "https://assets.finternet.io/chains/ethereum.svg"
                     explorers:
@@ -263,30 +248,21 @@ paths:
             schema:
               $ref: '#/components/schemas/ApiRequest_UpdateChainRequest'
             examples:
-              add_adapter:
-                summary: "Add a new adapter to Ethereum"
+              update_metadata:
+                summary: "Update Ethereum name and metadata"
                 value:
                   context:
                     id: "api.registry.chains.update"
                     version: "1.0"
                     ts: "2026-02-17T11:00:00Z"
                     msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef012"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     networkId: "eip155:1"
-                    adapters:
-                      - url: "https://adapter-alchemy.finternet.io"
-                        type: "alchemy"
-                        priority: 1
-                        status: "active"
-                      - url: "https://adapter-kwala.finternet.io"
-                        type: "kwala"
-                        priority: 2
-                        status: "active"
-                      - url: "https://adapter-community.example.io"
-                        type: "community"
-                        priority: 3
-                        status: "active"
+                    name: "Ethereum"
+                    metadata:
+                      iconUrl: "https://assets.finternet.io/chains/ethereum.svg"
+                      blockTime: 12
               deactivate_chain:
                 summary: "Deactivate a chain"
                 value:
@@ -295,7 +271,7 @@ paths:
                     version: "1.0"
                     ts: "2026-02-17T11:00:00Z"
                     msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef0123"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     networkId: "eip155:11155111"
                     status: "INACTIVE"
@@ -335,7 +311,7 @@ paths:
                 version: "1.0"
                 ts: "2026-02-17T10:00:00Z"
                 msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef01234"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
               payload:
                 networkId: "eip155:1"
       responses:
@@ -373,7 +349,7 @@ paths:
                     version: "1.0"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "a7b8c9d0-e1f2-3456-7890-abcdef012345"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     filters:
                       status: "ACTIVE"
@@ -392,7 +368,7 @@ paths:
                     version: "1.0"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "b8c9d0e1-f2a3-4567-8901-bcdef0123456"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     filters:
                       chainFamily: "evm"
@@ -421,11 +397,6 @@ paths:
                       chainFamily: "evm"
                       isTestnet: false
                       status: "ACTIVE"
-                      adapters:
-                        - url: "https://adapter-alchemy.finternet.io"
-                          type: "alchemy"
-                          priority: 1
-                          status: "active"
                       metadata:
                         iconUrl: "https://assets.finternet.io/chains/ethereum.svg"
                         nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 }
@@ -437,11 +408,6 @@ paths:
                       chainFamily: "evm"
                       isTestnet: false
                       status: "ACTIVE"
-                      adapters:
-                        - url: "https://adapter-alchemy.finternet.io"
-                          type: "alchemy"
-                          priority: 1
-                          status: "active"
                       metadata:
                         iconUrl: "https://assets.finternet.io/chains/polygon.svg"
                         nativeCurrency: { name: "POL", symbol: "POL", decimals: 18 }
@@ -482,7 +448,7 @@ paths:
                     version: "1.0"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "c9d0e1f2-a3b4-5678-9012-cdef01234567"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     name: "MetaMask"
                     rdns: "io.metamask"
@@ -502,7 +468,7 @@ paths:
                     version: "1.0"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "d0e1f2a3-b4c5-6789-0123-def012345678"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     name: "Coinbase Wallet"
                     rdns: "com.coinbase.wallet"
@@ -521,7 +487,7 @@ paths:
                     version: "1.0"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "e1f2a3b4-c5d6-7890-1234-ef0123456789"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     name: "Trust Wallet"
                     rdns: "com.trustwallet.app"
@@ -594,7 +560,7 @@ paths:
                     version: "1.0"
                     ts: "2026-02-17T11:00:00Z"
                     msgId: "f2a3b4c5-d6e7-8901-2345-f01234567890"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     rdns: "io.metamask"
                     supportedChains: ["eip155:1", "eip155:137", "eip155:8453", "eip155:42161", "eip155:56", "eip155:10", "eip155:59144"]
@@ -606,7 +572,7 @@ paths:
                     version: "1.0"
                     ts: "2026-02-17T11:00:00Z"
                     msgId: "a3b4c5d6-e7f8-9012-3456-012345678901"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     rdns: "com.suspicious.wallet"
                     status: "BLOCKED"
@@ -646,7 +612,7 @@ paths:
                 version: "1.0"
                 ts: "2026-02-17T10:00:00Z"
                 msgId: "b4c5d6e7-f8a9-0123-4567-123456789012"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
               payload:
                 rdns: "io.metamask"
       responses:
@@ -684,7 +650,7 @@ paths:
                     version: "1.0"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "c5d6e7f8-a9b0-1234-5678-234567890123"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     filters:
                       status: "ACTIVE"
@@ -699,7 +665,7 @@ paths:
                     version: "1.0"
                     ts: "2026-02-17T10:00:00Z"
                     msgId: "d6e7f8a9-b0c1-2345-6789-345678901234"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     filters:
                       "supportedChains": "eip155:1"
@@ -746,6 +712,282 @@ paths:
                       updatedAt: "2026-02-17T10:00:00Z"
                   pagination:
                     total: 2
+                    limit: 50
+                    offset: 0
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+
+  # -------------------- Federation --------------------
+  /v1/registry/lookup-address:
+    post:
+      tags:
+        - "Federation"
+      summary: "Resolve an on-chain address to a UNITS account"
+      description: |
+        Resolve an on-chain `(chain_id, address)` pair to the owning UNITS account —
+        returning its DID, home instance, and account ID. Developer-token gated.
+      security:
+        - developerToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_LookupAddressRequest'
+            example:
+              context:
+                id: "api.registry.lookup.address"
+                version: "1.0"
+                ts: "2026-02-17T10:00:00Z"
+                msgId: "e7f8a9b0-c1d2-3456-7890-456789012345"
+                developerToken: "fnt_..."
+              payload:
+                chain_id: "eip155:1"
+                address: "0x1111111111111111111111111111111111111111"
+      responses:
+        '200':
+          description: "Address resolved"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_LookupAddress'
+              example:
+                context:
+                  id: "api.registry.lookup.address"
+                  version: "1.0"
+                  ts: "2026-02-17T10:00:00Z"
+                  msgId: "e7f8a9b0-c1d2-3456-7890-456789012345"
+                  status: "successful"
+                response:
+                  did: "did:units:acct:550e8400-e29b-41d4-a716-446655440000"
+                  home_instance: "https://foundry.finternetlab.io"
+                  account_id: "550e8400-e29b-41d4-a716-446655440000"
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+
+  # -------------------- Adapter Registry --------------------
+  /v1/adapter/register:
+    post:
+      tags:
+        - "Adapter Registry"
+      summary: "Register a new adapter"
+      description: |
+        Register a new adapter service instance in the adapter registry. Each adapter
+        declares the chains it serves via `chainIds[]`. The AdapterOrchestrator uses this
+        table for priority-based routing. Requires Developer + User auth.
+      security:
+        - developerToken: []
+        - userToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_RegisterAdapterRequest'
+            example:
+              context:
+                id: "api.adapter.register"
+                version: "1.0"
+                ts: "2026-03-05T10:00:00Z"
+                msgId: "f5a6b7c8-d9e0-1234-f012-567890abcdef"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                adapterId: "alchemy_chain_adapter"
+                name: "Alchemy Chain Adapter"
+                type: "chain"
+                chainIds: ["eip155:1", "eip155:8453", "eip155:11155111"]
+                priority: 1
+                active: true
+                config:
+                  url: "http://chain-adapter:3500"
+                  timeoutMs: 5000
+      responses:
+        '201':
+          description: "Adapter registered successfully"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_AdapterDetails'
+              example:
+                context:
+                  id: "api.adapter.register"
+                  version: "1.0"
+                  ts: "2026-03-05T10:00:00Z"
+                  msgId: "f5a6b7c8-d9e0-1234-f012-567890abcdef"
+                  status: "successful"
+                response:
+                  id: "990e8400-e29b-41d4-a716-446655440004"
+                  adapterId: "alchemy_chain_adapter"
+                  name: "Alchemy Chain Adapter"
+                  type: "chain"
+                  chainIds: ["eip155:1", "eip155:8453", "eip155:11155111"]
+                  priority: 1
+                  active: true
+                  config:
+                    url: "http://chain-adapter:3500"
+                    timeoutMs: 5000
+                  createdAt: "2026-03-05T10:00:00Z"
+                  updatedAt: "2026-03-05T10:00:00Z"
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '409':
+          description: "Adapter with this adapterId already exists"
+
+  /v1/adapter/update:
+    post:
+      tags:
+        - "Adapter Registry"
+      summary: "Update an adapter"
+      description: |
+        Update an adapter's configuration. Only the fields provided in the payload are
+        updated. Requires Developer + User auth.
+      security:
+        - developerToken: []
+        - userToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_UpdateAdapterRequest'
+            example:
+              context:
+                id: "api.adapter.update"
+                version: "1.0"
+                ts: "2026-03-05T11:00:00Z"
+                msgId: "a6b7c8d9-e0f1-2345-0123-67890abcdef0"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                adapterId: "alchemy_chain_adapter"
+                chainIds: ["eip155:1", "eip155:8453", "eip155:11155111", "eip155:137"]
+                priority: 2
+      responses:
+        '200':
+          description: "Adapter updated successfully"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_AdapterDetails'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+
+  /v1/adapter/get:
+    post:
+      tags:
+        - "Adapter Registry"
+      summary: "Get adapter details"
+      description: "Retrieve details of a specific adapter by its adapter ID. Requires Developer + User auth."
+      security:
+        - developerToken: []
+        - userToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_GetAdapterRequest'
+            example:
+              context:
+                id: "api.adapter.get"
+                version: "1.0"
+                ts: "2026-03-05T10:00:00Z"
+                msgId: "b7c8d9e0-f1a2-3456-1234-7890abcdef01"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                adapterId: "alchemy_chain_adapter"
+      responses:
+        '200':
+          description: "Adapter details retrieved"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_AdapterDetails'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+
+  /v1/adapter/search:
+    post:
+      tags:
+        - "Adapter Registry"
+      summary: "Search adapters"
+      description: "Search and list registered adapters with filters and pagination. Requires Developer + User auth."
+      security:
+        - developerToken: []
+        - userToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_SearchAdapterRequest'
+            example:
+              context:
+                id: "api.adapter.search"
+                version: "1.0"
+                ts: "2026-03-05T10:00:00Z"
+                msgId: "c8d9e0f1-a2b3-4567-2345-890abcdef012"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                filters:
+                  type: "chain"
+                  active: true
+                pagination:
+                  limit: 50
+                  offset: 0
+                sortBy:
+                  field: "priority"
+                  order: "asc"
+      responses:
+        '200':
+          description: "Adapter list retrieved"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_AdapterList'
+              example:
+                context:
+                  id: "api.adapter.search"
+                  version: "1.0"
+                  ts: "2026-03-05T10:00:00Z"
+                  msgId: "c8d9e0f1-a2b3-4567-2345-890abcdef012"
+                  status: "successful"
+                response:
+                  adapters:
+                    - id: "990e8400-e29b-41d4-a716-446655440004"
+                      adapterId: "alchemy_chain_adapter"
+                      name: "Alchemy Chain Adapter"
+                      type: "chain"
+                      chainIds: ["eip155:1", "eip155:8453"]
+                      priority: 1
+                      active: true
+                      config:
+                        url: "http://chain-adapter:3500"
+                      createdAt: "2026-03-05T10:00:00Z"
+                      updatedAt: "2026-03-05T10:00:00Z"
+                  pagination:
+                    total: 1
                     limit: 50
                     offset: 0
         '401':
@@ -823,34 +1065,9 @@ components:
 
     # --- Chain Registry Schemas ---
 
-    AdapterConfig:
-      type: object
-      required: [url, type, priority, status]
-      description: "Configuration for a chain adapter service"
-      properties:
-        url:
-          type: string
-          format: uri
-          description: "Base URL of the adapter service"
-          example: "https://adapter-alchemy.finternet.io"
-        type:
-          type: string
-          description: "Adapter type identifier (e.g., alchemy, kwala, community)"
-          example: "alchemy"
-        priority:
-          type: integer
-          minimum: 1
-          description: "Selection priority (1 = highest). Used for failover ordering."
-          example: 1
-        status:
-          type: string
-          enum: [active, inactive, deprecated]
-          description: "Adapter operational status"
-          example: "active"
-
     Chain:
       type: object
-      required: [id, networkId, name, chainFamily, isTestnet, status, adapters]
+      required: [id, networkId, name, chainFamily, isTestnet, status]
       description: "Blockchain network registry entry"
       properties:
         id:
@@ -878,14 +1095,14 @@ components:
           enum: [ACTIVE, INACTIVE, DEPRECATED]
           description: "Registry status"
           example: "ACTIVE"
-        adapters:
-          type: array
-          items: { $ref: '#/components/schemas/AdapterConfig' }
-          description: "Adapter service configurations, ordered by priority"
         metadata:
           type: object
           description: "Extensible chain metadata (icons, explorers, native currency, etc.)"
           additionalProperties: true
+        identities:
+          description: |
+            Optional identities associated with the chain. Untyped (interface{}) in the
+            service — any JSON value; the concrete shape is not constrained by the API.
         createdAt:
           type: string
           format: date-time
@@ -901,9 +1118,6 @@ components:
         name: { type: string, example: "Ethereum Mainnet" }
         chainFamily: { type: string, enum: [evm, solana, cosmos, substrate] }
         isTestnet: { type: boolean, default: false }
-        adapters:
-          type: array
-          items: { $ref: '#/components/schemas/AdapterConfig' }
         metadata:
           type: object
           additionalProperties: true
@@ -914,11 +1128,9 @@ components:
       properties:
         networkId: { type: string, example: "eip155:1" }
         name: { type: string }
+        chainFamily: { type: string, enum: [evm, solana, cosmos, substrate] }
+        isTestnet: { type: boolean }
         status: { type: string, enum: [ACTIVE, INACTIVE, DEPRECATED] }
-        adapters:
-          type: array
-          items: { $ref: '#/components/schemas/AdapterConfig' }
-          description: "Full replacement of adapters list"
         metadata:
           type: object
           additionalProperties: true
@@ -943,7 +1155,7 @@ components:
             isTestnet: { type: boolean, description: "Filter by testnet flag" }
           additionalProperties: true
         pagination: { $ref: '#/components/schemas/PaginationRequest' }
-        sort: { $ref: '#/components/schemas/SortRequest' }
+        sortBy: { $ref: '#/components/schemas/SortRequest' }
 
     ChainList:
       type: object
@@ -986,6 +1198,10 @@ components:
           type: object
           description: "Extensible wallet metadata (icon, website, platforms, deep links, etc.)"
           additionalProperties: true
+        identities:
+          description: |
+            Optional identities associated with the wallet provider. Untyped (interface{})
+            in the service — any JSON value; the concrete shape is not constrained by the API.
         createdAt:
           type: string
           format: date-time
@@ -1040,7 +1256,7 @@ components:
             supportedChains: { type: string, description: "Filter by a chain ID the wallet supports" }
           additionalProperties: true
         pagination: { $ref: '#/components/schemas/PaginationRequest' }
-        sort: { $ref: '#/components/schemas/SortRequest' }
+        sortBy: { $ref: '#/components/schemas/SortRequest' }
 
     WalletProviderList:
       type: object
@@ -1048,6 +1264,156 @@ components:
         walletProviders:
           type: array
           items: { $ref: '#/components/schemas/WalletProvider' }
+        pagination: { $ref: '#/components/schemas/PaginationResponse' }
+
+    # --- Federation Schemas ---
+
+    LookupAddressRequest:
+      type: object
+      required: [chain_id, address]
+      additionalProperties: false
+      properties:
+        chain_id:
+          type: string
+          minLength: 1
+          description: "CAIP-2 chain identifier"
+          example: "eip155:1"
+        address:
+          type: string
+          minLength: 1
+          description: "On-chain address to resolve"
+          example: "0x1111111111111111111111111111111111111111"
+
+    LookupAddress:
+      type: object
+      required: [did, home_instance, account_id]
+      description: "Resolved UNITS account for an on-chain address"
+      properties:
+        did:
+          type: string
+          description: "Decentralized identifier of the owning account"
+        home_instance:
+          type: string
+          description: "Home UNITS instance URL for the account"
+        account_id:
+          type: string
+          description: "Internal UNITS account ID"
+
+    # --- Adapter Registry Schemas ---
+
+    Adapter:
+      type: object
+      required: [id, adapterId, name, type, chainIds, priority, active, config, createdAt, updatedAt]
+      description: "Adapter service registry entry, used by the AdapterOrchestrator for priority-based routing."
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: "Internal registry ID"
+        adapterId:
+          type: string
+          description: "Client-supplied unique adapter identifier"
+          example: "alchemy_chain_adapter"
+        name:
+          type: string
+          example: "Alchemy Chain Adapter"
+        type:
+          type: string
+          description: "Adapter type (e.g. chain)"
+          example: "chain"
+        chainIds:
+          type: array
+          items: { type: string }
+          description: "CAIP-2 chain IDs this adapter serves"
+          example: ["eip155:1", "eip155:8453"]
+        priority:
+          type: integer
+          description: "Selection priority (used for failover ordering)"
+          example: 1
+        active:
+          type: boolean
+        config:
+          type: object
+          additionalProperties: true
+          description: "Adapter-specific configuration (e.g. url, timeouts)"
+        identities:
+          description: |
+            Optional adapter identities. Untyped (interface{}) in the service — any JSON
+            value; the concrete shape is not constrained by the API.
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    RegisterAdapterRequest:
+      type: object
+      required: [adapterId, name, chainIds, config]
+      additionalProperties: true
+      properties:
+        adapterId: { type: string, example: "alchemy_chain_adapter" }
+        name: { type: string, example: "Alchemy Chain Adapter" }
+        type: { type: string, description: "Adapter type", example: "chain" }
+        chainIds:
+          type: array
+          items: { type: string }
+          example: ["eip155:1", "eip155:8453"]
+        priority: { type: integer, description: "Selection priority (1 = highest)" }
+        active: { type: boolean }
+        config:
+          type: object
+          additionalProperties: true
+          description: "Adapter-specific configuration"
+
+    UpdateAdapterRequest:
+      type: object
+      required: [adapterId]
+      additionalProperties: true
+      properties:
+        adapterId: { type: string, example: "alchemy_chain_adapter" }
+        name: { type: string }
+        type: { type: string }
+        chainIds:
+          type: array
+          items: { type: string }
+        priority: { type: integer }
+        active: { type: boolean }
+        config:
+          type: object
+          additionalProperties: true
+
+    GetAdapterRequest:
+      type: object
+      required: [adapterId]
+      properties:
+        adapterId: { type: string, example: "alchemy_chain_adapter" }
+
+    SearchAdapterRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          description: |
+            Search filters for adapters. Common fields: type, active.
+          properties:
+            type: { type: string }
+            active: { type: boolean }
+          additionalProperties: true
+        pagination: { $ref: '#/components/schemas/PaginationRequest' }
+        sortBy:
+          type: object
+          description: "Sort options. `field` is free-form; `order` is asc or desc."
+          properties:
+            field: { type: string }
+            order: { type: string, enum: [asc, desc] }
+
+    AdapterList:
+      type: object
+      properties:
+        adapters:
+          type: array
+          items: { $ref: '#/components/schemas/Adapter' }
         pagination: { $ref: '#/components/schemas/PaginationResponse' }
 
     # --- Request Envelopes ---
@@ -1124,6 +1490,54 @@ components:
         - properties:
             response: { $ref: '#/components/schemas/WalletProviderList' }
 
+    ApiRequest_LookupAddressRequest:
+      allOf:
+        - $ref: '#/components/schemas/RequestContext'
+        - properties:
+            payload: { $ref: '#/components/schemas/LookupAddressRequest' }
+
+    ApiResponse_LookupAddress:
+      allOf:
+        - $ref: '#/components/schemas/ApiResponse'
+        - properties:
+            response: { $ref: '#/components/schemas/LookupAddress' }
+
+    ApiRequest_RegisterAdapterRequest:
+      allOf:
+        - $ref: '#/components/schemas/RequestContext'
+        - properties:
+            payload: { $ref: '#/components/schemas/RegisterAdapterRequest' }
+
+    ApiRequest_UpdateAdapterRequest:
+      allOf:
+        - $ref: '#/components/schemas/RequestContext'
+        - properties:
+            payload: { $ref: '#/components/schemas/UpdateAdapterRequest' }
+
+    ApiRequest_GetAdapterRequest:
+      allOf:
+        - $ref: '#/components/schemas/RequestContext'
+        - properties:
+            payload: { $ref: '#/components/schemas/GetAdapterRequest' }
+
+    ApiRequest_SearchAdapterRequest:
+      allOf:
+        - $ref: '#/components/schemas/RequestContext'
+        - properties:
+            payload: { $ref: '#/components/schemas/SearchAdapterRequest' }
+
+    ApiResponse_AdapterDetails:
+      allOf:
+        - $ref: '#/components/schemas/ApiResponse'
+        - properties:
+            response: { $ref: '#/components/schemas/Adapter' }
+
+    ApiResponse_AdapterList:
+      allOf:
+        - $ref: '#/components/schemas/ApiResponse'
+        - properties:
+            response: { $ref: '#/components/schemas/AdapterList' }
+
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
@@ -1184,3 +1598,10 @@ components:
       in: header
       name: Signature
       description: "IETF HTTP Signature (RFC 9421) for message integrity."
+    userToken:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: |
+        End-user JWT session token, passed in `context.authorization` as `Bearer <token>`.
+        Required by the adapter registry endpoints (register, update, get, search).

--- a/api/scopes-interfaces.yaml
+++ b/api/scopes-interfaces.yaml
@@ -11,20 +11,50 @@ info:
     - **Scope approvals** (`/v1/scope-approvals`): admin-facing listing of pending
       (or otherwise-filtered) scope-approval entries, grouped by API client.
 
-    ### Envelope
+    ### Protocol-Agnostic Envelope
+    All API interactions use a standard JSON envelope.
 
-    All endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
-    On failure `context.status` is `failed`, `context.error` carries a `code` and a
-    `message`, and `response` is empty.
+    **Request Envelope:**
+    ```json
+    {
+      "context": { ... },
+      "payload": { ... },
+      "signature": { ... } // Optional
+    }
+    ```
 
-    ### Authentication
+    **Response Envelope (Success):**
+    ```json
+    {
+      "context": { ..., "status": "successful" },
+      "response": { ... }
+    }
+    ```
 
-    * `context.developerToken`: the calling application's developer token. Required on
-      every endpoint.
-    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
-      `Signature` header.
-    * `context.authorization`: the end user's session token, required by the endpoints
-      that act on a signed-in user. Each operation states when it is needed.
+    **Response Envelope (Error):**
+    ```json
+    {
+      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." },
+      "response": {} // Empty on error
+    }
+    ```
+    (Error details are in the context.error object)
+
+    ### Authentication and Authorization
+    This API uses a two-level authorization model contained within the `context`:
+
+    1.  **Platform-Level (Developer) Authentication:**
+        * `context.developerToken`: The B2B Developer's API Key/Token.
+        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
+
+    2.  **User-Level (End-User) Authorization:**
+        * `context.authorization`: The end-user's JWT session token (for session-based calls).
+        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
+
+    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
+
+    All endpoints in this service require **both** developer authentication and a
+    valid end-user session token.
 
     ### RBAC Scopes
 
@@ -32,17 +62,18 @@ info:
     |----------|----------------|
     | `POST /v1/scopes/search` | `scopes:view` |
     | `POST /v1/scopes/apis/search` | `scopes:view` |
-    | `POST /v1/scope-approvals/` | *(scope check applies; see the note below)* |
+    | `POST /v1/scope-approvals/` | *(scope check applies; specific scope key not fixed in source; see note)* |
 
-    Calls failing the scope check return `403`. The scope-approvals list is additionally
-    narrowed by caller role: super admins see all clients, owners see their clients'
-    entries, and other callers see only their own.
+    Scope keys are resolved from the server-side `scope_api` mapping table. Calls
+    failing the scope check return `403 FORBIDDEN`. The scope-approvals
+    list is additionally narrowed server-side by caller role: super admins see
+    all clients, owners see their clients' entries, and other callers see only
+    their own.
 
     ### Rate limiting
 
-    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
-    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
-    the tier assigned to the calling client.
+    All endpoints are protected by a scope-tier sliding-window rate limiter; on
+    breach the response is `429 Too Many Requests` with a `Retry-After` header.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -68,7 +99,9 @@ paths:
       tags: [Scopes]
       summary: "Search scopes catalogue"
       description: |
-        Returns a paginated list of scope entities × actions. Requires a user session token.
+        Returns a paginated list of scope entities × actions. Requires developer
+        authentication and a valid end-user session token, plus the `scopes:view`
+        scope.
       operationId: searchScopes
       security:
         - developerToken: []
@@ -122,7 +155,8 @@ paths:
       summary: "Search scope-to-API mappings"
       description: |
         Returns a paginated list of `(api_id -> scope_key)` mappings that drive
-        per-endpoint authorization. Requires a user session token.
+        per-endpoint authorization. Requires developer authentication and a valid
+        end-user session token, plus the `scopes:view` scope.
       operationId: searchScopeAPIs
       security:
         - developerToken: []
@@ -178,7 +212,8 @@ paths:
         Returns one row per client with at least one scope matching the requested
         status (defaults to `pending`). Results are narrowed server-side by caller
         role: super admins see all clients, owners see their clients' entries, and
-        other callers see only their own. Requires a user session token.
+        other callers see only their own. Requires developer authentication and a
+        valid end-user session token.
       operationId: listScopeApprovals
       security:
         - developerToken: []
@@ -523,7 +558,7 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
+      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -531,12 +566,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "The caller does not have the scope required by this endpoint."
+      description: "Forbidden. Insufficient permissions (scope check failed)."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
             response: {}
     BadRequestError:
       description: "Invalid request."
@@ -547,7 +582,9 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
-      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }

--- a/api/scopes-interfaces.yaml
+++ b/api/scopes-interfaces.yaml
@@ -85,6 +85,8 @@ tags:
     description: "Read-only catalogue of RBAC scopes and api-to-scope mappings."
   - name: "Scope Approval"
     description: "Admin-facing listing of scope-approval entries grouped by client."
+  - name: "User Scopes"
+    description: "Read and replace the scopes granted to a user account."
 
 # ===============================================================
 #   PATHS
@@ -255,6 +257,67 @@ paths:
                           requestedByName: "Alice Smith"
                           requestedAt: "2026-07-08T15:00:00Z"
                           expiresAt: "2026-07-15T15:00:00Z"
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+  /v1/users/scopes/get:
+    post:
+      tags: ["User Scopes"]
+      summary: "Get a user account's granted scopes"
+      description: |
+        Returns the scopes currently granted to the given user account. Requires the
+        `users:view` scope.
+      security:
+        - developerToken: []
+        - developerSignature: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ApiRequest_GetUserScopesRequest' }
+            example:
+              context: { id: "api.users.scopes.get", version: "v1", ts: "2026-04-07T10:00:00Z", msgId: "11111111-2222-3333-4444-555555555555", developerToken: "fnt_..." }
+              payload:
+                account: { accountId: "018f2c3d-4e5f-7890-abcd-1234567890ab" }
+      responses:
+        '200':
+          description: "The account's granted scopes."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiResponse_UserScopes' }
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+  /v1/users/scopes/update:
+    post:
+      tags: ["User Scopes"]
+      summary: "Replace a user account's scopes"
+      description: |
+        Replaces (not merges) the scopes granted to the given user account. Requires
+        the `users:manage` scope.
+      security:
+        - developerToken: []
+        - developerSignature: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ApiRequest_UpdateUserScopesRequest' }
+            example:
+              context: { id: "api.users.scopes.update", version: "v1", ts: "2026-04-07T10:00:00Z", msgId: "22222222-3333-4444-5555-666666666666", developerToken: "fnt_..." }
+              payload:
+                account: { accountId: "018f2c3d-4e5f-7890-abcd-1234567890ab" }
+                scopes: ["tokens:read", "tokens:write"]
+      responses:
+        '200':
+          description: "Updated granted scopes."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiResponse_UserScopes' }
         '400': { $ref: '#/components/responses/BadRequestError' }
         '401': { $ref: '#/components/responses/UnauthorizedError' }
         '403': { $ref: '#/components/responses/ForbiddenError' }
@@ -455,6 +518,30 @@ components:
         limit: { type: integer, example: 50 }
         offset: { type: integer, example: 0 }
 
+    UserAccountRef:
+      type: object
+      description: "Identify the user account by exactly one of `accountId` or `address`."
+      properties:
+        accountId: { type: string, format: uuid }
+        address: { type: string }
+    GetUserScopesRequest:
+      type: object
+      required: [account]
+      properties:
+        account: { $ref: '#/components/schemas/UserAccountRef' }
+    UpdateUserScopesRequest:
+      type: object
+      required: [account, scopes]
+      properties:
+        account: { $ref: '#/components/schemas/UserAccountRef' }
+        scopes: { type: array, items: { type: string }, description: "Replace semantics — the full set of scopes to grant." }
+    UserScopesResponse:
+      type: object
+      required: [accountId, scopes]
+      properties:
+        accountId: { type: string, format: uuid }
+        scopes: { type: array, items: { type: string } }
+
     # --- Specific Request Envelopes ---
     ApiRequest_SearchScopesRequest:       { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/SearchScopesRequest' } } } ] }
     ApiRequest_SearchScopeAPIsRequest:    { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/SearchScopeAPIsRequest' } } } ] }
@@ -464,6 +551,9 @@ components:
     ApiResponse_SearchScopes:       { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/SearchScopesResponse' } } } ] }
     ApiResponse_SearchScopeAPIs:    { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/SearchScopeAPIsResponse' } } } ] }
     ApiResponse_ListScopeApprovals: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/ListScopeApprovalsResponse' } } } ] }
+    ApiRequest_GetUserScopesRequest:    { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/GetUserScopesRequest' } } } ] }
+    ApiRequest_UpdateUserScopesRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/UpdateUserScopesRequest' } } } ] }
+    ApiResponse_UserScopes:             { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/UserScopesResponse' } } } ] }
 
   # -------------------- Responses --------------------
   responses:

--- a/api/scopes-interfaces.yaml
+++ b/api/scopes-interfaces.yaml
@@ -40,18 +40,14 @@ info:
     ```
     (Error details are in the context.error object)
 
-    ### Authentication and Authorization
-    This API uses a two-level authorization model contained within the `context`:
+    ### Authentication
 
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
-
-    2.  **User-Level (End-User) Authorization:**
-        * `context.authorization`: The end-user's JWT session token (for session-based calls).
-        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
-
-    All endpoints in this service require **both** developer authentication and a
-    valid end-user session token.
+    * `context.developerToken`: the developer token of the calling application. Required on
+      every endpoint.
+    * `context.authorization`: the end user's session token. Required on the endpoints that
+      act on a signed-in user; each operation states when it is needed.
+    * `signature` (top level): the end user's JWS over the payload, for operations that must
+      be signed by the user.
 
     ### RBAC Scopes
 
@@ -96,12 +92,10 @@ paths:
       tags: [Scopes]
       summary: "Search scopes catalogue"
       description: |
-        Returns a paginated list of scope entities × actions. Requires developer
-        authentication and a valid end-user session token, plus the `scopes:view`
-        scope.
+        Returns a paginated list of scope entities × actions.
+
+        Requires a user session token in `context.authorization`.
       operationId: searchScopes
-      security:
-        - developerToken: []
       x-scopes: ["scopes:view"]
       requestBody:
         required: true
@@ -114,7 +108,7 @@ paths:
                 version: "v1"
                 ts: "2026-07-09T12:00:00Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 filters: {}
@@ -151,11 +145,10 @@ paths:
       summary: "Search scope-to-API mappings"
       description: |
         Returns a paginated list of `(api_id -> scope_key)` mappings that drive
-        per-endpoint authorization. Requires developer authentication and a valid
-        end-user session token, plus the `scopes:view` scope.
+        per-endpoint authorization.
+
+        Requires a user session token in `context.authorization`.
       operationId: searchScopeAPIs
-      security:
-        - developerToken: []
       x-scopes: ["scopes:view"]
       requestBody:
         required: true
@@ -168,7 +161,7 @@ paths:
                 version: "v1"
                 ts: "2026-07-09T12:05:00Z"
                 msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef23"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 filters: {}
@@ -207,11 +200,10 @@ paths:
         Returns one row per client with at least one scope matching the requested
         status (defaults to `pending`). Results are narrowed server-side by caller
         role: super admins see all clients, owners see their clients' entries, and
-        other callers see only their own. Requires developer authentication and a
-        valid end-user session token.
+        other callers see only their own.
+
+        Requires a user session token in `context.authorization`.
       operationId: listScopeApprovals
-      security:
-        - developerToken: []
       requestBody:
         required: true
         content:
@@ -223,7 +215,7 @@ paths:
                 version: "v1"
                 ts: "2026-07-09T12:10:00Z"
                 msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef2345"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 status: "pending"
@@ -263,15 +255,15 @@ paths:
       description: |
         Returns the scopes currently granted to the given user account. Requires the
         `users:view` scope.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
           application/json:
             schema: { $ref: '#/components/schemas/ApiRequest_GetUserScopesRequest' }
             example:
-              context: { id: "api.users.scopes.get", version: "v1", ts: "2026-04-07T10:00:00Z", msgId: "11111111-2222-3333-4444-555555555555", developerToken: "fnt_..." }
+              context: { id: "api.users.scopes.get", version: "v1", ts: "2026-04-07T10:00:00Z", msgId: "11111111-2222-3333-4444-555555555555", developerToken: "c2Et..." }
               payload:
                 account: { accountId: "018f2c3d-4e5f-7890-abcd-1234567890ab" }
       responses:
@@ -292,15 +284,15 @@ paths:
       description: |
         Replaces (not merges) the scopes granted to the given user account. Requires
         the `users:manage` scope.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
           application/json:
             schema: { $ref: '#/components/schemas/ApiRequest_UpdateUserScopesRequest' }
             example:
-              context: { id: "api.users.scopes.update", version: "v1", ts: "2026-04-07T10:00:00Z", msgId: "22222222-3333-4444-5555-666666666666", developerToken: "fnt_..." }
+              context: { id: "api.users.scopes.update", version: "v1", ts: "2026-04-07T10:00:00Z", msgId: "22222222-3333-4444-5555-666666666666", developerToken: "c2Et..." }
               payload:
                 account: { accountId: "018f2c3d-4e5f-7890-abcd-1234567890ab" }
                 scopes: ["tokens:read", "tokens:write"]
@@ -325,14 +317,13 @@ components:
     # --- API Envelope Schemas ---
     Context:
       type: object
-      required: [id, version, ts, msgId]
+      required: [id, version, ts, msgId, developerToken]
       properties:
         id: { type: string, example: "api.scopes.search" }
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token." }
     ResponseContext:
       type: object
@@ -367,6 +358,26 @@ components:
       required: [context, payload]
       properties:
         context: { $ref: '#/components/schemas/Context' }
+        payload: { type: object }
+        signature:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Signature'
+    UserContext:
+      type: object
+      required: [id, version, ts, msgId, developerToken, authorization]
+      properties:
+        id: { type: string, example: "api.scopes.search" }
+        version: { type: string, example: "v1" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
+        authorization: { type: string, example: "Bearer eyJ...", description: "End-user's session token." }
+    UserRequestContext:
+      type: object
+      required: [context, payload]
+      properties:
+        context: { $ref: '#/components/schemas/UserContext' }
         payload: { type: object }
         signature:
           nullable: true
@@ -534,16 +545,16 @@ components:
         scopes: { type: array, items: { type: string } }
 
     # --- Specific Request Envelopes ---
-    ApiRequest_SearchScopesRequest:       { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/SearchScopesRequest' } } } ] }
-    ApiRequest_SearchScopeAPIsRequest:    { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/SearchScopeAPIsRequest' } } } ] }
-    ApiRequest_ListScopeApprovalsRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/ListScopeApprovalsRequest' } } } ] }
+    ApiRequest_SearchScopesRequest:       { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/SearchScopesRequest' } } } ] }
+    ApiRequest_SearchScopeAPIsRequest:    { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/SearchScopeAPIsRequest' } } } ] }
+    ApiRequest_ListScopeApprovalsRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/ListScopeApprovalsRequest' } } } ] }
 
     # --- Specific Response Envelopes ---
     ApiResponse_SearchScopes:       { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/SearchScopesResponse' } } } ] }
     ApiResponse_SearchScopeAPIs:    { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/SearchScopeAPIsResponse' } } } ] }
     ApiResponse_ListScopeApprovals: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/ListScopeApprovalsResponse' } } } ] }
-    ApiRequest_GetUserScopesRequest:    { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/GetUserScopesRequest' } } } ] }
-    ApiRequest_UpdateUserScopesRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/UpdateUserScopesRequest' } } } ] }
+    ApiRequest_GetUserScopesRequest:    { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/GetUserScopesRequest' } } } ] }
+    ApiRequest_UpdateUserScopesRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/UpdateUserScopesRequest' } } } ] }
     ApiResponse_UserScopes:             { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/UserScopesResponse' } } } ] }
 
   # -------------------- Responses --------------------
@@ -585,16 +596,3 @@ components:
           example:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
-
-  # -------------------- Security --------------------
-  securitySchemes:
-    # This section is for documentation purposes.
-    # The server will check for the HTTP header first and fallbacks to context in case the headers are missing.
-
-    # 1. The Developer's Identity Token (Who they are)
-    developerToken:
-      type: http
-      scheme: bearer
-      bearerFormat: "JWT or Opaque"
-      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."
-    # 2. The Developer's Request Signature (What they're attesting to)

--- a/api/scopes-interfaces.yaml
+++ b/api/scopes-interfaces.yaml
@@ -113,7 +113,7 @@ paths:
             example:
               context:
                 id: "api.scopes.search"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-07-09T12:00:00Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -130,7 +130,7 @@ paths:
               example:
                 context:
                   id: "api.scopes.search"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-07-09T12:00:01Z"
                   msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
                   status: "successful"
@@ -168,7 +168,7 @@ paths:
             example:
               context:
                 id: "api.scopes.apis.search"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-07-09T12:05:00Z"
                 msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef23"
                 developerToken: "fnt_..."
@@ -185,7 +185,7 @@ paths:
               example:
                 context:
                   id: "api.scopes.apis.search"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-07-09T12:05:01Z"
                   msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef234"
                   status: "successful"
@@ -224,7 +224,7 @@ paths:
             example:
               context:
                 id: "api.scope-approvals.list"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-07-09T12:10:00Z"
                 msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef2345"
                 developerToken: "fnt_..."
@@ -240,7 +240,7 @@ paths:
               example:
                 context:
                   id: "api.scope-approvals.list"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-07-09T12:10:01Z"
                   msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef23456"
                   status: "successful"
@@ -273,7 +273,7 @@ components:
       required: [id, version, ts, msgId]
       properties:
         id: { type: string, example: "api.scopes.search" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
@@ -285,7 +285,7 @@ components:
       required: [id, version, ts, msgId, status]
       properties:
         id: { type: string, example: "api.scopes.search" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true }

--- a/api/scopes-interfaces.yaml
+++ b/api/scopes-interfaces.yaml
@@ -11,50 +11,20 @@ info:
     - **Scope approvals** (`/v1/scope-approvals`): admin-facing listing of pending
       (or otherwise-filtered) scope-approval entries, grouped by API client.
 
-    ### Protocol-Agnostic Envelope
-    All API interactions use a standard JSON envelope.
+    ### Envelope
 
-    **Request Envelope:**
-    ```json
-    {
-      "context": { ... },
-      "payload": { ... },
-      "signature": { ... } // Optional
-    }
-    ```
+    All endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
+    On failure `context.status` is `failed`, `context.error` carries a `code` and a
+    `message`, and `response` is empty.
 
-    **Response Envelope (Success):**
-    ```json
-    {
-      "context": { ..., "status": "successful" },
-      "response": { ... }
-    }
-    ```
+    ### Authentication
 
-    **Response Envelope (Error):**
-    ```json
-    {
-      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." },
-      "response": {} // Empty on error
-    }
-    ```
-    (Error details are in the context.error object)
-
-    ### Authentication and Authorization
-    This API uses a two-level authorization model contained within the `context`:
-
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
-        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
-
-    2.  **User-Level (End-User) Authorization:**
-        * `context.authorization`: The end-user's JWT session token (for session-based calls).
-        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
-
-    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
-
-    All endpoints in this service require **both** developer authentication and a
-    valid end-user session token.
+    * `context.developerToken`: the calling application's developer token. Required on
+      every endpoint.
+    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
+      `Signature` header.
+    * `context.authorization`: the end user's session token, required by the endpoints
+      that act on a signed-in user. Each operation states when it is needed.
 
     ### RBAC Scopes
 
@@ -62,18 +32,17 @@ info:
     |----------|----------------|
     | `POST /v1/scopes/search` | `scopes:view` |
     | `POST /v1/scopes/apis/search` | `scopes:view` |
-    | `POST /v1/scope-approvals/` | *(scope check applies; specific scope key not fixed in source — see note)* |
+    | `POST /v1/scope-approvals/` | *(scope check applies; see the note below)* |
 
-    Scope keys are resolved from the server-side `scope_api` mapping table. Calls
-    failing the scope check return `403 FORBIDDEN`. The scope-approvals
-    list is additionally narrowed server-side by caller role: super admins see
-    all clients, owners see their clients' entries, and other callers see only
-    their own.
+    Calls failing the scope check return `403`. The scope-approvals list is additionally
+    narrowed by caller role: super admins see all clients, owners see their clients'
+    entries, and other callers see only their own.
 
     ### Rate limiting
 
-    All endpoints are protected by a scope-tier sliding-window rate limiter; on
-    breach the response is `429 Too Many Requests` with a `Retry-After` header.
+    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
+    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
+    the tier assigned to the calling client.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -99,9 +68,7 @@ paths:
       tags: [Scopes]
       summary: "Search scopes catalogue"
       description: |
-        Returns a paginated list of scope entities × actions. Requires developer
-        authentication and a valid end-user session token, plus the `scopes:view`
-        scope.
+        Returns a paginated list of scope entities × actions. Requires a user session token.
       operationId: searchScopes
       security:
         - developerToken: []
@@ -155,8 +122,7 @@ paths:
       summary: "Search scope-to-API mappings"
       description: |
         Returns a paginated list of `(api_id -> scope_key)` mappings that drive
-        per-endpoint authorization. Requires developer authentication and a valid
-        end-user session token, plus the `scopes:view` scope.
+        per-endpoint authorization. Requires a user session token.
       operationId: searchScopeAPIs
       security:
         - developerToken: []
@@ -212,8 +178,7 @@ paths:
         Returns one row per client with at least one scope matching the requested
         status (defaults to `pending`). Results are narrowed server-side by caller
         role: super admins see all clients, owners see their clients' entries, and
-        other callers see only their own. Requires developer authentication and a
-        valid end-user session token.
+        other callers see only their own. Requires a user session token.
       operationId: listScopeApprovals
       security:
         - developerToken: []
@@ -534,7 +499,7 @@ components:
       required: [account, scopes]
       properties:
         account: { $ref: '#/components/schemas/UserAccountRef' }
-        scopes: { type: array, items: { type: string }, description: "Replace semantics — the full set of scopes to grant." }
+        scopes: { type: array, items: { type: string }, description: "Replace semantics: the full set of scopes to grant." }
     UserScopesResponse:
       type: object
       required: [accountId, scopes]
@@ -558,7 +523,7 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
+      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -566,12 +531,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "Forbidden. Insufficient permissions (scope check failed)."
+      description: "The caller does not have the scope required by this endpoint."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
             response: {}
     BadRequestError:
       description: "Invalid request."
@@ -582,9 +547,7 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
-      description: |
-        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
-        response header indicates how long the caller should wait before retrying.
+      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }

--- a/api/scopes-interfaces.yaml
+++ b/api/scopes-interfaces.yaml
@@ -296,9 +296,9 @@ components:
             - $ref: '#/components/schemas/ErrorPayload'
     Signature:
       type: object
-      required: [key_id, jws]
+      required: [keyId, jws]
       properties:
-        key_id: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
+        keyId: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
         jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object." }
     ErrorPayload:
       type: object

--- a/api/scopes-interfaces.yaml
+++ b/api/scopes-interfaces.yaml
@@ -1,0 +1,533 @@
+openapi: 3.0.4
+info:
+  title: "Finternet API - Scopes & Approvals"
+  description: |
+    The official API specification for the Finternet Scopes catalogue and
+    Scope-Approval services.
+
+    - **Scopes catalogue** (`/v1/scopes/*`): read-only listings of the RBAC scope
+      entities × actions, and of the `api_id -> scope_key` mappings that drive
+      per-endpoint authorization.
+    - **Scope approvals** (`/v1/scope-approvals`): admin-facing listing of pending
+      (or otherwise-filtered) scope-approval entries, grouped by API client.
+
+    ### Protocol-Agnostic Envelope
+    All API interactions use a standard JSON envelope.
+
+    **Request Envelope:**
+    ```json
+    {
+      "context": { ... },
+      "payload": { ... },
+      "signature": { ... } // Optional
+    }
+    ```
+
+    **Response Envelope (Success):**
+    ```json
+    {
+      "context": { ..., "status": "successful" },
+      "response": { ... }
+    }
+    ```
+
+    **Response Envelope (Error):**
+    ```json
+    {
+      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." },
+      "response": {} // Empty on error
+    }
+    ```
+    (Error details are in the context.error object)
+
+    ### Authentication and Authorization
+    This API uses a two-level authorization model contained within the `context`:
+
+    1.  **Platform-Level (Developer) Authentication:**
+        * `context.developerToken`: The B2B Developer's API Key/Token.
+        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
+
+    2.  **User-Level (End-User) Authorization:**
+        * `context.authorization`: The end-user's JWT session token (for session-based calls).
+        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
+
+    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
+
+    All endpoints in this service require **both** developer authentication and a
+    valid end-user session token.
+
+    ### RBAC Scopes
+
+    | Endpoint | Required scope |
+    |----------|----------------|
+    | `POST /v1/scopes/search` | `scopes:view` |
+    | `POST /v1/scopes/apis/search` | `scopes:view` |
+    | `POST /v1/scope-approvals/` | *(scope check applies; specific scope key not fixed in source — see note)* |
+
+    Scope keys are resolved from the server-side `scope_api` mapping table. Calls
+    failing the scope check return `403 PERMISSION_DENIED`. The scope-approvals
+    list is additionally narrowed server-side by caller role: super admins see
+    all clients, owners see their clients' entries, and other callers see only
+    their own.
+
+    ### Rate limiting
+
+    All endpoints are protected by a scope-tier sliding-window rate limiter; on
+    breach the response is `429 Too Many Requests` with a `Retry-After` header.
+  version: "1.0.0"
+servers:
+  - url: "https://foundry.finternetlab.io"
+    description: "Development Environment"
+  - url: "http://localhost:3000"
+    description: "Local Server"
+tags:
+  - name: "Scopes"
+    description: "Read-only catalogue of RBAC scopes and api-to-scope mappings."
+  - name: "Scope Approval"
+    description: "Admin-facing listing of scope-approval entries grouped by client."
+
+# ===============================================================
+#   PATHS
+# ===============================================================
+
+paths:
+  # -------------------- Scopes catalogue --------------------
+  /v1/scopes/search:
+    post:
+      tags: [Scopes]
+      summary: "Search scopes catalogue"
+      description: |
+        Returns a paginated list of scope entities × actions. Requires developer
+        authentication and a valid end-user session token, plus the `scopes:view`
+        scope.
+      operationId: searchScopes
+      security:
+        - developerToken: []
+        - developerSignature: []
+      x-scopes: ["scopes:view"]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ApiRequest_SearchScopesRequest' }
+            example:
+              context:
+                id: "api.scopes.search"
+                version: "1.0"
+                ts: "2026-07-09T12:00:00Z"
+                msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                filters: {}
+                pagination: { limit: 50, offset: 0 }
+      responses:
+        '200':
+          description: "Scopes retrieved successfully."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiResponse_SearchScopes' }
+              example:
+                context:
+                  id: "api.scopes.search"
+                  version: "1.0"
+                  ts: "2026-07-09T12:00:01Z"
+                  msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
+                  status: "successful"
+                response:
+                  scopes:
+                    - id: "b50db0e7-d5f7-6bfe-fcbf-7f45ae7683e1"
+                      entity: "accounts"
+                      scope: "accounts:view"
+                      accessLevel: "view"
+                      createdAt: "2026-07-01T09:00:00Z"
+                  pagination: { total: 1, limit: 50, offset: 0 }
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+  /v1/scopes/apis/search:
+    post:
+      tags: [Scopes]
+      summary: "Search scope-to-API mappings"
+      description: |
+        Returns a paginated list of `(api_id -> scope_key)` mappings that drive
+        per-endpoint authorization. Requires developer authentication and a valid
+        end-user session token, plus the `scopes:view` scope.
+      operationId: searchScopeAPIs
+      security:
+        - developerToken: []
+        - developerSignature: []
+      x-scopes: ["scopes:view"]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ApiRequest_SearchScopeAPIsRequest' }
+            example:
+              context:
+                id: "api.scopes.apis.search"
+                version: "1.0"
+                ts: "2026-07-09T12:05:00Z"
+                msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef23"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                filters: {}
+                pagination: { limit: 50, offset: 0 }
+      responses:
+        '200':
+          description: "Scope-to-API mappings retrieved successfully."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiResponse_SearchScopeAPIs' }
+              example:
+                context:
+                  id: "api.scopes.apis.search"
+                  version: "1.0"
+                  ts: "2026-07-09T12:05:01Z"
+                  msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef234"
+                  status: "successful"
+                response:
+                  scopeApis:
+                    - id: "c60db0e7-d5f7-6bfe-fcbf-7f45ae7683e2"
+                      scopeKey: "registry-programs:view"
+                      apiId: "api.tokenprogram.get"
+                      createdAt: "2026-07-01T09:00:00Z"
+                  pagination: { total: 1, limit: 50, offset: 0 }
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+  # -------------------- Scope approvals --------------------
+  /v1/scope-approvals/:
+    post:
+      tags: [Scope Approval]
+      summary: "List scope-approval entries grouped by client"
+      description: |
+        Returns one row per client with at least one scope matching the requested
+        status (defaults to `pending`). Results are narrowed server-side by caller
+        role: super admins see all clients, owners see their clients' entries, and
+        other callers see only their own. Requires developer authentication and a
+        valid end-user session token.
+      operationId: listScopeApprovals
+      security:
+        - developerToken: []
+        - developerSignature: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ApiRequest_ListScopeApprovalsRequest' }
+            example:
+              context:
+                id: "api.scope-approvals.list"
+                version: "1.0"
+                ts: "2026-07-09T12:10:00Z"
+                msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef2345"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                status: "pending"
+      responses:
+        '200':
+          description: "Scope-approval entries retrieved successfully."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiResponse_ListScopeApprovals' }
+              example:
+                context:
+                  id: "api.scope-approvals.list"
+                  version: "1.0"
+                  ts: "2026-07-09T12:10:01Z"
+                  msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef23456"
+                  status: "successful"
+                response:
+                  clients:
+                    - clientId: "b50db0e7-d5f7-6bfe-fcbf-7f45ae7683e1"
+                      clientName: "Acme Wallet"
+                      status: "pending"
+                      scopes:
+                        - scope: "accounts:view"
+                          requestedBy: "did:key:z..."
+                          requestedByName: "Alice Smith"
+                          requestedAt: "2026-07-08T15:00:00Z"
+                          expiresAt: "2026-07-15T15:00:00Z"
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+# ===============================================================
+#   COMPONENTS
+# ===============================================================
+
+components:
+  # -------------------- Schemas --------------------
+  schemas:
+    # --- API Envelope Schemas ---
+    Context:
+      type: object
+      required: [id, version, ts, msgId]
+      properties:
+        id: { type: string, example: "api.scopes.search" }
+        version: { type: string, example: "1.0" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "B2B Developer API Key/Token" }
+        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "B2B Developer Signature (e.g., HMAC)" }
+        authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token." }
+    ResponseContext:
+      type: object
+      required: [id, version, ts, msgId, status]
+      properties:
+        id: { type: string, example: "api.scopes.search" }
+        version: { type: string, example: "1.0" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        transactionId: { type: string, format: uuid, nullable: true }
+        status: { type: string, enum: [successful, failed, pending] }
+        error:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/ErrorPayload'
+    Signature:
+      type: object
+      required: [key_id, jws]
+      properties:
+        key_id: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
+        jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object." }
+    ErrorPayload:
+      type: object
+      required: [code, message]
+      properties:
+        code: { type: string, example: "RESOURCE_NOT_FOUND" }
+        message: { type: string }
+
+    # --- Base Request/Response Schemas ---
+    RequestContext:
+      type: object
+      required: [context, payload]
+      properties:
+        context: { $ref: '#/components/schemas/Context' }
+        payload: { type: object }
+        signature:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Signature'
+    ApiResponse:
+      type: object
+      required: [context, response]
+      properties:
+        context: { $ref: '#/components/schemas/ResponseContext' }
+        response: { type: object }
+    ApiError:
+      type: object
+      required: [context, response]
+      properties:
+        context: { $ref: '#/components/schemas/ResponseContext' }
+        response: { type: object, description: "Always empty on error.", example: {} }
+
+    # --- Core Data Schemas (Payloads) ---
+    # NOTE: SearchScopesRequest and SearchScopeAPIsRequest have identical payload
+    # shapes in source, but are kept as separate schemas to mirror the two
+    # distinct request types (search_scopes_request.json / search_scope_apis_request.json).
+    SearchScopesRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          additionalProperties: true
+          description: "Free-form filter object applied server-side."
+        pagination:
+          type: object
+          properties:
+            limit: { type: integer, minimum: 0 }
+            offset: { type: integer, minimum: 0 }
+          additionalProperties: false
+        sortBy:
+          type: object
+          properties:
+            field: { type: string }
+            order: { type: string, enum: [asc, desc] }
+          additionalProperties: false
+      additionalProperties: true
+    SearchScopeAPIsRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          additionalProperties: true
+          description: "Free-form filter object applied server-side."
+        pagination:
+          type: object
+          properties:
+            limit: { type: integer, minimum: 0 }
+            offset: { type: integer, minimum: 0 }
+          additionalProperties: false
+        sortBy:
+          type: object
+          properties:
+            field: { type: string }
+            order: { type: string, enum: [asc, desc] }
+          additionalProperties: false
+      additionalProperties: true
+    ListScopeApprovalsRequest:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [pending, active, rejected]
+          description: "Filter by scope status. Defaults to `pending` when omitted."
+        clientId:
+          type: string
+          format: uuid
+          description: "Optional client UUID filter."
+      additionalProperties: false
+
+    # --- Response Data Schemas ---
+    ScopeResponse:
+      type: object
+      required: [id, entity, scope, accessLevel, createdAt]
+      properties:
+        id: { type: string, example: "b50db0e7-d5f7-6bfe-fcbf-7f45ae7683e1" }
+        entity: { type: string, example: "accounts" }
+        scope: { type: string, example: "accounts:view" }
+        accessLevel: { type: string, example: "view" }
+        createdAt: { type: string, format: date-time }
+    SearchScopesResponse:
+      type: object
+      required: [scopes, pagination]
+      properties:
+        scopes:
+          type: array
+          items: { $ref: '#/components/schemas/ScopeResponse' }
+        pagination: { $ref: '#/components/schemas/PaginationInfo' }
+    ScopeAPIResponse:
+      type: object
+      required: [id, scopeKey, apiId, createdAt]
+      properties:
+        id: { type: string, example: "c60db0e7-d5f7-6bfe-fcbf-7f45ae7683e2" }
+        scopeKey: { type: string, example: "registry-programs:view" }
+        apiId: { type: string, example: "api.tokenprogram.get" }
+        createdAt: { type: string, format: date-time }
+    SearchScopeAPIsResponse:
+      type: object
+      required: [scopeApis, pagination]
+      properties:
+        scopeApis:
+          type: array
+          items: { $ref: '#/components/schemas/ScopeAPIResponse' }
+        pagination: { $ref: '#/components/schemas/PaginationInfo' }
+    ScopeApprovalGroupEntry:
+      type: object
+      required: [scope]
+      properties:
+        scope: { type: string, example: "accounts:view" }
+        requestedBy: { type: string, nullable: true, description: "Identifier of the requester. Omitted when empty." }
+        requestedByName: { type: string, nullable: true, description: "Human-readable name of the requester. Omitted when empty." }
+        requestedAt: { type: string, format: date-time, nullable: true, description: "Omitted when empty." }
+        expiresAt: { type: string, format: date-time, nullable: true, description: "Omitted when empty." }
+    ScopeApprovalGroup:
+      type: object
+      required: [clientId, clientName, status, scopes]
+      properties:
+        clientId: { type: string, format: uuid }
+        clientName: { type: string, example: "Acme Wallet" }
+        status: { type: string, example: "pending" }
+        scopes:
+          type: array
+          items: { $ref: '#/components/schemas/ScopeApprovalGroupEntry' }
+    ListScopeApprovalsResponse:
+      type: object
+      required: [clients]
+      properties:
+        clients:
+          type: array
+          items: { $ref: '#/components/schemas/ScopeApprovalGroup' }
+    PaginationInfo:
+      type: object
+      properties:
+        total: { type: integer, example: 1 }
+        limit: { type: integer, example: 50 }
+        offset: { type: integer, example: 0 }
+
+    # --- Specific Request Envelopes ---
+    ApiRequest_SearchScopesRequest:       { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/SearchScopesRequest' } } } ] }
+    ApiRequest_SearchScopeAPIsRequest:    { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/SearchScopeAPIsRequest' } } } ] }
+    ApiRequest_ListScopeApprovalsRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/ListScopeApprovalsRequest' } } } ] }
+
+    # --- Specific Response Envelopes ---
+    ApiResponse_SearchScopes:       { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/SearchScopesResponse' } } } ] }
+    ApiResponse_SearchScopeAPIs:    { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/SearchScopeAPIsResponse' } } } ] }
+    ApiResponse_ListScopeApprovals: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/ListScopeApprovalsResponse' } } } ] }
+
+  # -------------------- Responses --------------------
+  responses:
+    UnauthorizedError:
+      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "AUTHENTICATION_FAILED", message: "Token invalid or expired." } }
+            response: {}
+    ForbiddenError:
+      description: "Forbidden. Insufficient permissions (scope check failed)."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "PERMISSION_DENIED", message: "Insufficient permissions to perform this action." } }
+            response: {}
+    BadRequestError:
+      description: "Invalid request."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "Invalid request parameters." } }
+            response: {}
+    RateLimitedError:
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
+      headers:
+        Retry-After:
+          schema: { type: integer, description: "Seconds to wait before retrying." }
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
+            response: {}
+
+  # -------------------- Security --------------------
+  securitySchemes:
+    # This section is for documentation purposes.
+    # The server will check for the HTTP header first and fallbacks to context in case the headers are missing.
+
+    # 1. The Developer's Identity Token (Who they are)
+    developerToken:
+      type: http
+      scheme: bearer
+      bearerFormat: "JWT or Opaque"
+      description: |
+        A JWT or Opaque token that identifies the calling B2B developer/backend service.
+        This is passed in the standard `Authorization: Bearer <token>` header.
+        (This can also be passed in the `context.developerToken` as a fallback).
+
+    # 2. The Developer's Request Signature (What they're attesting to)
+    developerSignature:
+      type: apiKey
+      in: header
+      name: Signature
+      description: |
+        The IETF HTTP Signature (RFC 9421) used by B2B developers to ensure message
+        integrity and non-repudiation. This is passed in the `Signature` header.
+
+        Example Format:
+        Signature keyId="...",algorithm="...",created="...",expires="...",headers="...",signature="..."

--- a/api/scopes-interfaces.yaml
+++ b/api/scopes-interfaces.yaml
@@ -45,13 +45,10 @@ info:
 
     1.  **Platform-Level (Developer) Authentication:**
         * `context.developerToken`: The B2B Developer's API Key/Token.
-        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
 
     2.  **User-Level (End-User) Authorization:**
         * `context.authorization`: The end-user's JWT session token (for session-based calls).
         * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
-
-    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
 
     All endpoints in this service require **both** developer authentication and a
     valid end-user session token.
@@ -105,7 +102,6 @@ paths:
       operationId: searchScopes
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: ["scopes:view"]
       requestBody:
         required: true
@@ -160,7 +156,6 @@ paths:
       operationId: searchScopeAPIs
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: ["scopes:view"]
       requestBody:
         required: true
@@ -217,7 +212,6 @@ paths:
       operationId: listScopeApprovals
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -271,7 +265,6 @@ paths:
         `users:view` scope.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -301,7 +294,6 @@ paths:
         the `users:manage` scope.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -340,8 +332,7 @@ components:
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "B2B Developer API Key/Token" }
-        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "B2B Developer Signature (e.g., HMAC)" }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token." }
     ResponseContext:
       type: object
@@ -605,17 +596,5 @@ components:
       type: http
       scheme: bearer
       bearerFormat: "JWT or Opaque"
-      description: |
-        A JWT or Opaque token that identifies the calling B2B developer/backend service.
-
+      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."
     # 2. The Developer's Request Signature (What they're attesting to)
-    developerSignature:
-      type: apiKey
-      in: header
-      name: Signature
-      description: |
-        The IETF HTTP Signature (RFC 9421) used by B2B developers to ensure message
-        integrity and non-repudiation. This is passed in the `Signature` header.
-
-        Example Format:
-        Signature keyId="...",algorithm="...",created="...",expires="...",headers="...",signature="..."

--- a/api/scopes-interfaces.yaml
+++ b/api/scopes-interfaces.yaml
@@ -65,7 +65,7 @@ info:
     | `POST /v1/scope-approvals/` | *(scope check applies; specific scope key not fixed in source — see note)* |
 
     Scope keys are resolved from the server-side `scope_api` mapping table. Calls
-    failing the scope check return `403 PERMISSION_DENIED`. The scope-approvals
+    failing the scope check return `403 FORBIDDEN`. The scope-approvals
     list is additionally narrowed server-side by caller role: super admins see
     all clients, owners see their clients' entries, and other callers see only
     their own.
@@ -473,7 +473,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "AUTHENTICATION_FAILED", message: "Token invalid or expired." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
       description: "Forbidden. Insufficient permissions (scope check failed)."
@@ -481,7 +481,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "PERMISSION_DENIED", message: "Insufficient permissions to perform this action." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
             response: {}
     BadRequestError:
       description: "Invalid request."
@@ -489,7 +489,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "Invalid request parameters." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
       description: |
@@ -502,7 +502,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
 
   # -------------------- Security --------------------

--- a/api/scopes-interfaces.yaml
+++ b/api/scopes-interfaces.yaml
@@ -517,8 +517,6 @@ components:
       bearerFormat: "JWT or Opaque"
       description: |
         A JWT or Opaque token that identifies the calling B2B developer/backend service.
-        This is passed in the standard `Authorization: Bearer <token>` header.
-        (This can also be passed in the `context.developerToken` as a fallback).
 
     # 2. The Developer's Request Signature (What they're attesting to)
     developerSignature:

--- a/api/terms-interfaces.yaml
+++ b/api/terms-interfaces.yaml
@@ -110,7 +110,7 @@ paths:
             example:
               context:
                 id: "api.terms.get"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-07-09T12:00:00Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -126,7 +126,7 @@ paths:
               example:
                 context:
                   id: "api.terms.get"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-07-09T12:00:01Z"
                   msgId: "b1b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "successful"
@@ -174,7 +174,7 @@ paths:
             example:
               context:
                 id: "api.terms.accept"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-07-09T12:05:00Z"
                 msgId: "c1b2c3d4-e5f6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -192,7 +192,7 @@ paths:
               example:
                 context:
                   id: "api.terms.accept"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-07-09T12:05:01Z"
                   msgId: "d1b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "successful"
@@ -213,7 +213,7 @@ paths:
               example:
                 context:
                   id: "api.terms.accept"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-07-09T12:05:01Z"
                   msgId: "d1b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "failed"
@@ -248,7 +248,7 @@ paths:
             example:
               context:
                 id: "api.terms.publish"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-07-09T09:00:00Z"
                 msgId: "e1b2c3d4-e5f6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -268,7 +268,7 @@ paths:
               example:
                 context:
                   id: "api.terms.publish"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-07-09T09:00:01Z"
                   msgId: "f1b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "successful"
@@ -302,7 +302,7 @@ components:
       required: [id, version, ts, msgId]
       properties:
         id: { type: string, example: "api.terms.get" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
@@ -314,7 +314,7 @@ components:
       required: [id, version, ts, msgId, status]
       properties:
         id: { type: string, example: "api.terms.get" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true }

--- a/api/terms-interfaces.yaml
+++ b/api/terms-interfaces.yaml
@@ -477,8 +477,6 @@ components:
       bearerFormat: "JWT or Opaque"
       description: |
         A JWT or Opaque token that identifies the calling B2B developer/backend service.
-        This is passed in the standard `Authorization: Bearer <token>` header.
-        (This can also be passed in the `context.developerToken` as a fallback).
 
     # 2. The Developer's Request Signature (What they're attesting to)
     developerSignature:

--- a/api/terms-interfaces.yaml
+++ b/api/terms-interfaces.yaml
@@ -65,7 +65,7 @@ info:
     | `POST /v1/terms/accept` | `terms:create` |
     | `POST /v1/terms/publish` | `terms:manage` *(protected — admin-only; granted via the scope-approval workflow at client registration)* |
 
-    Calls failing the scope check return `403 PERMISSION_DENIED`.
+    Calls failing the scope check return `403 FORBIDDEN`.
 
     ### Rate limiting
 
@@ -218,7 +218,7 @@ paths:
                   msgId: "d1b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "failed"
                   error:
-                    code: "RESOURCE_CONFLICT"
+                    code: "CONFLICT"
                     message: "A newer version of this document has been published. Please review it before accepting."
                 response: {}
         '429': { $ref: '#/components/responses/RateLimitedError' }
@@ -425,7 +425,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "AUTHENTICATION_FAILED", message: "Token invalid or expired." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
       description: "Forbidden. Insufficient permissions (missing required scope)."
@@ -433,7 +433,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "PERMISSION_DENIED", message: "Insufficient permissions to perform this action." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -449,7 +449,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "Invalid request parameters." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
       description: |
@@ -462,7 +462,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
 
   # -------------------- Security --------------------

--- a/api/terms-interfaces.yaml
+++ b/api/terms-interfaces.yaml
@@ -325,9 +325,9 @@ components:
             - $ref: '#/components/schemas/ErrorPayload'
     Signature:
       type: object
-      required: [key_id, jws]
+      required: [keyId, jws]
       properties:
-        key_id: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
+        keyId: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
         jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object." }
     ErrorPayload:
       type: object

--- a/api/terms-interfaces.yaml
+++ b/api/terms-interfaces.yaml
@@ -1,0 +1,493 @@
+openapi: 3.0.4
+info:
+  title: "Finternet API - Terms & Consent"
+  description: |
+    The official API specification for the Finternet Terms and Consent services.
+    These endpoints publish, serve, and record end-user agreement to versioned
+    legal documents (Terms of Use, Privacy Policy, etc.).
+
+    ### Protocol-Agnostic Envelope
+    All API interactions use a standard JSON envelope.
+
+    **Request Envelope:**
+    ```json
+    {
+      "context": { ... },
+      "payload": { ... },
+      "signature": { ... } // Optional
+    }
+    ```
+
+    **Response Envelope (Success):**
+    ```json
+    {
+      "context": { ..., "status": "successful" },
+      "response": { ... }
+    }
+    ```
+
+    **Response Envelope (Error):**
+    ```json
+    {
+      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." },
+      "response": {} // Empty on error
+    }
+    ```
+    (Error details are in the context.error object)
+
+    ### Authentication and Authorization
+    This API uses a two-level authorization model contained within the `context`:
+
+    1.  **Platform-Level (Developer) Authentication:**
+        * `context.developerToken`: The B2B Developer's API Key/Token.
+        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
+
+    2.  **User-Level (End-User) Authorization:**
+        * `context.authorization`: The end-user's JWT session token (for session-based calls).
+        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
+
+    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
+
+    ### Per-endpoint authentication
+
+    * `POST /v1/terms/get` — Developer auth only. **No end-user JWT** is required: the
+      document must be readable during onboarding, before the user has a session.
+    * `POST /v1/terms/accept` — Developer auth **plus** an end-user JWT
+      (`context.authorization`). Consent is recorded against the authenticated account.
+    * `POST /v1/terms/publish` — Developer auth only, admin-gated via a protected scope.
+      **No end-user JWT** is required.
+
+    ### RBAC Scopes
+
+    | Endpoint | Required scope |
+    |----------|----------------|
+    | `POST /v1/terms/get` | `terms:view` |
+    | `POST /v1/terms/accept` | `terms:create` |
+    | `POST /v1/terms/publish` | `terms:manage` *(protected — admin-only; granted via the scope-approval workflow at client registration)* |
+
+    Calls failing the scope check return `403 PERMISSION_DENIED`.
+
+    ### Rate limiting
+
+    All endpoints are protected by a scope-tier sliding-window rate limiter; on
+    breach the response is `429 Too Many Requests` with a `Retry-After` header.
+  version: "1.0.0"
+servers:
+  - url: "https://foundry.finternetlab.io"
+    description: "Development Environment"
+  - url: "http://localhost:3000"
+    description: "Local Server"
+tags:
+  - name: "Terms"
+    description: "Endpoints for publishing, serving, and accepting versioned Terms documents."
+
+# ===============================================================
+#   PATHS
+# ===============================================================
+
+paths:
+  /v1/terms/get:
+    post:
+      tags:
+        - "Terms"
+      summary: "Get the latest published Terms"
+      description: |
+        Returns the current published version (with content) of a Terms document.
+        The `docType` selects which document; omitting it returns the default document.
+
+        Requires Developer auth only — **no end-user JWT is required**, so the document
+        can be fetched during onboarding before the user has a session.
+      security:
+        - developerToken: []
+        - developerSignature: []
+      x-scopes: [terms:view]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_GetTermsRequest'
+            example:
+              context:
+                id: "api.terms.get"
+                version: "1.0"
+                ts: "2026-07-09T12:00:00Z"
+                msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+                developerToken: "fnt_..."
+              payload:
+                docType: "terms_of_use"
+      responses:
+        '200':
+          description: "Latest published Terms version."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_TermsVersion'
+              example:
+                context:
+                  id: "api.terms.get"
+                  version: "1.0"
+                  ts: "2026-07-09T12:00:01Z"
+                  msgId: "b1b2c3d4-e5f6-7890-1234-567890abcdef"
+                  status: "successful"
+                response:
+                  id: "5f3c9a1e-2b4d-4c6e-8a1f-9b0c1d2e3f40"
+                  docType: "terms_of_use"
+                  version: 3
+                  versionLabel: "2026.07"
+                  content: "# Terms of Use\n\nBy using this service..."
+                  contentFormat: "markdown"
+                  contentHash: "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+                  status: "published"
+                  requiresReconsent: true
+                  effectiveFrom: "2026-07-01T00:00:00Z"
+                  publishedAt: "2026-06-25T10:00:00Z"
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '404': { $ref: '#/components/responses/NotFoundError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+  /v1/terms/accept:
+    post:
+      tags:
+        - "Terms"
+      summary: "Record consent to a Terms version"
+      description: |
+        Records the authenticated user's agreement to a specific version of a Terms
+        document. `versionId` must be the version the user actually saw — if a newer
+        version has since been published, the accept is rejected (409) so the user
+        re-reads it.
+
+        Requires Developer auth **plus** an end-user JWT (`context.authorization`);
+        the consent is recorded against the authenticated account.
+      security:
+        - developerToken: []
+        - developerSignature: []
+      x-scopes: [terms:create]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_AcceptTermsRequest'
+            example:
+              context:
+                id: "api.terms.accept"
+                version: "1.0"
+                ts: "2026-07-09T12:05:00Z"
+                msgId: "c1b2c3d4-e5f6-7890-1234-567890abcdef"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                docType: "terms_of_use"
+                versionId: "5f3c9a1e-2b4d-4c6e-8a1f-9b0c1d2e3f40"
+      responses:
+        '200':
+          description: "Consent recorded."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_AcceptTerms'
+              example:
+                context:
+                  id: "api.terms.accept"
+                  version: "1.0"
+                  ts: "2026-07-09T12:05:01Z"
+                  msgId: "d1b2c3d4-e5f6-7890-1234-567890abcdef"
+                  status: "successful"
+                response:
+                  docType: "terms_of_use"
+                  version: 3
+                  consentedAt: "2026-07-09T12:05:01Z"
+                  message: "Consent recorded."
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '404': { $ref: '#/components/responses/NotFoundError' }
+        '409':
+          description: "The submitted version is stale; a newer version has been published and must be re-read."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+              example:
+                context:
+                  id: "api.terms.accept"
+                  version: "1.0"
+                  ts: "2026-07-09T12:05:01Z"
+                  msgId: "d1b2c3d4-e5f6-7890-1234-567890abcdef"
+                  status: "failed"
+                  error:
+                    code: "RESOURCE_CONFLICT"
+                    message: "A newer version of this document has been published. Please review it before accepting."
+                response: {}
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+  /v1/terms/publish:
+    post:
+      tags:
+        - "Terms"
+      summary: "Publish a new Terms version"
+      description: |
+        Creates a new version of a Terms document. Admin-only: gated by the protected
+        `terms:manage` scope, which is granted through the scope-approval workflow at
+        client registration.
+
+        Requires Developer auth only — **no end-user JWT is required**.
+        `requiresReconsent` defaults to `true` when omitted (treated as a material change).
+      security:
+        - developerToken: []
+        - developerSignature: []
+      x-scopes: [terms:manage]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_PublishTermsRequest'
+            example:
+              context:
+                id: "api.terms.publish"
+                version: "1.0"
+                ts: "2026-07-09T09:00:00Z"
+                msgId: "e1b2c3d4-e5f6-7890-1234-567890abcdef"
+                developerToken: "fnt_..."
+              payload:
+                docType: "terms_of_use"
+                versionLabel: "2026.07"
+                content: "# Terms of Use\n\nBy using this service..."
+                requiresReconsent: true
+                effectiveFrom: "2026-07-01T00:00:00Z"
+      responses:
+        '201':
+          description: "New Terms version published."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_TermsVersion'
+              example:
+                context:
+                  id: "api.terms.publish"
+                  version: "1.0"
+                  ts: "2026-07-09T09:00:01Z"
+                  msgId: "f1b2c3d4-e5f6-7890-1234-567890abcdef"
+                  status: "successful"
+                response:
+                  id: "5f3c9a1e-2b4d-4c6e-8a1f-9b0c1d2e3f40"
+                  docType: "terms_of_use"
+                  version: 3
+                  versionLabel: "2026.07"
+                  content: "# Terms of Use\n\nBy using this service..."
+                  contentFormat: "markdown"
+                  contentHash: "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+                  status: "published"
+                  requiresReconsent: true
+                  effectiveFrom: "2026-07-01T00:00:00Z"
+                  publishedAt: "2026-07-09T09:00:01Z"
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+# ===============================================================
+#   COMPONENTS
+# ===============================================================
+
+components:
+  # -------------------- Schemas --------------------
+  schemas:
+    # --- API Envelope Schemas ---
+    Context:
+      type: object
+      required: [id, version, ts, msgId]
+      properties:
+        id: { type: string, example: "api.terms.get" }
+        version: { type: string, example: "1.0" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "B2B Developer API Key/Token" }
+        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "B2B Developer Signature (e.g., HMAC)" }
+        authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token." }
+    ResponseContext:
+      type: object
+      required: [id, version, ts, msgId, status]
+      properties:
+        id: { type: string, example: "api.terms.get" }
+        version: { type: string, example: "1.0" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        transactionId: { type: string, format: uuid, nullable: true }
+        status: { type: string, enum: [successful, failed, pending] }
+        error:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/ErrorPayload'
+    Signature:
+      type: object
+      required: [key_id, jws]
+      properties:
+        key_id: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
+        jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object." }
+    ErrorPayload:
+      type: object
+      required: [code, message]
+      properties:
+        code: { type: string, example: "RESOURCE_NOT_FOUND" }
+        message: { type: string }
+
+    # --- Base Request/Response Schemas ---
+    RequestContext:
+      type: object
+      required: [context, payload]
+      properties:
+        context: { $ref: '#/components/schemas/Context' }
+        payload: { type: object }
+        signature:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Signature'
+    ApiResponse:
+      type: object
+      required: [context, response]
+      properties:
+        context: { $ref: '#/components/schemas/ResponseContext' }
+        response: { type: object }
+    ApiError:
+      type: object
+      required: [context, response]
+      properties:
+        context: { $ref: '#/components/schemas/ResponseContext' }
+        response: { type: object, description: "Always empty on error.", example: {} }
+
+    # --- Specific Request Envelopes ---
+    ApiRequest_GetTermsRequest:     { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/GetTermsRequest' } } } ] }
+    ApiRequest_AcceptTermsRequest:  { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/AcceptTermsRequest' } } } ] }
+    ApiRequest_PublishTermsRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/PublishTermsRequest' } } } ] }
+
+    # --- Specific Response Envelopes ---
+    ApiResponse_TermsVersion: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/TermsVersionResponse' } } } ] }
+    ApiResponse_AcceptTerms:  { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/AcceptTermsResponse' } } } ] }
+
+    # --- Core Data Schemas (Payloads) ---
+    GetTermsRequest:
+      type: object
+      description: "Requests the latest published version of a Terms document. `docType` is optional; empty means the default document (e.g. terms_of_use)."
+      properties:
+        docType: { type: string, example: "terms_of_use", description: "Which document to fetch. Defaults to the platform default when omitted." }
+    AcceptTermsRequest:
+      type: object
+      required: [versionId]
+      description: "Records a user's agreement to a specific version. `versionId` must be the version the user actually saw."
+      properties:
+        docType: { type: string, example: "terms_of_use", description: "Which document is being accepted. Defaults to the platform default when omitted." }
+        versionId: { type: string, example: "5f3c9a1e-2b4d-4c6e-8a1f-9b0c1d2e3f40", description: "Identifier of the exact version the user viewed and is accepting." }
+    PublishTermsRequest:
+      type: object
+      required: [content]
+      description: "Creates a new Terms version. Admin-only (protected scope)."
+      properties:
+        docType: { type: string, example: "terms_of_use", description: "Which document to publish a new version of. Defaults to the platform default when omitted." }
+        versionLabel: { type: string, example: "2026.07", description: "Optional human-readable label for the version." }
+        content: { type: string, minLength: 1, example: "# Terms of Use\n\nBy using this service...", description: "The full document body." }
+        requiresReconsent: { type: boolean, default: true, description: "Whether existing users must re-accept. Defaults to true (treat as a material change) when omitted." }
+        effectiveFrom: { type: string, format: date-time, nullable: true, description: "Optional RFC3339 timestamp; empty means effective immediately." }
+
+    TermsVersionResponse:
+      type: object
+      description: "A single Terms version, returned by /terms/get and /terms/publish."
+      properties:
+        id: { type: string, example: "5f3c9a1e-2b4d-4c6e-8a1f-9b0c1d2e3f40" }
+        docType: { type: string, example: "terms_of_use" }
+        version: { type: integer, example: 3 }
+        versionLabel: { type: string, example: "2026.07", description: "Omitted when unset." }
+        content: { type: string, example: "# Terms of Use\n\nBy using this service..." }
+        contentFormat: { type: string, example: "markdown" }
+        contentHash: { type: string, example: "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08" }
+        status: { type: string, example: "published" }
+        requiresReconsent: { type: boolean, example: true }
+        effectiveFrom: { type: string, format: date-time, example: "2026-07-01T00:00:00Z", description: "Omitted when unset." }
+        publishedAt: { type: string, format: date-time, example: "2026-06-25T10:00:00Z", description: "Omitted when unset." }
+    AcceptTermsResponse:
+      type: object
+      description: "Confirms a recorded agreement."
+      properties:
+        docType: { type: string, example: "terms_of_use" }
+        version: { type: integer, example: 3 }
+        consentedAt: { type: string, format: date-time, example: "2026-07-09T12:05:01Z" }
+        message: { type: string, example: "Consent recorded." }
+
+  # -------------------- Responses --------------------
+  responses:
+    UnauthorizedError:
+      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "AUTHENTICATION_FAILED", message: "Token invalid or expired." } }
+            response: {}
+    ForbiddenError:
+      description: "Forbidden. Insufficient permissions (missing required scope)."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "PERMISSION_DENIED", message: "Insufficient permissions to perform this action." } }
+            response: {}
+    NotFoundError:
+      description: "Resource not found."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "The requested resource was not found." } }
+            response: {}
+    BadRequestError:
+      description: "Invalid request."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "Invalid request parameters." } }
+            response: {}
+    RateLimitedError:
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
+      headers:
+        Retry-After:
+          schema: { type: integer, description: "Seconds to wait before retrying." }
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
+            response: {}
+
+  # -------------------- Security --------------------
+  securitySchemes:
+    # This section is for documentation purposes.
+    # The server will check for the HTTP header first and fallbacks to context in case the headers are missing.
+
+    # 1. The Developer's Identity Token (Who they are)
+    developerToken:
+      type: http
+      scheme: bearer
+      bearerFormat: "JWT or Opaque"
+      description: |
+        A JWT or Opaque token that identifies the calling B2B developer/backend service.
+        This is passed in the standard `Authorization: Bearer <token>` header.
+        (This can also be passed in the `context.developerToken` as a fallback).
+
+    # 2. The Developer's Request Signature (What they're attesting to)
+    developerSignature:
+      type: apiKey
+      in: header
+      name: Signature
+      description: |
+        The IETF HTTP Signature (RFC 9421) used by B2B developers to ensure message
+        integrity and non-repudiation. This is passed in the `Signature` header.
+
+        Example Format:
+        Signature keyId="...",algorithm="...",created="...",expires="...",headers="...",signature="..."

--- a/api/terms-interfaces.yaml
+++ b/api/terms-interfaces.yaml
@@ -40,13 +40,10 @@ info:
 
     1.  **Platform-Level (Developer) Authentication:**
         * `context.developerToken`: The B2B Developer's API Key/Token.
-        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
 
     2.  **User-Level (End-User) Authorization:**
         * `context.authorization`: The end-user's JWT session token (for session-based calls).
         * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
-
-    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
 
     ### Per-endpoint authentication
 
@@ -99,7 +96,6 @@ paths:
         can be fetched during onboarding before the user has a session.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [terms:view]
       requestBody:
         required: true
@@ -163,7 +159,6 @@ paths:
         the consent is recorded against the authenticated account.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [terms:create]
       requestBody:
         required: true
@@ -237,7 +232,6 @@ paths:
         `requiresReconsent` defaults to `true` when omitted (treated as a material change).
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [terms:manage]
       requestBody:
         required: true
@@ -306,8 +300,7 @@ components:
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "B2B Developer API Key/Token" }
-        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "B2B Developer Signature (e.g., HMAC)" }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token." }
     ResponseContext:
       type: object
@@ -475,17 +468,5 @@ components:
       type: http
       scheme: bearer
       bearerFormat: "JWT or Opaque"
-      description: |
-        A JWT or Opaque token that identifies the calling B2B developer/backend service.
-
+      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."
     # 2. The Developer's Request Signature (What they're attesting to)
-    developerSignature:
-      type: apiKey
-      in: header
-      name: Signature
-      description: |
-        The IETF HTTP Signature (RFC 9421) used by B2B developers to ensure message
-        integrity and non-repudiation. This is passed in the `Signature` header.
-
-        Example Format:
-        Signature keyId="...",algorithm="...",created="...",expires="...",headers="...",signature="..."

--- a/api/terms-interfaces.yaml
+++ b/api/terms-interfaces.yaml
@@ -6,56 +6,28 @@ info:
     These endpoints publish, serve, and record end-user agreement to versioned
     legal documents (Terms of Use, Privacy Policy, etc.).
 
-    ### Protocol-Agnostic Envelope
-    All API interactions use a standard JSON envelope.
+    ### Envelope
 
-    **Request Envelope:**
-    ```json
-    {
-      "context": { ... },
-      "payload": { ... },
-      "signature": { ... } // Optional
-    }
-    ```
+    All endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
+    On failure `context.status` is `failed`, `context.error` carries a `code` and a
+    `message`, and `response` is empty.
 
-    **Response Envelope (Success):**
-    ```json
-    {
-      "context": { ..., "status": "successful" },
-      "response": { ... }
-    }
-    ```
+    ### Authentication
 
-    **Response Envelope (Error):**
-    ```json
-    {
-      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." },
-      "response": {} // Empty on error
-    }
-    ```
-    (Error details are in the context.error object)
+    * `context.developerToken`: the calling application's developer token. Required on
+      every endpoint.
+    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
+      `Signature` header.
+    * `context.authorization`: the end user's session token, required by the endpoints
+      that act on a signed-in user. Each operation states when it is needed.
 
-    ### Authentication and Authorization
-    This API uses a two-level authorization model contained within the `context`:
+    ### Per-endpoint requirements
 
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
-        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
-
-    2.  **User-Level (End-User) Authorization:**
-        * `context.authorization`: The end-user's JWT session token (for session-based calls).
-        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
-
-    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
-
-    ### Per-endpoint authentication
-
-    * `POST /v1/terms/get` — Developer auth only. **No end-user JWT** is required: the
-      document must be readable during onboarding, before the user has a session.
-    * `POST /v1/terms/accept` — Developer auth **plus** an end-user JWT
-      (`context.authorization`). Consent is recorded against the authenticated account.
-    * `POST /v1/terms/publish` — Developer auth only, admin-gated via a protected scope.
-      **No end-user JWT** is required.
+    * `POST /v1/terms/get`: no user session token, so the document can be read during
+      onboarding before the user has a session.
+    * `POST /v1/terms/accept`: requires a user session token. Consent is recorded against
+      that user.
+    * `POST /v1/terms/publish`: no user session token; restricted to administrators.
 
     ### RBAC Scopes
 
@@ -63,14 +35,15 @@ info:
     |----------|----------------|
     | `POST /v1/terms/get` | `terms:view` |
     | `POST /v1/terms/accept` | `terms:create` |
-    | `POST /v1/terms/publish` | `terms:manage` *(protected — admin-only; granted via the scope-approval workflow at client registration)* |
+    | `POST /v1/terms/publish` | `terms:manage` *(administrators only)* |
 
-    Calls failing the scope check return `403 FORBIDDEN`.
+    Calls failing the scope check return `403`.
 
     ### Rate limiting
 
-    All endpoints are protected by a scope-tier sliding-window rate limiter; on
-    breach the response is `429 Too Many Requests` with a `Retry-After` header.
+    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
+    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
+    the tier assigned to the calling client.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -95,8 +68,8 @@ paths:
         Returns the current published version (with content) of a Terms document.
         The `docType` selects which document; omitting it returns the default document.
 
-        Requires Developer auth only — **no end-user JWT is required**, so the document
-        can be fetched during onboarding before the user has a session.
+        No user session token is required, so the document can be fetched during onboarding
+        before the user has a session.
       security:
         - developerToken: []
         - developerSignature: []
@@ -155,12 +128,11 @@ paths:
       summary: "Record consent to a Terms version"
       description: |
         Records the authenticated user's agreement to a specific version of a Terms
-        document. `versionId` must be the version the user actually saw — if a newer
+        document. `versionId` must be the version the user actually saw. If a newer
         version has since been published, the accept is rejected (409) so the user
         re-reads it.
 
-        Requires Developer auth **plus** an end-user JWT (`context.authorization`);
-        the consent is recorded against the authenticated account.
+        Requires a user session token. The consent is recorded against that user.
       security:
         - developerToken: []
         - developerSignature: []
@@ -233,7 +205,7 @@ paths:
         `terms:manage` scope, which is granted through the scope-approval workflow at
         client registration.
 
-        Requires Developer auth only — **no end-user JWT is required**.
+        No user session token is required.
         `requiresReconsent` defaults to `true` when omitted (treated as a material change).
       security:
         - developerToken: []
@@ -420,7 +392,7 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
+      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -428,12 +400,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "Forbidden. Insufficient permissions (missing required scope)."
+      description: "The caller does not have the scope required by this endpoint."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -452,9 +424,7 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
-      description: |
-        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
-        response header indicates how long the caller should wait before retrying.
+      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }

--- a/api/terms-interfaces.yaml
+++ b/api/terms-interfaces.yaml
@@ -35,24 +35,14 @@ info:
     ```
     (Error details are in the context.error object)
 
-    ### Authentication and Authorization
-    This API uses a two-level authorization model contained within the `context`:
+    ### Authentication
 
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
-
-    2.  **User-Level (End-User) Authorization:**
-        * `context.authorization`: The end-user's JWT session token (for session-based calls).
-        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
-
-    ### Per-endpoint authentication
-
-    * `POST /v1/terms/get`: Developer auth only. **No end-user JWT** is required: the
-      document must be readable during onboarding, before the user has a session.
-    * `POST /v1/terms/accept`: Developer auth **plus** an end-user JWT
-      (`context.authorization`). Consent is recorded against the authenticated account.
-    * `POST /v1/terms/publish`: Developer auth only, admin-gated via a protected scope.
-      **No end-user JWT** is required.
+    * `context.developerToken`: the developer token of the calling application. Required on
+      every endpoint.
+    * `context.authorization`: the end user's session token. Required on the endpoints that
+      act on a signed-in user; each operation states when it is needed.
+    * `signature` (top level): the end user's JWS over the payload, for operations that must
+      be signed by the user.
 
     ### RBAC Scopes
 
@@ -92,10 +82,8 @@ paths:
         Returns the current published version (with content) of a Terms document.
         The `docType` selects which document; omitting it returns the default document.
 
-        Requires Developer auth only. **No end-user JWT is required**, so the document
-        can be fetched during onboarding before the user has a session.
-      security:
-        - developerToken: []
+        No user session token is required, so the document can be fetched during onboarding
+        before the user has a session.
       x-scopes: [terms:view]
       requestBody:
         required: true
@@ -109,7 +97,7 @@ paths:
                 version: "v1"
                 ts: "2026-07-09T12:00:00Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
               payload:
                 docType: "terms_of_use"
       responses:
@@ -155,10 +143,9 @@ paths:
         version has since been published, the accept is rejected (409) so the user
         re-reads it.
 
-        Requires Developer auth **plus** an end-user JWT (`context.authorization`);
-        the consent is recorded against the authenticated account.
-      security:
-        - developerToken: []
+        The consent is recorded against the authenticated account.
+
+        Requires a user session token in `context.authorization`.
       x-scopes: [terms:create]
       requestBody:
         required: true
@@ -172,7 +159,7 @@ paths:
                 version: "v1"
                 ts: "2026-07-09T12:05:00Z"
                 msgId: "c1b2c3d4-e5f6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 docType: "terms_of_use"
@@ -228,10 +215,8 @@ paths:
         `terms:manage` scope, which is granted through the scope-approval workflow at
         client registration.
 
-        Requires Developer auth only. **No end-user JWT is required**.
+        No user session token is required.
         `requiresReconsent` defaults to `true` when omitted (treated as a material change).
-      security:
-        - developerToken: []
       x-scopes: [terms:manage]
       requestBody:
         required: true
@@ -245,7 +230,7 @@ paths:
                 version: "v1"
                 ts: "2026-07-09T09:00:00Z"
                 msgId: "e1b2c3d4-e5f6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
               payload:
                 docType: "terms_of_use"
                 versionLabel: "2026.07"
@@ -293,14 +278,13 @@ components:
     # --- API Envelope Schemas ---
     Context:
       type: object
-      required: [id, version, ts, msgId]
+      required: [id, version, ts, msgId, developerToken]
       properties:
         id: { type: string, example: "api.terms.get" }
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token." }
     ResponseContext:
       type: object
@@ -340,6 +324,26 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/Signature'
+    UserContext:
+      type: object
+      required: [id, version, ts, msgId, developerToken, authorization]
+      properties:
+        id: { type: string, example: "api.terms.get" }
+        version: { type: string, example: "v1" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
+        authorization: { type: string, example: "Bearer eyJ...", description: "End-user's session token." }
+    UserRequestContext:
+      type: object
+      required: [context, payload]
+      properties:
+        context: { $ref: '#/components/schemas/UserContext' }
+        payload: { type: object }
+        signature:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Signature'
     ApiResponse:
       type: object
       required: [context, response]
@@ -355,7 +359,7 @@ components:
 
     # --- Specific Request Envelopes ---
     ApiRequest_GetTermsRequest:     { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/GetTermsRequest' } } } ] }
-    ApiRequest_AcceptTermsRequest:  { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/AcceptTermsRequest' } } } ] }
+    ApiRequest_AcceptTermsRequest:  { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/AcceptTermsRequest' } } } ] }
     ApiRequest_PublishTermsRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/PublishTermsRequest' } } } ] }
 
     # --- Specific Response Envelopes ---
@@ -457,16 +461,3 @@ components:
           example:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
-
-  # -------------------- Security --------------------
-  securitySchemes:
-    # This section is for documentation purposes.
-    # The server will check for the HTTP header first and fallbacks to context in case the headers are missing.
-
-    # 1. The Developer's Identity Token (Who they are)
-    developerToken:
-      type: http
-      scheme: bearer
-      bearerFormat: "JWT or Opaque"
-      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."
-    # 2. The Developer's Request Signature (What they're attesting to)

--- a/api/terms-interfaces.yaml
+++ b/api/terms-interfaces.yaml
@@ -6,28 +6,56 @@ info:
     These endpoints publish, serve, and record end-user agreement to versioned
     legal documents (Terms of Use, Privacy Policy, etc.).
 
-    ### Envelope
+    ### Protocol-Agnostic Envelope
+    All API interactions use a standard JSON envelope.
 
-    All endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
-    On failure `context.status` is `failed`, `context.error` carries a `code` and a
-    `message`, and `response` is empty.
+    **Request Envelope:**
+    ```json
+    {
+      "context": { ... },
+      "payload": { ... },
+      "signature": { ... } // Optional
+    }
+    ```
 
-    ### Authentication
+    **Response Envelope (Success):**
+    ```json
+    {
+      "context": { ..., "status": "successful" },
+      "response": { ... }
+    }
+    ```
 
-    * `context.developerToken`: the calling application's developer token. Required on
-      every endpoint.
-    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
-      `Signature` header.
-    * `context.authorization`: the end user's session token, required by the endpoints
-      that act on a signed-in user. Each operation states when it is needed.
+    **Response Envelope (Error):**
+    ```json
+    {
+      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." },
+      "response": {} // Empty on error
+    }
+    ```
+    (Error details are in the context.error object)
 
-    ### Per-endpoint requirements
+    ### Authentication and Authorization
+    This API uses a two-level authorization model contained within the `context`:
 
-    * `POST /v1/terms/get`: no user session token, so the document can be read during
-      onboarding before the user has a session.
-    * `POST /v1/terms/accept`: requires a user session token. Consent is recorded against
-      that user.
-    * `POST /v1/terms/publish`: no user session token; restricted to administrators.
+    1.  **Platform-Level (Developer) Authentication:**
+        * `context.developerToken`: The B2B Developer's API Key/Token.
+        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
+
+    2.  **User-Level (End-User) Authorization:**
+        * `context.authorization`: The end-user's JWT session token (for session-based calls).
+        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
+
+    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
+
+    ### Per-endpoint authentication
+
+    * `POST /v1/terms/get`: Developer auth only. **No end-user JWT** is required: the
+      document must be readable during onboarding, before the user has a session.
+    * `POST /v1/terms/accept`: Developer auth **plus** an end-user JWT
+      (`context.authorization`). Consent is recorded against the authenticated account.
+    * `POST /v1/terms/publish`: Developer auth only, admin-gated via a protected scope.
+      **No end-user JWT** is required.
 
     ### RBAC Scopes
 
@@ -35,15 +63,14 @@ info:
     |----------|----------------|
     | `POST /v1/terms/get` | `terms:view` |
     | `POST /v1/terms/accept` | `terms:create` |
-    | `POST /v1/terms/publish` | `terms:manage` *(administrators only)* |
+    | `POST /v1/terms/publish` | `terms:manage` *(protected: admin-only; granted via the scope-approval workflow at client registration)* |
 
-    Calls failing the scope check return `403`.
+    Calls failing the scope check return `403 FORBIDDEN`.
 
     ### Rate limiting
 
-    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
-    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
-    the tier assigned to the calling client.
+    All endpoints are protected by a scope-tier sliding-window rate limiter; on
+    breach the response is `429 Too Many Requests` with a `Retry-After` header.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -68,8 +95,8 @@ paths:
         Returns the current published version (with content) of a Terms document.
         The `docType` selects which document; omitting it returns the default document.
 
-        No user session token is required, so the document can be fetched during onboarding
-        before the user has a session.
+        Requires Developer auth only. **No end-user JWT is required**, so the document
+        can be fetched during onboarding before the user has a session.
       security:
         - developerToken: []
         - developerSignature: []
@@ -132,7 +159,8 @@ paths:
         version has since been published, the accept is rejected (409) so the user
         re-reads it.
 
-        Requires a user session token. The consent is recorded against that user.
+        Requires Developer auth **plus** an end-user JWT (`context.authorization`);
+        the consent is recorded against the authenticated account.
       security:
         - developerToken: []
         - developerSignature: []
@@ -205,7 +233,7 @@ paths:
         `terms:manage` scope, which is granted through the scope-approval workflow at
         client registration.
 
-        No user session token is required.
+        Requires Developer auth only. **No end-user JWT is required**.
         `requiresReconsent` defaults to `true` when omitted (treated as a material change).
       security:
         - developerToken: []
@@ -392,7 +420,7 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
+      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -400,12 +428,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "The caller does not have the scope required by this endpoint."
+      description: "Forbidden. Insufficient permissions (missing required scope)."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -424,7 +452,9 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
-      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }

--- a/api/token-class-config-interfaces.yaml
+++ b/api/token-class-config-interfaces.yaml
@@ -2,56 +2,33 @@ openapi: 3.0.4
 info:
   title: "Finternet API - Token Class Configuration"
   description: |
-    API specification for managing **Token Class Configurations** — the mapping
+    API specification for managing **Token Class Configurations**: the mapping
     between a registered Token Class and the Token Program (and hooks) that
     process its operations.
 
     A Token Class describes *what* the token is (its metadata, identity model,
     token standard). A Token Program describes *how* operations on it are
     executed (mint, burn, transfer, freeze, etc.). The Token Class Config glues
-    the two together for a specific class — and additionally configures pre/post
+    the two together for a specific class, and configures pre/post
     hooks, per-operation overrides, and class-specific commitment settings.
 
     A Token Class **must** have a corresponding Token Class Config before any
     operation (mint, transfer, burn …) can be executed on tokens in that class.
 
-    ### Protocol-Agnostic Envelope
-    All API interactions use a standard JSON envelope.
+    ### Envelope
 
-    **Request Envelope:**
-    ```json
-    {
-      "context": { ... },
-      "payload": { ... },
-      "signature": { ... } // Optional
-    }
-    ```
+    All endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
+    On failure `context.status` is `failed`, `context.error` carries a `code` and a
+    `message`, and `response` is empty.
 
-    **Response Envelope (Success):**
-    ```json
-    {
-      "context": { ..., "status": "successful" },
-      "response": { ... }
-    }
-    ```
+    ### Authentication
 
-    **Response Envelope (Error):**
-    ```json
-    {
-      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." }},
-      "response": {} // Empty on error
-    }
-    ```
-
-    ### Authentication and Authorization
-    This API uses the same two-level authorization model as other UNITS services:
-
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
-        * `context.developerSignature`: The B2B Developer's signature.
-
-    2.  **User-Level (End-User) Authorization:**
-        * `context.authorization`: The end-user's JWT session token.
+    * `context.developerToken`: the calling application's developer token. Required on
+      every endpoint.
+    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
+      `Signature` header.
+    * `context.authorization`: the end user's session token, required by the endpoints
+      that act on a signed-in user. Each operation states when it is needed.
 
     ### RBAC Scopes
 
@@ -64,9 +41,9 @@ info:
 
     ### Rate limiting
 
-    Requests are subject to a scope-tier sliding-window rate limiter. When the
-    limit is exceeded the service responds with `429 Too Many Requests` and a
-    `Retry-After` header (see the `RateLimitedError` response component).
+    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
+    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
+    the tier assigned to the calling client.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -75,7 +52,7 @@ servers:
     description: "Local Server"
 tags:
   - name: "Token Class Configs"
-    description: "Endpoints for managing the mapping between a Token Class and a Token Program — including pre/post hooks, per-operation overrides, and commitment settings."
+    description: "Endpoints for managing the mapping between a Token Class and a Token Program, including pre/post hooks, per-operation overrides, and commitment settings."
 
 # ===============================================================
 #   PATHS
@@ -212,8 +189,8 @@ paths:
         - "Token Class Configs"
       summary: "Update a token class config"
       description: |
-        Update an existing token class configuration. Supports partial update —
-        only fields present in the payload are modified. Use to add or rotate
+        Update an existing token class configuration. Only fields present in the payload
+        are modified. Use to add or rotate
         hooks, change the program binding, or toggle status.
       security:
         - developerToken: []
@@ -313,6 +290,8 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '429':
           $ref: '#/components/responses/RateLimitedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
 
   /v1/tokenclassconfig/search:
     post:
@@ -357,6 +336,8 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '429':
           $ref: '#/components/responses/RateLimitedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
 
 # ===============================================================
 #   COMPONENTS
@@ -375,7 +356,7 @@ components:
         msgId: { type: string, format: uuid }
         developerToken: { type: string, nullable: true, description: "B2B Developer API Key/Token" }
         developerSignature: { type: string, nullable: true, description: "B2B Developer Signature" }
-        authorization: { type: string, nullable: true, description: "End-user JWT session token" }
+        authorization: { type: string, nullable: true, description: "End user's session token" }
     ResponseContext:
       type: object
       required: [id, version, ts, msgId, status]
@@ -581,7 +562,7 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed."
+      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -589,12 +570,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "Forbidden. Insufficient permissions."
+      description: "The caller does not have the scope required by this endpoint."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -613,9 +594,7 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
-      description: |
-        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
-        response header indicates how long the caller should wait before retrying.
+      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }

--- a/api/token-class-config-interfaces.yaml
+++ b/api/token-class-config-interfaces.yaml
@@ -9,26 +9,49 @@ info:
     A Token Class describes *what* the token is (its metadata, identity model,
     token standard). A Token Program describes *how* operations on it are
     executed (mint, burn, transfer, freeze, etc.). The Token Class Config glues
-    the two together for a specific class, and configures pre/post
+    the two together for a specific class, and additionally configures pre/post
     hooks, per-operation overrides, and class-specific commitment settings.
 
     A Token Class **must** have a corresponding Token Class Config before any
     operation (mint, transfer, burn …) can be executed on tokens in that class.
 
-    ### Envelope
+    ### Protocol-Agnostic Envelope
+    All API interactions use a standard JSON envelope.
 
-    All endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
-    On failure `context.status` is `failed`, `context.error` carries a `code` and a
-    `message`, and `response` is empty.
+    **Request Envelope:**
+    ```json
+    {
+      "context": { ... },
+      "payload": { ... },
+      "signature": { ... } // Optional
+    }
+    ```
 
-    ### Authentication
+    **Response Envelope (Success):**
+    ```json
+    {
+      "context": { ..., "status": "successful" },
+      "response": { ... }
+    }
+    ```
 
-    * `context.developerToken`: the calling application's developer token. Required on
-      every endpoint.
-    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
-      `Signature` header.
-    * `context.authorization`: the end user's session token, required by the endpoints
-      that act on a signed-in user. Each operation states when it is needed.
+    **Response Envelope (Error):**
+    ```json
+    {
+      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." }},
+      "response": {} // Empty on error
+    }
+    ```
+
+    ### Authentication and Authorization
+    This API uses the same two-level authorization model as other UNITS services:
+
+    1.  **Platform-Level (Developer) Authentication:**
+        * `context.developerToken`: The B2B Developer's API Key/Token.
+        * `context.developerSignature`: The B2B Developer's signature.
+
+    2.  **User-Level (End-User) Authorization:**
+        * `context.authorization`: The end-user's JWT session token.
 
     ### RBAC Scopes
 
@@ -41,9 +64,9 @@ info:
 
     ### Rate limiting
 
-    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
-    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
-    the tier assigned to the calling client.
+    Requests are subject to a scope-tier sliding-window rate limiter. When the
+    limit is exceeded the service responds with `429 Too Many Requests` and a
+    `Retry-After` header (see the `RateLimitedError` response component).
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -189,8 +212,8 @@ paths:
         - "Token Class Configs"
       summary: "Update a token class config"
       description: |
-        Update an existing token class configuration. Only fields present in the payload
-        are modified. Use to add or rotate
+        Update an existing token class configuration. Supports partial update:
+        only fields present in the payload are modified. Use to add or rotate
         hooks, change the program binding, or toggle status.
       security:
         - developerToken: []
@@ -290,8 +313,6 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '429':
           $ref: '#/components/responses/RateLimitedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
 
   /v1/tokenclassconfig/search:
     post:
@@ -336,8 +357,6 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '429':
           $ref: '#/components/responses/RateLimitedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
 
 # ===============================================================
 #   COMPONENTS
@@ -356,7 +375,7 @@ components:
         msgId: { type: string, format: uuid }
         developerToken: { type: string, nullable: true, description: "B2B Developer API Key/Token" }
         developerSignature: { type: string, nullable: true, description: "B2B Developer Signature" }
-        authorization: { type: string, nullable: true, description: "End user's session token" }
+        authorization: { type: string, nullable: true, description: "End-user JWT session token" }
     ResponseContext:
       type: object
       required: [id, version, ts, msgId, status]
@@ -562,7 +581,7 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
+      description: "Authentication failed."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -570,12 +589,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "The caller does not have the scope required by this endpoint."
+      description: "Forbidden. Insufficient permissions."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions." } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -594,7 +613,9 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
-      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }

--- a/api/token-class-config-interfaces.yaml
+++ b/api/token-class-config-interfaces.yaml
@@ -109,7 +109,7 @@ paths:
                 value:
                   context:
                     id: "api.tokenclassconfig.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-03-05T10:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
                     developerToken: "fnt_..."
@@ -140,7 +140,7 @@ paths:
                 value:
                   context:
                     id: "api.tokenclassconfig.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-03-05T10:05:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
                     developerToken: "fnt_..."
@@ -166,7 +166,7 @@ paths:
               example:
                 context:
                   id: "api.tokenclassconfig.register"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-03-05T10:00:00Z"
                   msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
                   status: "successful"
@@ -230,7 +230,7 @@ paths:
                 value:
                   context:
                     id: "api.tokenclassconfig.update"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-03-05T11:00:00Z"
                     msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef012"
                     developerToken: "fnt_..."
@@ -250,7 +250,7 @@ paths:
                 value:
                   context:
                     id: "api.tokenclassconfig.update"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2026-03-05T11:30:00Z"
                     msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef0123"
                     developerToken: "fnt_..."
@@ -293,7 +293,7 @@ paths:
             example:
               context:
                 id: "api.tokenclassconfig.get"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-03-05T10:00:00Z"
                 msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef01234"
                 developerToken: "fnt_..."
@@ -331,7 +331,7 @@ paths:
             example:
               context:
                 id: "api.tokenclassconfig.search"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-03-05T10:00:00Z"
                 msgId: "a7b8c9d0-e1f2-3456-7890-abcdef012345"
                 developerToken: "fnt_..."
@@ -370,7 +370,7 @@ components:
       required: [id, version, ts, msgId]
       properties:
         id: { type: string, example: "api.tokenclassconfig.get" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         developerToken: { type: string, nullable: true, description: "B2B Developer API Key/Token" }
@@ -384,7 +384,7 @@ components:
         version: { type: string }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        status: { type: string, enum: [successful, failed] }
+        status: { type: string, enum: [successful, failed, pending] }
         error: { $ref: '#/components/schemas/ErrorPayload' }
     ErrorPayload:
       type: object

--- a/api/token-class-config-interfaces.yaml
+++ b/api/token-class-config-interfaces.yaml
@@ -112,7 +112,7 @@ paths:
                     version: "1.0"
                     ts: "2026-03-05T10:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer ..."
                   payload:
                     tokenClass: "USDC"
@@ -143,7 +143,7 @@ paths:
                     version: "1.0"
                     ts: "2026-03-05T10:05:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer ..."
                   payload:
                     tokenClass: "FINT-KYC-CRED"
@@ -233,7 +233,7 @@ paths:
                     version: "1.0"
                     ts: "2026-03-05T11:00:00Z"
                     msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef012"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer ..."
                   payload:
                     tokenClass: "USDC"
@@ -253,7 +253,7 @@ paths:
                     version: "1.0"
                     ts: "2026-03-05T11:30:00Z"
                     msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef0123"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer ..."
                   payload:
                     tokenClass: "USDC"
@@ -296,7 +296,7 @@ paths:
                 version: "1.0"
                 ts: "2026-03-05T10:00:00Z"
                 msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef01234"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
                 authorization: "Bearer ..."
               payload:
                 tokenClass: "USDC"
@@ -334,7 +334,7 @@ paths:
                 version: "1.0"
                 ts: "2026-03-05T10:00:00Z"
                 msgId: "a7b8c9d0-e1f2-3456-7890-abcdef012345"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
                 authorization: "Bearer ..."
               payload:
                 filters:
@@ -343,7 +343,7 @@ paths:
                 pagination:
                   limit: 50
                   offset: 0
-                sort:
+                sortBy:
                   field: "createdAt"
                   order: "desc"
       responses:
@@ -415,8 +415,8 @@ components:
     PaginationRequest:
       type: object
       properties:
-        limit: { type: integer, default: 50, minimum: 1, maximum: 100 }
-        offset: { type: integer, default: 0, minimum: 0 }
+        limit: { type: integer, minimum: 0 }
+        offset: { type: integer, minimum: 0 }
     PaginationResponse:
       type: object
       properties:
@@ -426,50 +426,13 @@ components:
     SortRequest:
       type: object
       properties:
-        field: { type: string, enum: [createdAt, updatedAt, tokenClass], default: createdAt }
-        order: { type: string, enum: [asc, desc], default: desc }
-
-    # --- Hook Configuration ---
-    HookConfig:
-      type: object
-      required: [hookId, priority, enabled]
-      description: |
-        A pre- or post-hook bound to operations on this token class. Hooks run
-        in priority order (lower numbers first). Pre-hook failures abort the
-        operation; post-hook failures are logged but do not roll back state.
-      properties:
-        hookId:
-          type: string
-          description: "Identifier of the hook implementation registered with the runtime."
-          example: "min-balance"
-        priority:
-          type: integer
-          minimum: 0
-          description: "Execution order. Lower runs first."
-          example: 1
-        enabled:
-          type: boolean
-          description: "Whether this hook is currently active."
-          example: true
-        operations:
-          type: array
-          items: { type: string }
-          nullable: true
-          description: |
-            Limit this hook to specific operations (mint, burn, transfer, freeze,
-            unfreeze, lock, unlock, redeem, update, addClaim, revokeClaim).
-            If omitted, the hook applies to all operations.
-          example: ["transfer", "burn"]
-        config:
-          type: object
-          nullable: true
-          additionalProperties: true
-          description: "Hook-specific configuration. Schema is defined by the hook implementation."
+        field: { type: string }
+        order: { type: string, enum: [asc, desc] }
 
     # --- Token Class Config ---
     TokenClassConfig:
       type: object
-      required: [id, tokenClass, tokenClassId, programId, status]
+      required: [id, tokenClass, tokenClassId, programId, status, createdAt, updatedAt]
       description: "Configuration mapping a Token Class to a Token Program with hooks and per-operation overrides."
       properties:
         id:
@@ -491,32 +454,28 @@ components:
         preHooks:
           type: array
           nullable: true
-          items: { $ref: '#/components/schemas/HookConfig' }
-          description: "Hooks executed before the operation. A failure aborts the operation."
+          items: { type: object, additionalProperties: true }
+          description: "Free-form hooks executed before the operation. Structure is defined by the hook implementation."
         postHooks:
           type: array
           nullable: true
-          items: { $ref: '#/components/schemas/HookConfig' }
-          description: "Hooks executed after the operation completes. Failures are logged but do not roll back state."
+          items: { type: object, additionalProperties: true }
+          description: "Free-form hooks executed after the operation completes. Structure is defined by the hook implementation."
         operationOverrides:
           type: object
           nullable: true
           additionalProperties: true
-          description: |
-            Per-operation override settings keyed by operation name
-            (e.g., `mint`, `transfer`, `burn`). Schema is operation-specific.
+          description: "Free-form per-operation override settings. Structure is service-defined."
         config:
           type: object
           nullable: true
           additionalProperties: true
-          description: |
-            Class-specific configuration. Recognised keys:
-              * `stateCommitmentFields` (string[]) — fields included in the per-token state-commitment chain.
-              * `stateCommitmentAlgorithm` (string) — hash algorithm. One of `sha256`, `blake3`.
+          description: "Free-form class-specific configuration. Structure is service-defined."
+        identities:
+          description: "Free-form identity metadata associated with the config (structure is service-defined)."
         status:
           type: string
-          enum: [active, inactive, suspended]
-          description: "Current status of the config. Operations are only routed when status is `active`."
+          description: "Current status of the config (e.g. `active`). Operations are only routed when status is `active`."
           example: "active"
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
@@ -530,10 +489,10 @@ components:
         programId: { type: string, example: "reference-ft" }
         preHooks:
           type: array
-          items: { $ref: '#/components/schemas/HookConfig' }
+          items: { type: object, additionalProperties: true }
         postHooks:
           type: array
-          items: { $ref: '#/components/schemas/HookConfig' }
+          items: { type: object, additionalProperties: true }
         operationOverrides:
           type: object
           additionalProperties: true
@@ -549,10 +508,10 @@ components:
         programId: { type: string }
         preHooks:
           type: array
-          items: { $ref: '#/components/schemas/HookConfig' }
+          items: { type: object, additionalProperties: true }
         postHooks:
           type: array
-          items: { $ref: '#/components/schemas/HookConfig' }
+          items: { type: object, additionalProperties: true }
         operationOverrides:
           type: object
           additionalProperties: true
@@ -561,7 +520,6 @@ components:
           additionalProperties: true
         status:
           type: string
-          enum: [active, inactive, suspended]
 
     GetTokenClassConfigRequest:
       type: object
@@ -574,19 +532,14 @@ components:
       properties:
         filters:
           type: object
-          description: |
-            Search filters for token class configs.
-            Known fields: tokenClass, programId, status.
-          properties:
-            tokenClass: { type: string }
-            programId: { type: string }
-            status: { type: string }
           additionalProperties: true
+          description: "Free-form search filters for token class configs."
         pagination: { $ref: '#/components/schemas/PaginationRequest' }
-        sort: { $ref: '#/components/schemas/SortRequest' }
+        sortBy: { $ref: '#/components/schemas/SortRequest' }
 
     TokenClassConfigList:
       type: object
+      required: [tokenClassConfigs, pagination]
       properties:
         tokenClassConfigs:
           type: array

--- a/api/token-class-config-interfaces.yaml
+++ b/api/token-class-config-interfaces.yaml
@@ -48,7 +48,6 @@ info:
 
     1.  **Platform-Level (Developer) Authentication:**
         * `context.developerToken`: The B2B Developer's API Key/Token.
-        * `context.developerSignature`: The B2B Developer's signature.
 
     2.  **User-Level (End-User) Authorization:**
         * `context.authorization`: The end-user's JWT session token.
@@ -96,7 +95,6 @@ paths:
         executed on tokens of this class.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -217,7 +215,6 @@ paths:
         hooks, change the program binding, or toggle status.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -373,8 +370,7 @@ components:
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        developerToken: { type: string, nullable: true, description: "B2B Developer API Key/Token" }
-        developerSignature: { type: string, nullable: true, description: "B2B Developer Signature" }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
         authorization: { type: string, nullable: true, description: "End-user JWT session token" }
     ResponseContext:
       type: object
@@ -632,9 +628,4 @@ components:
       type: http
       scheme: bearer
       bearerFormat: "JWT or Opaque"
-      description: "B2B Developer API Key/Token in Authorization header."
-    developerSignature:
-      type: apiKey
-      in: header
-      name: Signature
-      description: "IETF HTTP Signature (RFC 9421) for message integrity."
+      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."

--- a/api/token-class-config-interfaces.yaml
+++ b/api/token-class-config-interfaces.yaml
@@ -586,7 +586,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "AUTHENTICATION_FAILED", message: "Token invalid or expired." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
       description: "Forbidden. Insufficient permissions."
@@ -594,7 +594,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "PERMISSION_DENIED", message: "Insufficient permissions." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions." } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -610,7 +610,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "Invalid request parameters." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
       description: |
@@ -623,7 +623,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
 
   # -------------------- Security --------------------

--- a/api/token-class-config-interfaces.yaml
+++ b/api/token-class-config-interfaces.yaml
@@ -43,14 +43,12 @@ info:
     }
     ```
 
-    ### Authentication and Authorization
-    This API uses the same two-level authorization model as other UNITS services:
+    ### Authentication
 
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
-
-    2.  **User-Level (End-User) Authorization:**
-        * `context.authorization`: The end-user's JWT session token.
+    * `context.developerToken`: the developer token of the calling application. Required on
+      every endpoint.
+    * `context.authorization`: the end user's session token. Required on the endpoints that
+      act on a signed-in user; each operation states when it is needed.
 
     ### RBAC Scopes
 
@@ -93,8 +91,8 @@ paths:
 
         **Required before any operation** (mint, burn, transfer, etc.) can be
         executed on tokens of this class.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -110,7 +108,7 @@ paths:
                     version: "v1"
                     ts: "2026-03-05T10:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer ..."
                   payload:
                     tokenClass: "USDC"
@@ -141,7 +139,7 @@ paths:
                     version: "v1"
                     ts: "2026-03-05T10:05:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer ..."
                   payload:
                     tokenClass: "FINT-KYC-CRED"
@@ -213,8 +211,8 @@ paths:
         Update an existing token class configuration. Supports partial update:
         only fields present in the payload are modified. Use to add or rotate
         hooks, change the program binding, or toggle status.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -230,7 +228,7 @@ paths:
                     version: "v1"
                     ts: "2026-03-05T11:00:00Z"
                     msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef012"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer ..."
                   payload:
                     tokenClass: "USDC"
@@ -250,7 +248,7 @@ paths:
                     version: "v1"
                     ts: "2026-03-05T11:30:00Z"
                     msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef0123"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer ..."
                   payload:
                     tokenClass: "USDC"
@@ -278,9 +276,7 @@ paths:
       tags:
         - "Token Class Configs"
       summary: "Get a token class config"
-      description: "Retrieve the configuration registered for a specific token class."
-      security:
-        - developerToken: []
+      description: "Retrieve the configuration registered for a specific token class. Requires a user session token in `context.authorization`."
       requestBody:
         required: true
         content:
@@ -293,7 +289,7 @@ paths:
                 version: "v1"
                 ts: "2026-03-05T10:00:00Z"
                 msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef01234"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer ..."
               payload:
                 tokenClass: "USDC"
@@ -316,9 +312,7 @@ paths:
       tags:
         - "Token Class Configs"
       summary: "Search token class configs"
-      description: "Search and list token class configurations with filters and pagination."
-      security:
-        - developerToken: []
+      description: "Search and list token class configurations with filters and pagination. Requires a user session token in `context.authorization`."
       requestBody:
         required: true
         content:
@@ -331,7 +325,7 @@ paths:
                 version: "v1"
                 ts: "2026-03-05T10:00:00Z"
                 msgId: "a7b8c9d0-e1f2-3456-7890-abcdef012345"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer ..."
               payload:
                 filters:
@@ -364,13 +358,13 @@ components:
     # --- Shared Envelope Schemas ---
     Context:
       type: object
-      required: [id, version, ts, msgId]
+      required: [id, version, ts, msgId, developerToken]
       properties:
         id: { type: string, example: "api.tokenclassconfig.get" }
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
         authorization: { type: string, nullable: true, description: "End-user JWT session token" }
     ResponseContext:
       type: object
@@ -394,6 +388,22 @@ components:
       required: [context, payload]
       properties:
         context: { $ref: '#/components/schemas/Context' }
+        payload: { type: object }
+    UserContext:
+      type: object
+      required: [id, version, ts, msgId, developerToken, authorization]
+      properties:
+        id: { type: string, example: "api.tokenclassconfig.get" }
+        version: { type: string, example: "v1" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
+        authorization: { type: string, description: "End-user JWT session token" }
+    UserRequestContext:
+      type: object
+      required: [context, payload]
+      properties:
+        context: { $ref: '#/components/schemas/UserContext' }
         payload: { type: object }
     ApiResponse:
       type: object
@@ -545,22 +555,22 @@ components:
     # --- Request/Response Envelopes ---
     ApiRequest_RegisterTokenClassConfigRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/RegisterTokenClassConfigRequest' }
     ApiRequest_UpdateTokenClassConfigRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/UpdateTokenClassConfigRequest' }
     ApiRequest_GetTokenClassConfigRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/GetTokenClassConfigRequest' }
     ApiRequest_SearchTokenClassConfigRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/SearchTokenClassConfigRequest' }
     ApiResponse_TokenClassConfigDetails:
@@ -621,11 +631,3 @@ components:
           example:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
-
-  # -------------------- Security --------------------
-  securitySchemes:
-    developerToken:
-      type: http
-      scheme: bearer
-      bearerFormat: "JWT or Opaque"
-      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."

--- a/api/token-interfaces.yaml
+++ b/api/token-interfaces.yaml
@@ -1394,7 +1394,6 @@ paths:
                       status: "submitted"
                       message: "Transfer workflow submitted for primitive orchestration"
                       workflowInstanceId: "urn:uuid:tx-d8e5f6a7-b8c9-0123-4567-890abcdef123"
-                      workflowUrl: "https://restate.example/PrimitiveOperationWorkflow/urn:uuid:tx-d8e5f6a7-b8c9-0123-4567-890abcdef123"
                 BurnAccepted:
                   summary: "Burn submitted (no workflow fields)"
                   value:
@@ -2854,9 +2853,6 @@ components:
         workflowInstanceId:
           type: string
           description: "Federation workflow instance id (present when the operation routes a federation transfer)"
-        workflowUrl:
-          type: string
-          description: "Human-readable workflow URL (present when the operation routes a federation transfer)"
 
     AddTokenResponse:
       type: object

--- a/api/token-interfaces.yaml
+++ b/api/token-interfaces.yaml
@@ -1712,11 +1712,8 @@ paths:
         - **Proxy token** (USDC, ETH, SOL, etc.): supply `chainId`, `contractAddress`,
           `walletAddress`, `value`.
 
-        This is a **backend-to-backend** endpoint, typically called by the Finternet App
-        Backend on a provider callback.
-
-        **No User JWT Required:** This endpoint does not require end-user authentication.
-        The token owner address is provided in the payload.
+        This is a **backend-to-backend** endpoint, typically called by the application
+        backend on a provider callback. The token owner address is provided in the payload.
 
         The token is created via an async transaction/workflow; the returned `txId`
         tracks it.

--- a/api/token-interfaces.yaml
+++ b/api/token-interfaces.yaml
@@ -36,15 +36,14 @@ info:
     ```
     (Error details are in the context.error object)
 
-    ### Authentication and Authorization
-    This API uses the same two-level authorization model as the Account service:
+    ### Authentication
 
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
-
-    2.  **User-Level (End-User) Authorization:**
-        * `context.authorization`: The end-user's JWT session token (for session-based calls).
-        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
+    * `context.developerToken`: the developer token of the calling application. Required on
+      every endpoint.
+    * `context.authorization`: the end user's session token. Required on the endpoints that
+      act on a signed-in user; each operation states when it is needed.
+    * `signature` (top level): the end user's JWS over the payload, for operations that must
+      be signed by the user.
 
     ### RBAC Scopes
 
@@ -113,8 +112,8 @@ paths:
       description: |
         Register a new token class with schema definition and metadata.
         Only authorized administrators can register token classes.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -130,7 +129,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "USDC"
@@ -164,7 +163,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "USDT"
@@ -198,7 +197,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "EURC"
@@ -232,7 +231,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "GBPT"
@@ -266,7 +265,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef1"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "INRT"
@@ -300,7 +299,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef12"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "NFH-T"
@@ -335,7 +334,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "a7b8c9d0-e1f2-3456-7890-abcdef123"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "ART-NFT"
@@ -373,7 +372,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "b8c9d0e1-f2a3-4567-8901-bcdef1234"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "RWA-NFT"
@@ -457,8 +456,8 @@ paths:
       description: |
         Update token class metadata, schema, or identities/roles.
         Can be used to add/remove authorized minters or update class properties.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -471,7 +470,7 @@ paths:
                 version: "v1"
                 ts: "2025-01-04T11:00:00Z"
                 msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 tokenClass: "USDC"
@@ -502,10 +501,7 @@ paths:
       tags:
         - "Token Classes"
       summary: "Get token class details"
-      description: "Retrieve detailed information about a specific token class"
-      security:
-        - developerToken: []
-        - userToken: []
+      description: "Retrieve detailed information about a specific token class Requires a user session token in `context.authorization`."
       requestBody:
         required: true
         content:
@@ -518,7 +514,7 @@ paths:
                 version: "v1"
                 ts: "2025-01-04T10:00:00Z"
                 msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef12"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 tokenClass: "USDC"
@@ -574,10 +570,7 @@ paths:
       tags:
         - "Token Classes"
       summary: "Search token classes"
-      description: "Search and list all registered token classes with filters"
-      security:
-        - developerToken: []
-        - userToken: []
+      description: "Search and list all registered token classes with filters Requires a user session token in `context.authorization`."
       requestBody:
         required: true
         content:
@@ -590,7 +583,7 @@ paths:
                 version: "v1"
                 ts: "2025-01-04T10:00:00Z"
                 msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef123"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 filters:
@@ -685,10 +678,7 @@ paths:
       tags:
         - "Token"
       summary: "Get token details"
-      description: "Retrieves detailed information about a specific token by its ID. Requires Developer and User auth."
-      security:
-        - developerToken: []
-        - userToken: []
+      description: "Retrieves detailed information about a specific token by its ID. Requires Developer and User auth. Requires a user session token in `context.authorization`."
       requestBody:
         required: true
         content:
@@ -704,7 +694,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenId: "urn:uuid:a1b2c3d4-e5f6-7890-abcd-1234567890ab"
@@ -716,7 +706,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdf0"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                     valueFormat: "display"
                   payload:
@@ -807,9 +797,9 @@ paths:
         Mint (create) a new token instance. This endpoint has separate ACL controls from other token operations.
         Only authorized identities registered for the tokenClass can mint tokens.
 
-        Requires both developer authentication and end-user signature.
-      security:
-        - developerToken: []
+        Requires an end-user signature over the payload.
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -825,7 +815,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "c1d2e3f4-a5b6-7890-1234-567890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "USDC"
@@ -848,7 +838,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "d2e3f4a5-b6c7-8901-2345-67890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "INRT"
@@ -871,7 +861,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "e3f4a5b6-c7d8-9012-3456-7890abcdef1"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "NFH-T"
@@ -894,7 +884,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "f4a5b6c7-d8e9-0123-4567-890abcdef12"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "ART-NFT"
@@ -933,7 +923,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "a5b6c7d8-e9f0-1234-5678-90abcdef123"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "RWA-NFT"
@@ -989,9 +979,7 @@ paths:
       tags:
         - "Token"
       summary: "Search tokens"
-      description: "Search tokens with filters (type, status, etc.). Owner filtering inferred from JWT/ACL. Supports pagination. Requires Developer auth."
-      security:
-        - developerToken: []
+      description: "Search tokens with filters (type, status, etc.). Owner filtering inferred from JWT/ACL. Supports pagination. Requires Developer auth. Requires a user session token in `context.authorization`."
       requestBody:
         required: true
         content:
@@ -1007,7 +995,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     filters:
@@ -1030,7 +1018,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef2"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                     valueFormat: "display"
                   payload:
@@ -1134,8 +1122,8 @@ paths:
         **Signature required:** a top-level end-user payload `signature` is mandatory for
         every transact operation. units-api enforces this via a `RequireSignature`
         middleware on this route; a request without a valid `signature` is rejected.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -1151,7 +1139,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:15:00Z"
                     msgId: "f1a2b3c4-d5e6-7890-1234-567890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "transfer"
@@ -1169,7 +1157,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:15:00Z"
                     msgId: "g2b3c4d5-e6f7-8901-2345-67890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "transfer"
@@ -1187,7 +1175,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:15:00Z"
                     msgId: "h3c4d5e6-f7a8-9012-3456-7890abcdef1"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "transfer"
@@ -1205,7 +1193,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:15:00Z"
                     msgId: "i4d5e6f7-a8b9-0123-4567-890abcdef12"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "transfer"
@@ -1228,7 +1216,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:05:00Z"
                     msgId: "d1e2f3a4-b5c6-7890-1234-567890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "burn"
@@ -1246,7 +1234,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:05:00Z"
                     msgId: "d2e3f4a5-b6c7-8901-2345-67890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "burn"
@@ -1264,7 +1252,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:10:00Z"
                     msgId: "e1f2a3b4-c5d6-7890-1234-567890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "freeze"
@@ -1282,7 +1270,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:10:00Z"
                     msgId: "e2f3a4b5-c6d7-8901-2345-67890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "unfreeze"
@@ -1299,7 +1287,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:20:00Z"
                     msgId: "f3a4b5c6-d7e8-9012-3456-7890abcdef1"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "lock"
@@ -1318,7 +1306,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:20:00Z"
                     msgId: "f4a5b6c7-d8e9-0123-4567-890abcdef12"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "lock"
@@ -1337,7 +1325,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:20:00Z"
                     msgId: "f5a6b7c8-d9e0-1234-5678-90abcdef123"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "unlock"
@@ -1355,7 +1343,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-04T10:20:00Z"
                     msgId: "a2b3c4d5-e6f7-8901-2345-67890abcdef"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "update"
@@ -1431,9 +1419,8 @@ paths:
         `POST /v1/transactions/status` instead.
 
         Use this endpoint to poll for transaction completion after submitting via /v1/token/transact.
-      security:
-        - developerToken: []
-        - userToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -1446,7 +1433,7 @@ paths:
                 version: "v1"
                 ts: "2025-01-04T10:00:02Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
@@ -1523,9 +1510,8 @@ paths:
         proofs, and ledger anchors.
 
         Use this after transaction completion to get full audit trail.
-      security:
-        - developerToken: []
-        - userToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -1538,7 +1524,7 @@ paths:
                 version: "v1"
                 ts: "2025-01-04T10:00:10Z"
                 msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
@@ -1562,9 +1548,8 @@ paths:
       description: |
         Search transactions with filters and pagination.
         Useful for transaction history, reconciliation, and reporting. Owner/initiator filtering inferred from JWT/ACL.
-      security:
-        - developerToken: []
-        - userToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -1577,7 +1562,7 @@ paths:
                 version: "v1"
                 ts: "2025-01-04T10:00:00Z"
                 msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 filters:
@@ -1615,13 +1600,8 @@ paths:
         FederationController.Status). It reads the `transactions` row plus the
         `workflow_ops` audit list. A txn id with no transactions row returns 404.
 
-        Requires a developer token (+ scope) and a user token.
-
         The request has no dedicated JSON schema; the payload is modelled here as the
         transaction id (`txn_id`).
-      security:
-        - developerToken: []
-        - userToken: []
       requestBody:
         required: true
         content:
@@ -1634,7 +1614,7 @@ paths:
                 version: "v1"
                 ts: "2025-01-04T10:00:02Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 txn_id: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
@@ -1683,9 +1663,8 @@ paths:
       description: |
         Retrieves all transactions that affected a specific token.
         Provides complete audit trail and state history for the token.
-      security:
-        - developerToken: []
-        - userToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -1698,7 +1677,7 @@ paths:
                 version: "v1"
                 ts: "2025-01-04T10:00:00Z"
                 msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 filters:
@@ -1741,8 +1720,8 @@ paths:
 
         The token is created via an async transaction/workflow; the returned `txId`
         tracks it.
-      security:
-        - developerToken: []
+
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -1758,7 +1737,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-28T10:15:00Z"
                     msgId: "550e8400-e29b-41d4-a716-446655440000"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     tokenClass: "CREDENTIAL"
                     owner: "alice"
@@ -1789,7 +1768,7 @@ paths:
                     version: "v1"
                     ts: "2025-01-28T10:15:00Z"
                     msgId: "550e8400-e29b-41d4-a716-446655440001"
-                    developerToken: "fnt_..."
+                    developerToken: "c2Et..."
                   payload:
                     tokenClass: "USDC"
                     owner: "alice"
@@ -1841,10 +1820,7 @@ paths:
         - `proven`: Merkle proof generated
         - `anchored`: proof anchored to a public ledger, fully verifiable
 
-        Requires Developer + User auth.
-      security:
-        - developerToken: []
-        - userToken: []
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -1857,7 +1833,7 @@ paths:
                 version: "v1"
                 ts: "2025-01-04T10:00:02Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
@@ -1932,10 +1908,7 @@ paths:
         Merkle tree. Enables independent verification: fetch this data, hash it, and
         confirm it matches the `leafHash` returned by `/v1/transaction/proof`.
 
-        Requires Developer + User auth.
-      security:
-        - developerToken: []
-        - userToken: []
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -1948,7 +1921,7 @@ paths:
                 version: "v1"
                 ts: "2025-01-04T10:00:02Z"
                 msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
@@ -2004,10 +1977,7 @@ paths:
         For trustless verification, clients should verify independently using the data
         from `/v1/transaction/proof` and `/v1/transaction/proof/leaf`.
 
-        Requires Developer + User auth.
-      security:
-        - developerToken: []
-        - userToken: []
+        Requires a user session token in `context.authorization`.
       requestBody:
         required: true
         content:
@@ -2020,7 +1990,7 @@ paths:
                 version: "v1"
                 ts: "2025-01-04T10:00:02Z"
                 msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
@@ -2099,14 +2069,13 @@ components:
     # --- API Envelope Schemas (reusing from account API) ---
     Context:
       type: object
-      required: [id, version, ts, msgId]
+      required: [id, version, ts, msgId, developerToken]
       properties:
         id: { type: string, example: "api.token.get" }
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token" }
         valueFormat:
           type: string
@@ -2149,6 +2118,33 @@ components:
       required: [context, payload]
       properties:
         context: { $ref: '#/components/schemas/Context' }
+        payload: { type: object }
+        signature: { $ref: '#/components/schemas/Signature'}
+    UserContext:
+      type: object
+      required: [id, version, ts, msgId, developerToken, authorization]
+      properties:
+        id: { type: string, example: "api.token.get" }
+        version: { type: string, example: "v1" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
+        authorization: { type: string, example: "Bearer eyJ...", description: "End-user's session token" }
+        valueFormat:
+          type: string
+          enum: [raw, display]
+          default: "raw"
+          description: |
+            Controls how numeric amounts (balances, supply, fees) are represented in responses.
+            - `raw` (default): Smallest-unit integer strings (e.g., "100500000" for 100.5 USDC with 6 decimals).
+            - `display`: Human-readable decimal strings (e.g., "100.50" for 100.5 USDC).
+            The service layer performs decimal conversion using token class metadata.
+            Amounts are always opaque strings, never parsed as float by any system.
+    UserRequestContext:
+      type: object
+      required: [context, payload]
+      properties:
+        context: { $ref: '#/components/schemas/UserContext' }
         payload: { type: object }
         signature: { $ref: '#/components/schemas/Signature'}
     ApiResponse:
@@ -3238,25 +3234,25 @@ components:
     # TokenClass API Envelopes
     ApiRequest_RegisterTokenClassRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/RegisterTokenClassRequest' }
 
     ApiRequest_UpdateTokenClassRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/UpdateTokenClassRequest' }
 
     ApiRequest_GetTokenClassRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/GetTokenClassRequest' }
 
     ApiRequest_SearchTokenClassRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/SearchTokenClassRequest' }
 
@@ -3275,26 +3271,26 @@ components:
     # Token API Envelopes
     ApiRequest_GetTokenRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/GetTokenRequest' }
 
     ApiRequest_MintTokenRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/MintTokenRequest' }
             signature: { $ref: '#/components/schemas/Signature' }
 
     ApiRequest_SearchTokensRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/SearchTokensRequest' }
 
     ApiRequest_TransactRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - required: [signature]
           properties:
             payload: { $ref: '#/components/schemas/TransactRequest' }
@@ -3302,7 +3298,7 @@ components:
 
     ApiRequest_AddTokenRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/AddTokenRequest' }
 
@@ -3354,25 +3350,25 @@ components:
     # --- Transaction API Request Envelopes ---
     ApiRequest_TransactionStatusRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/TransactionStatusRequest' }
 
     ApiRequest_GetTransactionRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/GetTransactionRequest' }
 
     ApiRequest_SearchTransactionsRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/SearchTransactionsRequest' }
 
     ApiRequest_TokenTransactionsRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/TokenTransactionsRequest' }
 
@@ -3614,19 +3610,19 @@ components:
 
     ApiRequest_GetProofRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/GetProofRequest' }
 
     ApiRequest_GetProofLeafRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/GetProofLeafRequest' }
 
     ApiRequest_VerifyProofRequest:
       allOf:
-        - $ref: '#/components/schemas/RequestContext'
+        - $ref: '#/components/schemas/UserRequestContext'
         - properties:
             payload: { $ref: '#/components/schemas/VerifyProofRequest' }
 
@@ -3705,19 +3701,3 @@ components:
           example:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
-
-  # -------------------- Security --------------------
-  securitySchemes:
-    developerToken:
-      type: http
-      scheme: bearer
-      bearerFormat: "JWT or Opaque"
-      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."
-    userToken:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
-      description: |
-        A JWT token that identifies the end-user making the request. This is obtained
-        after user authentication (e.g., via `/v1/account/login`) and is passed in
-        the `context.authorization` field as `Bearer <token>`.

--- a/api/token-interfaces.yaml
+++ b/api/token-interfaces.yaml
@@ -1139,7 +1139,9 @@ paths:
 
         **Note:** `mint` operation has a dedicated `/v1/token/mint` endpoint with separate ACL controls.
 
-        Critical operations (burn, transfer, etc.) require end-user signature.
+        **Signature required:** a top-level end-user payload `signature` is mandatory for
+        every transact operation. units-api enforces this via a `RequireSignature`
+        middleware on this route; a request without a valid `signature` is rejected.
       security:
         - developerToken: []
         - developerSignature: []
@@ -3315,7 +3317,8 @@ components:
     ApiRequest_TransactRequest:
       allOf:
         - $ref: '#/components/schemas/RequestContext'
-        - properties:
+        - required: [signature]
+          properties:
             payload: { $ref: '#/components/schemas/TransactRequest' }
             signature: { $ref: '#/components/schemas/Signature' }
 

--- a/api/token-interfaces.yaml
+++ b/api/token-interfaces.yaml
@@ -53,14 +53,14 @@ info:
 
     Every endpoint requires the caller's developer token to carry at least one of the
     listed scopes. A `*` (wildcard) scope satisfies any check. Calls that fail the scope
-    check return `403 PERMISSION_DENIED`.
+    check return `403 FORBIDDEN`.
 
     | Endpoint | Required scope |
     |----------|----------------|
-    | `POST /v1/registry/tokenclasses/register` | `tokenclasses:create` |
-    | `POST /v1/registry/tokenclasses/update` | `tokenclasses:manage` |
-    | `POST /v1/registry/tokenclasses/get` | `tokenclasses:view` |
-    | `POST /v1/registry/tokenclasses/search` | `tokenclasses:view` |
+    | `POST /v1/registry/tokenclasses/register` | `tokenClasses:create` |
+    | `POST /v1/registry/tokenclasses/update` | `tokenClasses:manage` |
+    | `POST /v1/registry/tokenclasses/get` | `tokenClasses:view` |
+    | `POST /v1/registry/tokenclasses/search` | `tokenClasses:view` |
     | `POST /v1/token/get` | `tokens:view` |
     | `POST /v1/token/mint` | `tokens:create` |
     | `POST /v1/token/search` | `tokens:view` |
@@ -89,7 +89,12 @@ servers:
     description: "Local Server"
 tags:
   - name: "Token Classes"
-    description: "Endpoints for token class registration and management."
+    description: |
+      Endpoints for token class registration and management.
+
+      The `/v1/registry/tokenclasses/*` paths documented here are canonical. The same
+      controller is also served under an equivalent, undocumented alias group
+      (`/v1/tokenclass/{register,update,get,search}`); both forms hit identical logic.
   - name: "Token"
     description: "Endpoints for token creation, querying, and lifecycle management."
   - name: "Transaction"
@@ -2181,7 +2186,7 @@ components:
           type: integer
           default: 50
           minimum: 1
-          maximum: 100
+          maximum: 1000
           description: "Maximum number of results to return"
         offset:
           type: integer
@@ -2203,9 +2208,8 @@ components:
       properties:
         field:
           type: string
-          enum: [createdAt, updatedAt, name]
           default: createdAt
-          description: "Field to sort by"
+          description: "Field to sort by (free-form)"
         order:
           type: string
           enum: [asc, desc]
@@ -3673,7 +3677,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "AUTHENTICATION_FAILED", message: "Token invalid or expired." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
       description: "Forbidden. Insufficient permissions."
@@ -3681,7 +3685,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "PERMISSION_DENIED", message: "Insufficient permissions to perform this action." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -3697,7 +3701,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "Invalid request parameters." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     ConflictError:
       description: "Conflict with existing resource or state."
@@ -3705,7 +3709,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "RESOURCE_CONFLICT", message: "Operation conflicts with current token state." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "CONFLICT", message: "Operation conflicts with current token state." } }
             response: {}
     RateLimitedError:
       description: |
@@ -3718,7 +3722,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
 
   # -------------------- Security --------------------

--- a/api/token-interfaces.yaml
+++ b/api/token-interfaces.yaml
@@ -70,6 +70,10 @@ info:
     | `POST /v1/transaction/status` | `transactions:view` |
     | `POST /v1/transaction/get` | `transactions:view` |
     | `POST /v1/transaction/search` | `transactions:view` |
+    | `POST /v1/transactions/status` | `transactions:view` |
+    | `POST /v1/transaction/proof` | `tokens:view` |
+    | `POST /v1/transaction/proof/leaf` | `tokens:view` |
+    | `POST /v1/transaction/proof/verify` | `tokens:view` |
 
     ### Rate limiting
 
@@ -90,6 +94,8 @@ tags:
     description: "Endpoints for token creation, querying, and lifecycle management."
   - name: "Transaction"
     description: "Endpoints for transaction management."
+  - name: "Proof"
+    description: "Endpoints for retrieving and verifying Merkle proofs of transactions."
 
 # ===============================================================
 #   PATHS
@@ -123,7 +129,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "USDC"
@@ -150,19 +156,6 @@ paths:
                       currency: "USD"
                       fungible: true
                       category: "stablecoin"
-                    chainDeployments:
-                      - chainId: "eip155:1"
-                        contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-                        assetType: "erc20"
-                        decimals: 6
-                      - chainId: "eip155:137"
-                        contractAddress: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
-                        assetType: "erc20"
-                        decimals: 6
-                      - chainId: "eip155:8453"
-                        contractAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-                        assetType: "erc20"
-                        decimals: 6
               USDT:
                 summary: "Register USDT - Tether's USD stablecoin"
                 value:
@@ -171,7 +164,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "USDT"
@@ -205,7 +198,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "EURC"
@@ -239,7 +232,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "GBPT"
@@ -273,7 +266,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef1"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "INRT"
@@ -307,7 +300,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef12"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "NFH-T"
@@ -342,7 +335,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "a7b8c9d0-e1f2-3456-7890-abcdef123"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "ART-NFT"
@@ -380,7 +373,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "b8c9d0e1-f2a3-4567-8901-bcdef1234"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "RWA-NFT"
@@ -420,6 +413,7 @@ paths:
                   msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
                   status: "successful"
                 response:
+                  id: "urn:uuid:b2c3d4e5-f6a7-8901-2345-67890abcdef1"
                   tokenClass: "USDC"
                   tokenStandard: "UNITS-FT"
                   name: "USD Coin"
@@ -444,8 +438,8 @@ paths:
                     currency: "USD"
                     fungible: true
                     category: "stablecoin"
-                    createdAt: "2025-01-04T10:00:00Z"
-                    updatedAt: "2025-01-04T10:00:00Z"
+                  createdAt: "2025-01-04T10:00:00Z"
+                  updatedAt: "2025-01-04T10:00:00Z"
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':
@@ -478,7 +472,7 @@ paths:
                 version: "1.0"
                 ts: "2025-01-04T11:00:00Z"
                 msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
                 tokenClass: "USDC"
@@ -525,7 +519,7 @@ paths:
                 version: "1.0"
                 ts: "2025-01-04T10:00:00Z"
                 msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef12"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
                 tokenClass: "USDC"
@@ -544,6 +538,7 @@ paths:
                   msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
                   status: "successful"
                 response:
+                  id: "urn:uuid:b2c3d4e5-f6a7-8901-2345-67890abcdef1"
                   tokenClass: "USDC"
                   tokenStandard: "UNITS-FT"
                   name: "USD Coin"
@@ -568,8 +563,8 @@ paths:
                     currency: "USD"
                     fungible: true
                     category: "stablecoin"
-                    createdAt: "2025-01-04T10:00:00Z"
-                    updatedAt: "2025-01-04T10:00:00Z"
+                  createdAt: "2025-01-04T10:00:00Z"
+                  updatedAt: "2025-01-04T10:00:00Z"
         '404':
           $ref: '#/components/responses/NotFoundError'
         '401':
@@ -596,7 +591,7 @@ paths:
                 version: "1.0"
                 ts: "2025-01-04T10:00:00Z"
                 msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef123"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
                 filters:
@@ -624,7 +619,8 @@ paths:
                   status: "successful"
                 response:
                   tokenClasses:
-                    - tokenClass: "USDC"
+                    - id: "urn:uuid:b2c3d4e5-f6a7-8901-2345-67890abcdef1"
+                      tokenClass: "USDC"
                       tokenStandard: "UNITS-FT"
                       name: "USD Coin"
                       description: "Circle USD stablecoin pegged 1:1 to USD"
@@ -648,9 +644,10 @@ paths:
                         currency: "USD"
                         fungible: true
                         category: "stablecoin"
-                        createdAt: "2025-01-04T10:00:00Z"
-                        updatedAt: "2025-01-04T10:00:00Z"
-                    - tokenClass: "USDT"
+                      createdAt: "2025-01-04T10:00:00Z"
+                      updatedAt: "2025-01-04T10:00:00Z"
+                    - id: "urn:uuid:c3d4e5f6-a7b8-9012-3456-7890abcdef12"
+                      tokenClass: "USDT"
                       tokenStandard: "UNITS-FT"
                       name: "Tether USD"
                       description: "Tether USD stablecoin"
@@ -674,8 +671,8 @@ paths:
                         currency: "USD"
                         fungible: true
                         category: "stablecoin"
-                        createdAt: "2025-01-04T10:00:00Z"
-                        updatedAt: "2025-01-04T10:00:00Z"
+                      createdAt: "2025-01-04T10:00:00Z"
+                      updatedAt: "2025-01-04T10:00:00Z"
                   pagination:
                     total: 2
                     limit: 50
@@ -708,7 +705,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenId: "urn:uuid:a1b2c3d4-e5f6-7890-abcd-1234567890ab"
@@ -720,7 +717,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdf0"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                     valueFormat: "display"
                   payload:
@@ -744,6 +741,8 @@ paths:
                       status: "successful"
                     response:
                       id: "urn:uuid:a1b2c3d4-e5f6-7890-abcd-1234567890ab"
+                      tokenClass: "USDC"
+                      chainRegistryInfo: {}
                       metadata:
                         tokenClassId: "urn:uuid:b2c3d4e5-f6a7-8901-2345-67890abcdef1"
                         tokenClass: "USDC"
@@ -774,6 +773,8 @@ paths:
                       status: "successful"
                     response:
                       id: "urn:uuid:a1b2c3d4-e5f6-7890-abcd-1234567890ab"
+                      tokenClass: "USDC"
+                      chainRegistryInfo: {}
                       metadata:
                         tokenClassId: "urn:uuid:b2c3d4e5-f6a7-8901-2345-67890abcdef1"
                         tokenClass: "USDC"
@@ -826,7 +827,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "c1d2e3f4-a5b6-7890-1234-567890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "USDC"
@@ -839,7 +840,7 @@ paths:
                         roles: ["owner"]
                     initialSupply: "1000000000000"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               INRT:
                 summary: "Mint INRT - 10K tokens"
@@ -849,7 +850,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "d2e3f4a5-b6c7-8901-2345-67890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "INRT"
@@ -862,7 +863,7 @@ paths:
                         roles: ["owner"]
                     initialSupply: "1000000"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               NFH-T:
                 summary: "Mint NFH-T - 5K tokens with constraints"
@@ -872,7 +873,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "e3f4a5b6-c7d8-9012-3456-7890abcdef1"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "NFH-T"
@@ -885,7 +886,7 @@ paths:
                         roles: ["owner"]
                     initialSupply: "500000"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               ART-NFT:
                 summary: "Mint ART-NFT - Digital Art"
@@ -895,7 +896,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "f4a5b6c7-d8e9-0123-4567-890abcdef12"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "ART-NFT"
@@ -924,7 +925,7 @@ paths:
                         roles: ["owner"]
                     initialSupply: "1"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               RWA-NFT:
                 summary: "Mint RWA-NFT - Property Deed"
@@ -934,7 +935,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "a5b6c7d8-e9f0-1234-5678-90abcdef123"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     tokenClass: "RWA-NFT"
@@ -956,15 +957,28 @@ paths:
                         roles: ["owner"]
                     initialSupply: "1"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
       responses:
-        '202':
-          description: "Mint transaction accepted (async)"
+        '200':
+          description: "Mint transaction submitted (async). The txId tracks the mint workflow."
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse_TransactAccepted'
+                $ref: '#/components/schemas/ApiResponse_MintTokenResult'
+              example:
+                context:
+                  id: "api.token.mint"
+                  version: "1.0"
+                  ts: "2025-01-04T10:00:00Z"
+                  msgId: "c1d2e3f4-a5b6-7890-1234-567890abcdef"
+                  status: "successful"
+                  transactionId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
+                response:
+                  txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
+                  status: "submitted"
+                  message: "domain_lifecycle_workflow_submitted"
+                  estimatedCompletionTime: "2025-01-04T10:00:30Z"
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':
@@ -996,7 +1010,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     filters:
@@ -1019,7 +1033,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef2"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                     valueFormat: "display"
                   payload:
@@ -1049,6 +1063,8 @@ paths:
                     response:
                       tokens:
                         - id: "urn:uuid:a1b2c3d4-e5f6-7890-abcd-1234567890ab"
+                          tokenClass: "USDC"
+                          chainRegistryInfo: {}
                           metadata:
                             tokenClass: "USDC"
                             tokenStandard: "UNITS-FT"
@@ -1077,6 +1093,8 @@ paths:
                     response:
                       tokens:
                         - id: "urn:uuid:a1b2c3d4-e5f6-7890-abcd-1234567890ab"
+                          tokenClass: "USDC"
+                          chainRegistryInfo: {}
                           metadata:
                             tokenClass: "USDC"
                             tokenStandard: "UNITS-FT"
@@ -1135,15 +1153,15 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:15:00Z"
                     msgId: "f1a2b3c4-d5e6-7890-1234-567890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "transfer"
                     tokenId: "a1b2c3d4-e5f6-7890-abcd-1234567890ab"
                     to: "bob"
-                    amount: "100000000"
+                    value: "100000000"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               TransferINRT:
                 summary: "Transfer - INRT (Cross-Border Remittance)"
@@ -1153,15 +1171,15 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:15:00Z"
                     msgId: "g2b3c4d5-e6f7-8901-2345-67890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "transfer"
                     tokenId: "1ab71000-1001-4001-8001-000000000001"
                     to: "lakshmi"
-                    amount: "5000000000000"
+                    value: "5000000000000"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               TransferARTNFT:
                 summary: "Transfer - ART-NFT (Art Sale)"
@@ -1171,15 +1189,15 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:15:00Z"
                     msgId: "h3c4d5e6-f7a8-9012-3456-7890abcdef1"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "transfer"
                     tokenId: "a4571f00-57a4-4001-8001-000000000001"
                     to: "charlie"
-                    amount: "1"
+                    value: "1"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               TransferRWANFT:
                 summary: "Transfer - RWA-NFT (Property Sale)"
@@ -1189,20 +1207,20 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:15:00Z"
                     msgId: "i4d5e6f7-a8b9-0123-4567-890abcdef12"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "transfer"
                     tokenId: "4ea1000a-1001-4001-8001-000000000001"
                     to: "diana"
-                    amount: "1"
+                    value: "1"
                     data:
                       salePrice: "2500000.00"
                       saleCurrency: "USD"
                       closingDate: "2025-03-15"
                       escrowAgent: "titlecompany"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               BurnUSDT:
                 summary: "Burn - USDT (Redemption)"
@@ -1212,15 +1230,15 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:05:00Z"
                     msgId: "d1e2f3a4-b5c6-7890-1234-567890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "burn"
                     tokenId: "05d71000-1001-4001-8001-000000000001"
-                    amount: "1000000000"
+                    value: "1000000000"
                     reason: "Fiat withdrawal - Bank transfer to Tether redemption account"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               BurnNFHT:
                 summary: "Burn - NFH-T (Community Token Burn)"
@@ -1230,15 +1248,15 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:05:00Z"
                     msgId: "d2e3f4a5-b6c7-8901-2345-67890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "burn"
                     tokenId: "0ffa1000-1001-4001-8001-000000000001"
-                    amount: "500000000000000000000"
+                    value: "500000000000000000000"
                     reason: "Deflationary burn event - Q1 2025"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               FreezeINRT:
                 summary: "Freeze - INRT (Compliance Hold)"
@@ -1248,7 +1266,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:10:00Z"
                     msgId: "e1f2a3b4-c5d6-7890-1234-567890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "freeze"
@@ -1256,7 +1274,7 @@ paths:
                     reason: "AML investigation - Case #AML-2025-001"
                     frozenBy: "hdfc:compliance"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               UnfreezeToken:
                 summary: "Unfreeze a token"
@@ -1266,14 +1284,14 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:10:00Z"
                     msgId: "e2f3a4b5-c6d7-8901-2345-67890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "unfreeze"
                     tokenId: "1ab71000-5054-4001-8001-000000000001"
                     reason: "Compliance review completed"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               LockEURC:
                 summary: "Lock - EURC (DeFi Collateral)"
@@ -1283,16 +1301,16 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:20:00Z"
                     msgId: "f3a4b5c6-d7e8-9012-3456-7890abcdef1"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "lock"
                     tokenId: "e04c1000-1001-4001-8001-000000000001"
-                    amount: "500000000"
+                    value: "500000000"
                     reason: "Collateral for DeFi loan - Protocol: Aave"
                     lockUntil: "2025-12-31T23:59:59Z"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               LockGBPT:
                 summary: "Lock - GBPT (Escrow for Trade)"
@@ -1302,16 +1320,16 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:20:00Z"
                     msgId: "f4a5b6c7-d8e9-0123-4567-890abcdef12"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "lock"
                     tokenId: "6b971000-1001-4001-8001-000000000001"
-                    amount: "10000000000"
+                    value: "10000000000"
                     reason: "Escrow for international trade - Invoice #INV-2025-001"
                     lockUntil: "2025-06-30T23:59:59Z"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               UnlockToken:
                 summary: "Unlock previously locked tokens"
@@ -1321,15 +1339,15 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:20:00Z"
                     msgId: "f5a6b7c8-d9e0-1234-5678-90abcdef123"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "unlock"
                     tokenId: "e04c1000-1001-4001-8001-000000000001"
-                    amount: "500000000"
+                    value: "500000000"
                     reason: "Loan repaid"
                   signature:
-                    type: "JsonWebSignature2020"
+                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               UpdateToken:
                 summary: "Update token data and metadata"
@@ -1339,7 +1357,7 @@ paths:
                     version: "1.0"
                     ts: "2025-01-04T10:20:00Z"
                     msgId: "a2b3c4d5-e6f7-8901-2345-67890abcdef"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                     authorization: "Bearer eyJ..."
                   payload:
                     operation: "update"
@@ -1353,24 +1371,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse_TransactAccepted'
+                $ref: '#/components/schemas/ApiResponse_TransactTokenResult'
               examples:
-                MintAccepted:
-                  summary: "Mint transaction accepted"
-                  value:
-                    context:
-                      id: "api.token.transact"
-                      version: "1.0"
-                      ts: "2025-01-04T10:00:00Z"
-                      msgId: "c1d2e3f4-a5b6-7890-1234-567890abcdef"
-                      status: "accepted"
-                      transactionId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
-                    response:
-                      txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
-                      status: "submitted"
-                      message: "Transaction submitted for processing"
                 TransferAccepted:
-                  summary: "Transfer transaction accepted"
+                  summary: "Federation transfer submitted (workflow fields present)"
                   value:
                     context:
                       id: "api.token.transact"
@@ -1382,7 +1386,24 @@ paths:
                     response:
                       txId: "urn:uuid:tx-d8e5f6a7-b8c9-0123-4567-890abcdef123"
                       status: "submitted"
-                      message: "Transfer submitted for processing"
+                      message: "Transfer workflow submitted for primitive orchestration"
+                      workflowInstanceId: "urn:uuid:tx-d8e5f6a7-b8c9-0123-4567-890abcdef123"
+                      workflowUrl: "https://restate.example/PrimitiveOperationWorkflow/urn:uuid:tx-d8e5f6a7-b8c9-0123-4567-890abcdef123"
+                BurnAccepted:
+                  summary: "Burn submitted (no workflow fields)"
+                  value:
+                    context:
+                      id: "api.token.transact"
+                      version: "1.0"
+                      ts: "2025-01-04T10:05:00Z"
+                      msgId: "d1e2f3a4-b5c6-7890-1234-567890abcdef"
+                      status: "accepted"
+                      transactionId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
+                    response:
+                      txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
+                      status: "submitted"
+                      message: "Transaction submitted for processing"
+                      estimatedCompletionTime: "2025-01-04T10:05:30Z"
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':
@@ -1401,10 +1422,16 @@ paths:
         - "Transaction"
       summary: "Get transaction status"
       description: |
-        Polls the status of an asynchronous transaction.
+        Polls the stored status of a transaction. Returns the transaction's `txId`,
+        its lifecycle `status`, an optional free-form `error` payload (present only
+        on failure), and lifecycle `timestamps`.
 
-        **Status Progression:**
-        submitted → pending → executing → completed/failed/rolled_back
+        The base `status` defaults to `pending` and advances through the transaction's
+        own lifecycle (e.g. `pending`, `processing`, `awaiting_signature`, `completed`,
+        `failed`, `cancelled`).
+
+        For the richer per-operation federation lifecycle (ops, retries, outcome), use
+        `POST /v1/transactions/status` instead.
 
         Use this endpoint to poll for transaction completion after submitting via /v1/token/transact.
       security:
@@ -1422,7 +1449,7 @@ paths:
                 version: "1.0"
                 ts: "2025-01-04T10:00:02Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
                 txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
@@ -1434,8 +1461,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiResponse_TransactionStatus'
               examples:
-                Executing:
-                  summary: "Transaction in progress"
+                Pending:
+                  summary: "Transaction pending"
                   value:
                     context:
                       id: "api.transaction.status"
@@ -1445,14 +1472,9 @@ paths:
                       status: "successful"
                     response:
                       txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
-                      status: "executing"
-                      progress:
-                        currentStep: "Generating proof"
-                        completedSteps: 2
-                        totalSteps: 4
+                      status: "pending"
                       timestamps:
                         submitted: "2025-01-04T10:00:00Z"
-                        started: "2025-01-04T10:00:01Z"
                 Completed:
                   summary: "Transaction completed"
                   value:
@@ -1470,10 +1492,6 @@ paths:
                         started: "2025-01-04T10:00:01Z"
                         completed: "2025-01-04T10:00:03Z"
                         finalized: "2025-01-04T10:00:05Z"
-                      summary:
-                        operation: "transfer"
-                        tokenCount: 1
-                        proofId: "urn:uuid:proof-a1b2c3d4"
                 Failed:
                   summary: "Transaction failed"
                   value:
@@ -1489,9 +1507,6 @@ paths:
                       error:
                         code: "INSUFFICIENT_BALANCE"
                         message: "Insufficient token balance for transfer"
-                        details:
-                          required: "100000000"
-                          available: "50000000"
                       timestamps:
                         submitted: "2025-01-04T10:00:00Z"
                         started: "2025-01-04T10:00:01Z"
@@ -1526,7 +1541,7 @@ paths:
                 version: "1.0"
                 ts: "2025-01-04T10:00:10Z"
                 msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
                 txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
@@ -1565,7 +1580,7 @@ paths:
                 version: "1.0"
                 ts: "2025-01-04T10:00:00Z"
                 msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
                 filters:
@@ -1588,6 +1603,80 @@ paths:
                 $ref: '#/components/schemas/ApiResponse_TransactionList'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+
+  /v1/transactions/status:
+    post:
+      tags:
+        - "Transaction"
+      summary: "Get federation transaction status (developer-facing)"
+      description: |
+        Returns the federation lifecycle view of a transaction: overall `status`, the
+        ordered list of workflow operations (`ops`), retry/error info, and the final
+        `outcome` when available.
+
+        This is the developer-facing federation status endpoint (backed by
+        FederationController.Status). It reads the `transactions` row plus the
+        `workflow_ops` audit list. A txn id with no transactions row returns 404.
+
+        Requires a developer token (+ scope) and a user token.
+
+        The request has no dedicated JSON schema; the payload is modelled here as the
+        transaction id (`txn_id`).
+      security:
+        - developerToken: []
+        - userToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_FederationTransactionStatusRequest'
+            example:
+              context:
+                id: "api.transactions.status"
+                version: "1.0"
+                ts: "2025-01-04T10:00:02Z"
+                msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                txn_id: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
+      responses:
+        '200':
+          description: "Federation transaction status retrieved"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_FederationTransactionStatus'
+              example:
+                context:
+                  id: "api.transactions.status"
+                  version: "1.0"
+                  ts: "2025-01-04T10:00:05Z"
+                  msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+                  status: "successful"
+                response:
+                  txn_id: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
+                  workflow_name: "PrimitiveOperationWorkflow"
+                  status: "COMMITTED"
+                  ops:
+                    - op_seq: 0
+                      op_type: "DebitSource"
+                      result: { ok: true }
+                      created_at: "2025-01-04T10:00:01Z"
+                    - op_seq: 1
+                      op_type: "CommitCredit"
+                      result: { ok: true }
+                      created_at: "2025-01-04T10:00:03Z"
+                  outcome: { committed: true }
+                  created_at: "2025-01-04T10:00:00Z"
+                  updated_at: "2025-01-04T10:00:05Z"
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
 
   /v1/token/transactions:
     post:
@@ -1612,7 +1701,7 @@ paths:
                 version: "1.0"
                 ts: "2025-01-04T10:00:00Z"
                 msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef"
-                developerToken: "dev_pk_..."
+                developerToken: "fnt_..."
                 authorization: "Bearer eyJ..."
               payload:
                 filters:
@@ -1641,30 +1730,22 @@ paths:
     post:
       tags:
         - "Token"
-      summary: "Import token from external provider"
+      summary: "Add a token (credential VC or proxy token)"
       description: |
-        Process a completed journey from an external provider and mint a token.
+        Add a token to an owner. Two shapes are supported (selected via the payload's
+        `oneOf`):
+        - **Credential token** (W3C Verifiable Credential): supply `credential` + `metadata`.
+        - **Proxy token** (USDC, ETH, SOL, etc.): supply `chainId`, `contractAddress`,
+          `walletAddress`, `value`.
 
-        This is a **backend-to-backend** endpoint called by Finternet App Backend after receiving a
-        successful callback from a provider (Signzy, DigiLocker, etc.).
+        This is a **backend-to-backend** endpoint, typically called by the Finternet App
+        Backend on a provider callback.
 
         **No User JWT Required:** This endpoint does not require end-user authentication.
-        The token owner address must be provided in the payload.
+        The token owner address is provided in the payload.
 
-        **Processing Steps:**
-        1. Re-query provider API to verify journey status (security)
-        2. Download and encrypt relevant data/images to blob storage
-        3. Transform provider response to W3C Verifiable Credential format
-        4. Mint token based on specified tokenClass
-        5. Store minimal integration data for re-verification
-        6. Return transaction ID (async processing)
-
-        **Token Characteristics vary by tokenClass:**
-        - CREDENTIAL: Soulbound (non-transferable, non-burnable, revocable)
-        - Other token classes: Per token class configuration
-
-        **Note:** Token audit trail is handled by standard token_audit mechanism.
-        Blob storage uses journey hash as key - failures override same blob.
+        The token is created via an async transaction/workflow; the returned `txId`
+        tracks it.
       security:
         - developerToken: []
         - developerSignature: []
@@ -1673,118 +1754,346 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApiRequest_AddCredentialRequest'
+              $ref: '#/components/schemas/ApiRequest_AddTokenRequest'
             examples:
-              SignzyAadhaar:
-                summary: "Import Aadhaar credential from Signzy"
+              CredentialToken:
+                summary: "Add a credential token (W3C VC)"
                 value:
                   context:
                     id: "api.token.add"
                     version: "1.0"
                     ts: "2025-01-28T10:15:00Z"
                     msgId: "550e8400-e29b-41d4-a716-446655440000"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
                     tokenClass: "CREDENTIAL"
                     owner: "alice"
-                    provider: "signzy"
-                    providerDetails:
-                      flowId: "922e2a58-6afa-4a81-a13b-37aa76793641"
-                      journeyId: "YIRJ0UBX87"
-              SignzyPassport:
-                summary: "Import Passport credential from Signzy"
+                    metadata:
+                      name: "KYC Credential"
+                      tokenStandard: "UNITS-VC"
+                    credential:
+                      "@context":
+                        - "https://www.w3.org/ns/credentials/v2"
+                      type:
+                        - "VerifiableCredential"
+                        - "IdentityCredential"
+                      issuer:
+                        id: "did:web:issuer.example"
+                        name: "Example Issuer"
+                      validFrom: "2025-01-28T10:00:00Z"
+                      credentialSubject:
+                        id: "did:finternet:alice"
+                        documentType: "PAN"
+                        country: "IN"
+                        faceMatchVerified: true
+                        faceMatchPercentage: "98.5"
+              ProxyToken:
+                summary: "Add a proxy token (USDC on Base)"
                 value:
                   context:
                     id: "api.token.add"
                     version: "1.0"
                     ts: "2025-01-28T10:15:00Z"
                     msgId: "550e8400-e29b-41d4-a716-446655440001"
-                    developerToken: "dev_pk_..."
+                    developerToken: "fnt_..."
                   payload:
-                    tokenClass: "CREDENTIAL"
-                    owner: "bob"
-                    provider: "signzy"
-                    providerDetails:
-                      flowId: "922e2a58-6afa-4a81-a13b-37aa76793641"
-                      journeyId: "PJGR096ABC"
+                    tokenClass: "USDC"
+                    owner: "alice"
+                    chainId: "eip155:8453"
+                    contractAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+                    walletAddress: "0x1111111111111111111111111111111111111111"
+                    value: "1000000"
       responses:
-        '202':
-          description: "Token processing accepted (async)"
+        '200':
+          description: "Token add transaction submitted (async). The txId tracks the workflow."
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse_AddCredentialAccepted'
+                $ref: '#/components/schemas/ApiResponse_AddTokenResult'
               example:
                 context:
                   id: "api.token.add"
                   version: "1.0"
                   ts: "2025-01-28T10:15:05Z"
                   msgId: "550e8400-e29b-41d4-a716-446655440002"
-                  status: "accepted"
+                  status: "successful"
                   transactionId: "urn:uuid:tx-credential-12345"
                 response:
                   txId: "urn:uuid:tx-credential-12345"
                   status: "submitted"
-                  message: "Credential processing submitted"
-                  journeyId: "PJGR095SLR"
-                  documentType: "PAN"
+                  message: "credential_add_transaction_submitted"
+                  estimatedCompletionTime: "2025-01-28T10:15:35Z"
         '400':
-          description: "Invalid request or journey not completed"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-              examples:
-                JourneyNotCompleted:
-                  summary: "Journey not in COMPLETED status"
-                  value:
-                    context:
-                      id: "api.token.credential.add"
-                      status: "failed"
-                      error:
-                        code: "JOURNEY_NOT_COMPLETED"
-                        message: "Journey PJGR095SLR is not in COMPLETED status"
-                    response: {}
-                VerificationFailed:
-                  summary: "Provider verification failed"
-                  value:
-                    context:
-                      id: "api.token.credential.add"
-                      status: "failed"
-                      error:
-                        code: "VERIFICATION_FAILED"
-                        message: "Document verification failed: Face match below threshold"
-                    response: {}
+          $ref: '#/components/responses/BadRequestError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '404':
-          description: "Journey not found at provider"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-              example:
-                context:
-                  id: "api.token.credential.add"
-                  status: "failed"
-                  error:
-                    code: "JOURNEY_NOT_FOUND"
-                    message: "Journey PJGR095SLR not found at provider"
-                response: {}
+          $ref: '#/components/responses/NotFoundError'
         '409':
-          description: "Credential already exists for this journey"
+          $ref: '#/components/responses/ConflictError'
+
+  # -------------------- Proof APIs --------------------
+  /v1/transaction/proof:
+    post:
+      tags:
+        - "Proof"
+      summary: "Get Merkle proof for a transaction"
+      description: |
+        Retrieves the Merkle proof for a transaction, enabling independent verification
+        that the transaction was included in a state commitment / batched Merkle tree.
+
+        **Proof status:**
+        - `pending` — awaiting proof generation
+        - `proven` — Merkle proof generated
+        - `anchored` — proof anchored to a public ledger, fully verifiable
+
+        Requires Developer + User auth.
+      security:
+        - developerToken: []
+        - userToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_GetProofRequest'
+            example:
+              context:
+                id: "api.transaction.proof"
+                version: "1.0"
+                ts: "2025-01-04T10:00:02Z"
+                msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
+      responses:
+        '200':
+          description: "Proof retrieved successfully"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiError'
+                $ref: '#/components/schemas/ApiResponse_ProofDetails'
+              examples:
+                Anchored:
+                  summary: "Fully anchored proof"
+                  value:
+                    context:
+                      id: "api.transaction.proof"
+                      version: "1.0"
+                      ts: "2025-01-04T10:00:02Z"
+                      msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+                      status: "successful"
+                    response:
+                      txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
+                      leafHash: "a1b2c3d4e5f6..."
+                      merkleRoot: "d4e5f6a7b8c9..."
+                      leafIndex: 42
+                      proofPath:
+                        - hash: "abc123..."
+                          direction: "left"
+                        - hash: "def456..."
+                          direction: "right"
+                      stateCommitment: "0xabcdef1234567890"
+                      proofStatus: "anchored"
+                      ledgerAnchors:
+                        - chain: "ethereum"
+                          network: "sepolia"
+                          txHash: "0x1234567890abcdef..."
+                          blockId: "12345678"
+                          timestamp: "2025-01-04T10:30:00Z"
+                      verificationEndpoints:
+                        leafDataEndpoint: "/v1/transaction/proof/leaf"
+                Pending:
+                  summary: "Proof pending (batch not yet full)"
+                  value:
+                    context:
+                      id: "api.transaction.proof"
+                      version: "1.0"
+                      ts: "2025-01-04T10:00:02Z"
+                      msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+                      status: "successful"
+                    response:
+                      txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
+                      proofStatus: "pending"
+                      message: "Transaction awaiting proof generation."
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+
+  /v1/transaction/proof/leaf:
+    post:
+      tags:
+        - "Proof"
+      summary: "Get raw leaf data for a transaction proof"
+      description: |
+        Returns the raw data that was hashed to create the transaction's leaf in the
+        Merkle tree. Enables independent verification: fetch this data, hash it, and
+        confirm it matches the `leafHash` returned by `/v1/transaction/proof`.
+
+        Requires Developer + User auth.
+      security:
+        - developerToken: []
+        - userToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_GetProofLeafRequest'
+            example:
+              context:
+                id: "api.transaction.proof.leaf"
+                version: "1.0"
+                ts: "2025-01-04T10:00:02Z"
+                msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
+      responses:
+        '200':
+          description: "Leaf data retrieved successfully"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_ProofLeafData'
               example:
                 context:
-                  id: "api.token.credential.add"
-                  status: "failed"
-                  error:
-                    code: "CREDENTIAL_EXISTS"
-                    message: "Credential already minted for journey PJGR095SLR"
-                response: {}
+                  id: "api.transaction.proof.leaf"
+                  version: "1.0"
+                  ts: "2025-01-04T10:00:02Z"
+                  msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef"
+                  status: "successful"
+                response:
+                  txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
+                  leafHash: "a1b2c3d4e5f6..."
+                  stateCommitment: "0xabcdef1234567890"
+                  tokenId: "urn:uuid:token-abc123"
+                  tokenClass: "USDC"
+                  operation: "transfer"
+                  timestamp: "2025-01-04T09:55:00Z"
+                  rawData:
+                    operation: "transfer"
+                    amount: "1000000"
+                    from: "alice"
+                    to: "bob"
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
+
+  /v1/transaction/proof/verify:
+    post:
+      tags:
+        - "Proof"
+      summary: "Verify a transaction proof (server-side)"
+      description: |
+        Performs server-side verification of a transaction's Merkle proof:
+        1. Leaf hash matches the stored transaction data
+        2. Proof path correctly computes to the Merkle root
+        3. Anchor exists on the ledger (if anchored)
+
+        For trustless verification, clients should verify independently using the data
+        from `/v1/transaction/proof` and `/v1/transaction/proof/leaf`.
+
+        Requires Developer + User auth.
+      security:
+        - developerToken: []
+        - userToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_VerifyProofRequest'
+            example:
+              context:
+                id: "api.transaction.proof.verify"
+                version: "1.0"
+                ts: "2025-01-04T10:00:02Z"
+                msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
+      responses:
+        '200':
+          description: "Verification result"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_ProofVerification'
+              examples:
+                Verified:
+                  summary: "All checks passed"
+                  value:
+                    context:
+                      id: "api.transaction.proof.verify"
+                      version: "1.0"
+                      ts: "2025-01-04T10:00:02Z"
+                      msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
+                      status: "successful"
+                    response:
+                      txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
+                      valid: true
+                      leafHashValid: true
+                      proofPathValid: true
+                      anchorValid: true
+                PartiallyVerified:
+                  summary: "Proof valid but not yet anchored"
+                  value:
+                    context:
+                      id: "api.transaction.proof.verify"
+                      version: "1.0"
+                      ts: "2025-01-04T10:00:02Z"
+                      msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
+                      status: "successful"
+                    response:
+                      txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
+                      valid: true
+                      leafHashValid: true
+                      proofPathValid: true
+                      anchorValid: null
+                      message: "Proof is valid but not yet anchored to a ledger."
+                Failed:
+                  summary: "Verification failed"
+                  value:
+                    context:
+                      id: "api.transaction.proof.verify"
+                      version: "1.0"
+                      ts: "2025-01-04T10:00:02Z"
+                      msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
+                      status: "successful"
+                    response:
+                      txId: "urn:uuid:tx-b7e3f9a1-c4d2-5e6f-7890-1234567890cd"
+                      valid: false
+                      leafHashValid: false
+                      proofPathValid: true
+                      message: "Leaf hash mismatch — transaction data may have been modified."
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
 # ===============================================================
 #   COMPONENTS
@@ -1803,7 +2112,7 @@ components:
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
-        developerToken: { type: string, example: "dev_pk_...", nullable: true, description: "B2B Developer API Key/Token" }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "B2B Developer API Key/Token" }
         developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "B2B Developer Signature" }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token" }
         valueFormat:
@@ -1829,9 +2138,9 @@ components:
         error: { $ref: '#/components/schemas/ErrorPayload' }
     Signature:
       type: object
-      required: [type, jws]
+      required: [key_id, jws]
       properties:
-        type: { type: string, example: "JsonWebSignature2020" }
+        key_id: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
         jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object" }
     ErrorPayload:
       type: object
@@ -1907,9 +2216,12 @@ components:
 
     TokenClass:
       type: object
-      required: [tokenClass, tokenStandard, name, schema, status]
-      description: "Token class definition with schema and authorized identities"
+      required: [id, tokenClass, tokenStandard, name, schema, status, createdAt, updatedAt]
+      description: "Token class details (response)."
       properties:
+        id:
+          type: string
+          description: "Token class record identifier"
         tokenClass:
           type: string
           description: "Unique token class identifier (e.g., USDC, USDT)"
@@ -1922,89 +2234,26 @@ components:
         description:
           type: string
           description: "Detailed description"
-        status:
-          type: string
-          enum: [active, inactive, deprecated, test]
-          description: "Token class status"
-          example: "active"
         schema:
           type: object
+          additionalProperties: true
           description: "JSON Schema definition for token instances"
-          properties:
-            metadata:
-              type: object
-              description: "Metadata schema requirements"
-            data:
-              type: object
-              description: "Data schema requirements"
         identities:
-          type: array
-          items: { $ref: '#/components/schemas/Identity' }
           description: "Authorized identities who can mint tokens of this class"
-        chainDeployments:
-          type: array
-          description: |
-            On-chain contract deployments for this token class. Maps chain IDs to contract
-            addresses. Used for anti-spam filtering during proxy token import.
-          items:
-            $ref: '#/components/schemas/ChainDeployment'
         metadata:
           type: object
-          description: "Token class metadata including fungibility configuration"
-          properties:
-            fungible:
-              type: boolean
-              default: true
-              description: |
-                Defines whether tokens of this class are fungible:
-                - true: Fungible tokens (FT) - each owner has their own token with balance.
-                        Mint creates/updates token for the owner.
-                        Transfer debits sender's token, credits recipient's token.
-                - false: Non-fungible tokens (NFT) - unique assets.
-                         Mint creates the unique token.
-                         Transfer changes ownership of the token.
-            decimals:
-              type: integer
-              minimum: 0
-              maximum: 18
-              description: "Decimal places for fungible tokens (e.g., 6 for USDC, 18 for ETH)"
-            category:
-              type: string
-              description: "Category (e.g., stablecoin, security, utility)"
-            tags:
-              type: array
-              items: { type: string }
-            createdAt:
-              type: string
-              format: date-time
-            updatedAt:
-              type: string
-              format: date-time
-
-    ChainDeployment:
-      type: object
-      required: [chainId, contractAddress, assetType, decimals]
-      description: "On-chain contract deployment for a token class"
-      properties:
-        chainId:
+          additionalProperties: true
+          description: "Token class metadata (free-form; may include fungibility, decimals, category, tags, etc.)"
+        status:
           type: string
-          description: "CAIP-2 chain identifier"
-          example: "eip155:1"
-        contractAddress:
+          description: "Token class status (e.g., active, inactive, deprecated, test)"
+          example: "active"
+        createdAt:
           type: string
-          description: "Contract address on chain, or 'native' for native assets"
-          example: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-        assetType:
+          format: date-time
+        updatedAt:
           type: string
-          enum: [erc20, erc721, erc1155, native, spl]
-          description: "Asset standard on chain"
-          example: "erc20"
-        decimals:
-          type: integer
-          minimum: 0
-          maximum: 18
-          description: "Decimal precision on this specific chain deployment"
-          example: 6
+          format: date-time
 
     RegisterTokenClassRequest:
       type: object
@@ -2012,7 +2261,7 @@ components:
       description: "Request to register a new token class"
       properties:
         tokenClass: { type: string, example: "USDC" }
-        tokenStandard: { type: string, example: "ERC-3643" }
+        tokenStandard: { type: string, example: "UNITS-FT" }
         name: { type: string, example: "USD Coin" }
         description: { type: string }
         schema:
@@ -2025,13 +2274,6 @@ components:
         metadata:
           type: object
           description: "Token class metadata"
-        chainDeployments:
-          type: array
-          description: |
-            On-chain contract deployments for this token class. Used for anti-spam filtering
-            during proxy token import — only holdings matching a known deployment are imported.
-          items:
-            $ref: '#/components/schemas/ChainDeployment'
 
     UpdateTokenClassRequest:
       type: object
@@ -2039,6 +2281,8 @@ components:
       description: "Request to update token class properties"
       properties:
         tokenClass: { type: string, example: "USDC" }
+        tokenStandard: { type: string }
+        name: { type: string }
         description: { type: string }
         schema:
           type: object
@@ -2050,11 +2294,9 @@ components:
         metadata:
           type: object
           description: "Updated metadata"
-        chainDeployments:
-          type: array
-          description: "Updated on-chain contract deployments"
-          items:
-            $ref: '#/components/schemas/ChainDeployment'
+        status:
+          type: string
+          description: "Updated token class status"
 
     GetTokenClassRequest:
       type: object
@@ -2069,29 +2311,18 @@ components:
         filters:
           type: object
           description: |
-            Search filters for token classes.
-            Known fields: tokenStandard, status, name.
+            Search filters for token classes (free-form object).
+            Common fields: tokenStandard, status, name.
             Use explicit paths for JSONB fields (e.g., metadata.category).
-            Use chainDeployments filter for reverse lookup by chain/contract.
           properties:
             tokenStandard: { type: string, description: "Filter by protocol standard" }
             status: { type: string, description: "Filter by status" }
             "metadata.category": { type: string, description: "Filter by metadata.category" }
-            "chainDeployments.chainId": { type: string, description: "Filter by chain ID in deployments (e.g., eip155:1)" }
-            "chainDeployments.contractAddress": { type: string, description: "Filter by contract address in deployments" }
           additionalProperties: true
         pagination:
           $ref: '#/components/schemas/PaginationRequest'
         sortBy:
           $ref: '#/components/schemas/SortRequest'
-        groupBy:
-          type: string
-          description: |
-            Optional aggregation key. When supplied, results are grouped by the named
-            field rather than returned as a flat list. Supported values include
-            `tokenStandard`, `status`, and any top-level property of `TokenClass`.
-            JSONB paths (e.g. `metadata.category`) are also supported.
-          nullable: true
 
     TokenClassList:
       type: object
@@ -2231,12 +2462,35 @@ components:
             jws: { type: string }
         status: { type: string, enum: [asserted, verified, revoked, expired] }
 
+    ChainRegistryInfo:
+      type: object
+      description: "Chain registry info for the token. Always present in the response; an empty object when not applicable."
+      properties:
+        name: { type: string }
+        chainFamily: { type: string }
+        status: { type: string }
+        metadata: { type: object, additionalProperties: true }
+
+    TokenClassInfo:
+      type: object
+      description: "Token class info, built from the joined token_class record."
+      properties:
+        tokenStandard: { type: string }
+        name: { type: string }
+        description: { type: string }
+        metadata: { type: object, additionalProperties: true }
+
     # Token Details (full representation)
     Token:
       type: object
-      required: [id, metadata, state]
+      required: [id, tokenClass, metadata, state]
       properties:
         id: { type: string, format: uri-reference }
+        tokenClass: { type: string, description: "Token class identifier (e.g., USDC)" }
+        chainRegistryInfo:
+          $ref: '#/components/schemas/ChainRegistryInfo'
+        tokenClassInfo:
+          $ref: '#/components/schemas/TokenClassInfo'
         metadata: { $ref: '#/components/schemas/TokenMetadata' }
         data: { type: object, additionalProperties: true }
         claims: { type: array, items: { $ref: '#/components/schemas/Claim' } }
@@ -2281,6 +2535,10 @@ components:
         initialSupply:
           type: string
           description: "Initial token supply (for fungible tokens). Format depends on `context.valueFormat` (raw: integer string, display: decimal string)."
+        extensions:
+          type: object
+          additionalProperties: true
+          description: "Token-programme-specific fields under extensions.<program-id>"
 
     SearchTokensRequest:
       type: object
@@ -2316,50 +2574,69 @@ components:
         sortBy:
           $ref: '#/components/schemas/SortRequest'
         groupBy:
-          type: string
-          description: |
-            Optional aggregation key. When supplied, results are grouped by the named
-            field — typical values: `tokenClass`, `chainId`, `tokenStandard`. Useful
-            for portfolio/holdings rollups by chain or class.
-          nullable: true
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            enum: [tokenClass]
+          description: "Fields to group results by. Currently only `tokenClass` is supported. When present, the response is grouped (see GroupedTokenList)."
+        aggregateFields:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            enum: [totalSupply, circulatingSupply, maxSupply, availableSupply, balance]
+          description: "Supply fields to aggregate (SUM) within each group. Only used when groupBy is present. Defaults to all supply fields when omitted."
 
     TransactRequest:
       type: object
-      required: [operation]
+      required: [operation, tokenId]
       description: |
-        Request payload for token operations. The structure varies by operation:
+        Request payload for token write operations. The structure varies by operation:
 
         **For update:** `operation`, `tokenId`, `data` (optional), `metadata` (optional)
-        **For burn/freeze/transfer:** `operation`, `tokenId`, plus operation-specific params at root level
-        **For sign (proxy tokens):** `operation`, `tokenId`, `transactionId`, `signedTx`
+        **For burn/freeze/lock/transfer:** `operation`, `tokenId`, plus operation-specific params at root level
 
-        **Note:** `mint` operation is handled by separate `/v1/token/mint` endpoint.
+        `operation` is an open string — common lifecycle operations (burn, freeze,
+        transfer, …) as well as domain-specific operations (e.g. `loan_disbursed`,
+        `emi_due`) are accepted.
+
+        **Note:** `mint` operation is handled by the separate `/v1/token/mint` endpoint.
       properties:
         operation:
           type: string
-          enum: [burn, freeze, unfreeze, lock, unlock, redeem, transfer, update, sign]
+          description: "Token operation type (e.g. burn, freeze, unfreeze, lock, unlock, redeem, transfer, update; or domain-specific ops like loan_disbursed, emi_due)"
         tokenId:
           type: string
           format: uri-reference
-          description: "Required for all operations except mint"
+          description: "Token identifier in URN format (e.g., urn:uuid:...)"
+        value:
+          type: string
+          description: "Value (quantity) for burn/transfer operations"
+        category:
+          type: string
+          description: "Category selector for policy-bound semi-fungible voucher transfer splits"
         metadata:
           type: object
-          description: "Token metadata (for mint, update operations)"
+          description: "Token metadata (for update operation). Can include name, tags (key-value object), description, etc."
           additionalProperties: true
         data:
           type: object
-          description: "Token data section (for mint, update operations)"
+          description: "Token data section (for update operation)"
           additionalProperties: true
-        amount:
-          type: string
-          description: "Amount for burn/transfer operations"
         to:
           type: string
           format: uri-reference
-          description: "Recipient for transfer operation"
+          description: "Recipient DID for transfer operation"
+        toAddress:
+          type: string
+          description: |
+            Optional explicit on-chain wallet address for the recipient (proxy token
+            transfers only). Must be registered in the recipient's public key registry
+            for the token's chain. If omitted, the recipient's primary key is used.
         reason:
           type: string
-          description: "Reason for burn/freeze/lock operations"
+          description: "Reason for burn/freeze operations"
         frozenBy:
           type: string
           format: uri-reference
@@ -2372,55 +2649,114 @@ components:
           type: string
           format: date-time
           description: "Lock expiration timestamp (optional)"
-        initialSupply:
-          type: string
-          description: "Initial supply for mint operation (fungible tokens)"
-        transactionId:
-          type: string
-          format: uuid
-          description: "Reference to the original transaction in AWAITING_SIGNATURE state (for sign operation on proxy tokens)"
-        signedTx:
-          type: string
-          description: "Externally signed transaction payload (for sign operation on proxy tokens)"
+        extensions:
+          type: object
+          additionalProperties: true
+          description: "Token-programme-specific fields under extensions.<program-id>"
+        signed_lock_envelope:
+          description: "Signed Lock envelope; used when /v1/token/transact routes a federation transfer. Free-form: an object, a string, or null."
 
-    AddCredentialRequest:
+    AddTokenRequest:
       type: object
-      required: [tokenClass, owner, provider, providerDetails]
+      required: [tokenClass, owner]
       description: |
-        Request to import a token from an external provider journey.
-        Called by Finternet App Backend after successful provider callback.
+        Request to add a token. Supports two shapes (selected via `oneOf`):
+          - **Credential token** (W3C VC): requires `credential` + `metadata`.
+          - **Proxy token** (USDC, ETH, SOL, etc.): requires `chainId`,
+            `contractAddress`, `walletAddress`, `value`.
 
-        The owner address must be provided in the payload (no user JWT required).
-        This supports any token type - credential, asset, or other token classes.
+        Called backend-to-backend by the Finternet App Backend (no end-user JWT).
+        The token owner address must be provided in the payload.
+      oneOf:
+        - title: "Credential Token"
+          required: [credential, metadata]
+        - title: "Proxy Token"
+          required: [chainId, contractAddress, walletAddress, value]
       properties:
         tokenClass:
           type: string
-          description: "Token class to mint (e.g., CREDENTIAL)"
+          minLength: 1
+          description: "Token class identifier (e.g., CREDENTIAL, USDC, ETH, SOL)"
           example: "CREDENTIAL"
         owner:
           type: string
-          description: "Finternet address of the token owner (e.g., alice)"
+          minLength: 1
+          description: "Owner address to issue the token to"
           example: "alice"
-        provider:
-          type: string
-          description: "Provider identifier (signzy, digilocker, etc.)"
-          example: "signzy"
-        providerDetails:
+        credential:
           type: object
-          description: "Provider-specific details (structure varies by provider)"
+          description: "Pre-built W3C Verifiable Credential (for credential tokens)"
+          additionalProperties: false
           properties:
-            flowId:
-              type: string
-              format: uuid
-              description: "Flow ID from provider (Signzy)"
-            providerId:
-              type: string
-              format: uuid
-              description: "Provider ID from integration_providers table"
-            journeyId:
-              type: string
-              description: "Journey ID from provider"
-          required: [journeyId]
+            "@context":
+              type: array
+              items: { type: string }
+              minItems: 1
+            type:
+              type: array
+              items: { type: string }
+              minItems: 1
+            issuer:
+              oneOf:
+                - type: string
+                  minLength: 1
+                - type: object
+                  required: [id, name]
+                  additionalProperties: false
+                  properties:
+                    id: { type: string, minLength: 1 }
+                    name: { type: string, minLength: 1 }
+            validFrom: { type: string, format: date-time }
+            validUntil: { type: string, format: date-time }
+            credentialSubject:
+              type: object
+              required: [id, documentType, country, faceMatchVerified, faceMatchPercentage]
+              additionalProperties: false
+              properties:
+                id: { type: string }
+                givenName: { type: string }
+                familyName: { type: string }
+                documentNumber: { type: string }
+                documentType: { type: string }
+                documentExpired: { type: boolean }
+                country: { type: string }
+                dateOfBirth: { type: string }
+                address: { type: string }
+                gender: { type: string }
+                faceMatchVerified: { type: boolean }
+                faceMatchPercentage: { type: string }
+            evidence:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: array
+                    items: { type: string }
+                  rawPayload: { type: object }
+        metadata:
+          type: object
+          description: "Token metadata (for credential tokens)"
+          additionalProperties: false
+          properties:
+            name: { type: string, minLength: 1 }
+            tokenStandard: { type: string, minLength: 1 }
+        chainId:
+          type: string
+          pattern: "^[a-z0-9]+:[a-zA-Z0-9._-]+$"
+          description: "Chain network ID for proxy tokens (e.g., solana:mainnet, eip155:8453)"
+        contractAddress:
+          type: string
+          minLength: 1
+          description: "On-chain contract address for proxy tokens"
+        walletAddress:
+          type: string
+          minLength: 1
+          description: "Wallet address holding the proxy token"
+        value:
+          type: string
+          pattern: "^[0-9]+$"
+          description: "Token value (quantity) in base units"
 
     # --- Response Payloads ---
     TokenDetails:
@@ -2429,6 +2765,7 @@ components:
 
     TokenList:
       type: object
+      description: "Flat token search result (returned when groupBy is absent)."
       properties:
         tokens:
           type: array
@@ -2437,9 +2774,67 @@ components:
         pagination:
           $ref: '#/components/schemas/PaginationResponse'
 
-    TransactAccepted:
+    TokenGroupAggregates:
       type: object
-      description: "Async transaction submission response"
+      description: |
+        SUM aggregates for supply fields in a group. All values are string big integers
+        in base units. A field is absent when no token in the group had that field.
+      properties:
+        totalSupply: { type: string }
+        circulatingSupply: { type: string }
+        maxSupply: { type: string }
+        availableSupply: { type: string }
+        balance: { type: string }
+
+    TokenGroup:
+      type: object
+      description: "One group in a grouped token search response."
+      required: [tokenClass, records]
+      properties:
+        tokenClass:
+          type: string
+        aggregates:
+          $ref: '#/components/schemas/TokenGroupAggregates'
+        records:
+          type: array
+          items:
+            $ref: '#/components/schemas/Token'
+
+    GroupedTokenList:
+      type: object
+      description: "Grouped token search result (returned when groupBy is present)."
+      properties:
+        tokens:
+          type: array
+          items:
+            $ref: '#/components/schemas/TokenGroup'
+        pagination:
+          $ref: '#/components/schemas/PaginationResponse'
+
+    MintTokenResponse:
+      type: object
+      description: "Response returned by /v1/token/mint. The mint runs as an async workflow; the txId tracks it."
+      required: [txId, status, message, estimatedCompletionTime]
+      properties:
+        txId:
+          type: string
+          format: uri-reference
+          description: "Transaction ID for tracking"
+        status:
+          type: string
+          description: "Workflow status (e.g. submitted)"
+          example: "submitted"
+        message:
+          type: string
+          description: "Confirmation message"
+        estimatedCompletionTime:
+          type: string
+          format: date-time
+          description: "Estimated completion time"
+
+    TransactTokenResponse:
+      type: object
+      description: "Response returned by /v1/token/transact. Runs as an async transaction/workflow; the txId tracks it."
       required: [txId, status, message]
       properties:
         txId:
@@ -2448,8 +2843,8 @@ components:
           description: "Transaction ID for tracking"
         status:
           type: string
-          enum: [submitted, queued]
-          description: "Initial status"
+          description: "Workflow/transaction status (e.g. submitted)"
+          example: "submitted"
         message:
           type: string
           description: "Confirmation message"
@@ -2457,44 +2852,39 @@ components:
           type: string
           format: date-time
           description: "Estimated completion time (optional)"
+        workflowInstanceId:
+          type: string
+          description: "Federation workflow instance id (present when the operation routes a federation transfer)"
+        workflowUrl:
+          type: string
+          description: "Human-readable workflow URL (present when the operation routes a federation transfer)"
 
-    AddCredentialAccepted:
+    AddTokenResponse:
       type: object
-      description: "Credential processing accepted response"
-      required: [txId, status, message, journeyId]
+      description: "Response returned by /v1/token/add. Runs as an async transaction/workflow; the txId tracks it."
+      required: [txId, status, message, estimatedCompletionTime]
       properties:
         txId:
           type: string
           format: uri-reference
-          description: "Transaction ID for tracking credential minting"
+          description: "Transaction ID for tracking"
         status:
           type: string
-          enum: [submitted, queued]
-          description: "Processing status"
+          description: "Workflow status (e.g. submitted)"
+          example: "submitted"
         message:
           type: string
           description: "Confirmation message"
-        journeyId:
+        estimatedCompletionTime:
           type: string
-          description: "Provider journey ID being processed"
-        documentType:
-          type: string
-          description: "Document type detected from journey (PAN, AADHAAR, etc.)"
-        tokenId:
-          type: string
-          format: uuid
-          description: "Token ID (only present if sync processing completed)"
+          format: date-time
+          description: "Estimated completion time"
 
     # --- Transaction Schemas ---
 
-    ExecutionStatus:
-      type: string
-      description: "Transaction execution status"
-      enum: [submitted, pending, executing, awaiting_signature, completed, failed, rolled_back]
-
     ExecutionTimestamps:
       type: object
-      description: "Transaction lifecycle timestamps"
+      description: "Transaction lifecycle timestamps. Only `submitted` is typically always present; the rest appear as the transaction advances."
       properties:
         submitted:
           type: string
@@ -2517,144 +2907,101 @@ components:
           format: date-time
           description: "When transaction failed (if applicable)"
 
-    TransactionProgress:
-      type: object
-      description: "Progress information for in-flight transactions"
-      properties:
-        currentStep:
-          type: string
-          description: "Current step being executed"
-        completedSteps:
-          type: integer
-          description: "Number of completed steps"
-        totalSteps:
-          type: integer
-          description: "Total number of steps"
-
-    TransactionSummary:
-      type: object
-      description: "High-level transaction summary"
-      properties:
-        operation:
-          type: string
-          description: "Primary operation type"
-        tokenCount:
-          type: integer
-          description: "Number of tokens affected"
-        proofId:
-          type: string
-          format: uri-reference
-          description: "Reference to proof record"
-
-    TransactionError:
-      type: object
-      description: "Error details for failed transactions"
-      required: [code, message]
-      properties:
-        code:
-          type: string
-          description: "Error code"
-        message:
-          type: string
-          description: "Error message"
-        details:
-          type: object
-          description: "Additional error details"
-          additionalProperties: true
-
     TransactionStatus:
       type: object
-      description: "Transaction status response"
-      required: [txId, status, timestamps]
+      description: |
+        Transaction status response returned by `/v1/transaction/status`. Reflects the
+        transaction's stored lifecycle status. The base `status` defaults to `pending`
+        and advances through the transaction's own lifecycle (e.g. pending, processing,
+        awaiting_signature, completed, failed, cancelled). The richer federation
+        lifecycle view (with per-op detail) is exposed separately via
+        `/v1/transactions/status`.
+      required: [txId, status]
       properties:
         txId:
           type: string
           format: uri-reference
         status:
-          $ref: '#/components/schemas/ExecutionStatus'
-        progress:
-          $ref: '#/components/schemas/TransactionProgress'
+          type: string
+          default: pending
+          description: "Transaction lifecycle status. Defaults to `pending`."
+        error:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: "Error payload for failed transactions (free-form; typically includes code/message). Absent when there is no error."
         timestamps:
           $ref: '#/components/schemas/ExecutionTimestamps'
-        summary:
-          $ref: '#/components/schemas/TransactionSummary'
-        error:
-          $ref: '#/components/schemas/TransactionError'
-        responseData:
-          type: object
-          description: |
-            Operation-specific response data. For proxy transfers in AWAITING_SIGNATURE state,
-            contains the unsigned transaction payload for external signing.
-          additionalProperties: true
 
-    TransactionLog:
+    TransactionResponse:
       type: object
-      description: "Complete transaction log with all details"
-      required: [txId, initiator, tokenTransactions, status, timestamps]
+      description: "Transaction details (returned by /v1/transaction/get and as items of /v1/transaction/search)."
+      required: [txId, initiator, status, createdAt, updatedAt]
       properties:
         txId:
           type: string
           format: uri-reference
         correlationId:
           type: string
+          nullable: true
           description: "External correlation ID"
         initiator:
           type: string
           format: uri-reference
           description: "Account that initiated the transaction"
-        identities:
-          type: array
-          items: { $ref: '#/components/schemas/Identity' }
-          description: "Snapshot of all identities involved (captured at transaction time for auditability)"
-        tokenTransactions:
-          type: array
-          items:
-            $ref: '#/components/schemas/TokenTransactionReference'
-          description: "References to token transactions"
         workflowInstanceId:
           type: string
-          format: uri-reference
+          nullable: true
           description: "Workflow instance reference"
         status:
-          $ref: '#/components/schemas/ExecutionStatus'
+          type: string
+          description: "Transaction lifecycle status"
+        error:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: "Error payload for failed transactions (free-form). Absent when there is no error."
+        responseData:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: "Operation-specific response data (free-form)."
         timestamps:
           $ref: '#/components/schemas/ExecutionTimestamps'
         proofId:
           type: string
-          format: uri-reference
+          nullable: true
         proofProfile:
           type: string
-          enum: [zk-snark, zk-stark, merkle, tee-attestation, signature-bundle, none]
+          nullable: true
         batchId:
           type: string
-        ledgerAnchors:
-          type: array
-          items:
-            $ref: '#/components/schemas/LedgerAnchor'
+          nullable: true
+        operationName:
+          type: string
+          description: "Primary operation name for the transaction"
         metadata:
           type: object
           additionalProperties: true
+        identities:
+          type: array
+          items: { $ref: '#/components/schemas/Identity' }
+          description: "Snapshot of identities involved in the transaction"
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
 
-    TokenTransactionReference:
+    TokenTransactionResponse:
       type: object
-      description: "Reference to a token transaction"
-      required: [tokenTxId, tokenId, operation]
+      description: |
+        Per-token state-change entry (row of the token_transactions table with
+        double-entry bookkeeping support).
+      required: [id, txId, tokenId, tokenClass, operation, timestamp, createdAt]
       properties:
-        tokenTxId:
-          type: string
-          format: uri-reference
-        tokenId:
-          type: string
-          format: uri-reference
-        operation:
-          type: string
-
-    TokenTransaction:
-      type: object
-      description: "Detailed token transaction record"
-      required: [tokenTxId, txId, tokenId, operation, stateAfter, timestamp]
-      properties:
-        tokenTxId:
+        id:
           type: string
           format: uri-reference
         txId:
@@ -2663,9 +3010,14 @@ components:
         tokenId:
           type: string
           format: uri-reference
+        tokenClass:
+          type: string
+          description: "Token class from the token_transactions table"
+        tokenClassInfo:
+          $ref: '#/components/schemas/TokenClassInfo'
         operation:
           type: string
-          enum: [mint, burn, transfer, freeze, unfreeze, lock, unlock, redeem, update]
+          description: "Operation type (e.g. mint, burn, transfer, freeze, unfreeze, lock, unlock, redeem, update; or domain-specific ops)"
         entryType:
           type: string
           enum: [debit, credit]
@@ -2685,98 +3037,34 @@ components:
         participants:
           type: array
           items:
-            $ref: '#/components/schemas/Participant'
-        fromAccount:
-          type: string
-          format: uri-reference
-        toAccount:
-          type: string
-          format: uri-reference
-        amount:
-          $ref: '#/components/schemas/AmountTransferred'
+            type: object
+            additionalProperties: true
+          description: "Participants involved in this token transaction (free-form)."
+        units:
+          description: "Units affected by this token transaction (free-form; may be null)."
         stateBefore:
-          $ref: '#/components/schemas/StateReference'
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: "Token state snapshot before this transaction (free-form)."
         stateAfter:
-          $ref: '#/components/schemas/StateReference'
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: "Token state snapshot after this transaction (free-form)."
         proofId:
           type: string
           format: uri-reference
+          nullable: true
         timestamp:
           type: string
           format: date-time
         metadata:
           type: object
           additionalProperties: true
-
-    Participant:
-      type: object
-      description: "Transaction participant"
-      required: [accountId, role]
-      properties:
-        accountId:
-          type: string
-          format: uri-reference
-        role:
-          type: string
-          enum: [sender, receiver, operator, approver]
-
-    AmountTransferred:
-      type: object
-      description: "Amount transferred/affected"
-      properties:
-        amount:
-          type: string
-          description: "Amount (string for big numbers)"
-        unit:
-          type: string
-          default: "token"
-        decimals:
-          type: integer
-
-    StateReference:
-      type: object
-      description: |
-        State reference with cryptographic commitment for verification.
-        State commitments form a chain where each commitment includes the previous one,
-        enabling tamper detection and full state history verification.
-      required: [stateCommitment]
-      properties:
-        stateCommitment:
-          type: string
-          description: |
-            SHA-256 hash of the token state computed from:
-            previousCommitment + lastTxId + timestamp + tokenId + owner +
-            identities + claims + state + stateVersion
-        previousCommitment:
-          type: string
-          description: "Previous state commitment hash (enables chain verification)"
-        lastTxId:
-          type: string
-          format: uri-reference
-          description: "Transaction ID that caused this state change"
-        stateVersion:
-          type: integer
-          description: "Monotonically increasing version number (optimistic locking)"
-        stateSnapshot:
-          type: object
-          additionalProperties: true
-          description: "Full state snapshot at this version"
-
-    LedgerAnchor:
-      type: object
-      description: "External blockchain anchor"
-      properties:
-        chain:
-          type: string
-          example: [ethereum, bitcoin, solana]
-        network:
-          type: string
-          example: [mainnet, sepolia]
-        txHash:
-          type: string
-        blockId:
-          type: string
-        timestamp:
+        signature:
+          description: "Signature payload for this token transaction (free-form; may be null)."
+        createdAt:
           type: string
           format: date-time
 
@@ -2810,7 +3098,8 @@ components:
             Use explicit paths for JSONB fields (e.g., metadata.field).
           properties:
             status:
-              $ref: '#/components/schemas/ExecutionStatus'
+              type: string
+              description: "Filter by transaction lifecycle status"
             correlationId:
               type: string
               description: "Filter by correlation ID"
@@ -2834,12 +3123,13 @@ components:
     TokenTransactionsRequest:
       type: object
       description: "Request for token transaction history with filters and pagination at payload level"
+      required: [filters]
       properties:
         filters:
           type: object
           description: |
             Transaction history filters.
-            Known fields: tokenId, operation, entryType, fromAccount, toAccount.
+            Known fields: tokenId, operation, entryType, dateRange.
             Use explicit paths for JSONB fields (e.g., metadata.field).
           properties:
             tokenId:
@@ -2848,8 +3138,7 @@ components:
               description: "Token ID to get history for"
             operation:
               type: string
-              enum: [mint, burn, transfer, freeze, unfreeze, lock, unlock, redeem, update]
-              description: "Filter by operation type"
+              description: "Filter by operation type (e.g. mint, burn, transfer; or domain-specific ops)"
             entryType:
               type: string
               enum: [debit, credit]
@@ -2879,7 +3168,7 @@ components:
 
     TransactionDetails:
       allOf:
-        - $ref: '#/components/schemas/TransactionLog'
+        - $ref: '#/components/schemas/TransactionResponse'
 
     TransactionList:
       type: object
@@ -2887,7 +3176,7 @@ components:
         transactions:
           type: array
           items:
-            $ref: '#/components/schemas/TransactionLog'
+            $ref: '#/components/schemas/TransactionResponse'
         pagination:
           $ref: '#/components/schemas/PaginationResponse'
 
@@ -2897,9 +3186,68 @@ components:
         tokenTransactions:
           type: array
           items:
-            $ref: '#/components/schemas/TokenTransaction'
+            $ref: '#/components/schemas/TokenTransactionResponse'
         pagination:
           $ref: '#/components/schemas/PaginationResponse'
+
+    # --- Federation Transaction Status (developer-facing) ---
+
+    FederationTransactionStatusRequest:
+      type: object
+      description: |
+        Payload of POST /v1/transactions/status. The endpoint has no dedicated JSON
+        schema; the payload carries the transaction id as `txn_id`.
+      required: [txn_id]
+      properties:
+        txn_id:
+          type: string
+          description: "Transaction id to query"
+
+    FederationWorkflowOp:
+      type: object
+      description: "One entry in the workflow-ops audit list."
+      required: [op_seq, op_type, created_at]
+      properties:
+        op_seq:
+          type: integer
+        op_type:
+          type: string
+        result:
+          description: "Operation result (free-form; may be null). Absent when not recorded."
+        details:
+          description: "Operation details (free-form; may be null). Absent when not recorded."
+        created_at:
+          type: string
+          format: date-time
+
+    FederationTransactionStatusResponse:
+      type: object
+      description: "Federation lifecycle view of a transaction, returned by POST /v1/transactions/status."
+      required: [txn_id, status, ops]
+      properties:
+        txn_id:
+          type: string
+        workflow_name:
+          type: string
+        status:
+          type: string
+          description: "Federation lifecycle status (e.g. SUBMITTED, COMMITTING, COMMITTED, ABORTED)."
+        ops:
+          type: array
+          items:
+            $ref: '#/components/schemas/FederationWorkflowOp'
+        retry_attempts:
+          type: integer
+        last_error:
+          type: string
+        outcome:
+          description: "Final outcome payload (free-form; may be null). Present when the workflow has produced an outcome."
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
 
     # --- Specific Request Envelopes ---
 
@@ -2967,11 +3315,11 @@ components:
             payload: { $ref: '#/components/schemas/TransactRequest' }
             signature: { $ref: '#/components/schemas/Signature' }
 
-    ApiRequest_AddCredentialRequest:
+    ApiRequest_AddTokenRequest:
       allOf:
         - $ref: '#/components/schemas/RequestContext'
         - properties:
-            payload: { $ref: '#/components/schemas/AddCredentialRequest' }
+            payload: { $ref: '#/components/schemas/AddTokenRequest' }
 
     # --- Specific Response Envelopes ---
     ApiResponse_TokenDetails:
@@ -2981,12 +3329,22 @@ components:
             response: { $ref: '#/components/schemas/TokenDetails' }
 
     ApiResponse_TokenList:
+      description: "Token search result envelope. `response` is a flat list (TokenList) or a grouped list (GroupedTokenList) when groupBy is set."
       allOf:
         - $ref: '#/components/schemas/ApiResponse'
         - properties:
-            response: { $ref: '#/components/schemas/TokenList' }
+            response:
+              oneOf:
+                - $ref: '#/components/schemas/TokenList'
+                - $ref: '#/components/schemas/GroupedTokenList'
 
-    ApiResponse_TransactAccepted:
+    ApiResponse_MintTokenResult:
+      allOf:
+        - $ref: '#/components/schemas/ApiResponse'
+        - properties:
+            response: { $ref: '#/components/schemas/MintTokenResponse' }
+
+    ApiResponse_TransactTokenResult:
       allOf:
         - $ref: '#/components/schemas/ApiResponse'
         - properties:
@@ -3000,23 +3358,13 @@ components:
                     transactionId:
                       type: string
                       format: uri-reference
-            response: { $ref: '#/components/schemas/TransactAccepted' }
+            response: { $ref: '#/components/schemas/TransactTokenResponse' }
 
-    ApiResponse_AddCredentialAccepted:
+    ApiResponse_AddTokenResult:
       allOf:
         - $ref: '#/components/schemas/ApiResponse'
         - properties:
-            context:
-              allOf:
-                - $ref: '#/components/schemas/ResponseContext'
-                - properties:
-                    status:
-                      type: string
-                      enum: ["accepted"]
-                    transactionId:
-                      type: string
-                      format: uri-reference
-            response: { $ref: '#/components/schemas/AddCredentialAccepted' }
+            response: { $ref: '#/components/schemas/AddTokenResponse' }
 
     # --- Transaction API Request Envelopes ---
     ApiRequest_TransactionStatusRequest:
@@ -3068,6 +3416,18 @@ components:
         - properties:
             response: { $ref: '#/components/schemas/TokenTransactionList' }
 
+    ApiRequest_FederationTransactionStatusRequest:
+      allOf:
+        - $ref: '#/components/schemas/RequestContext'
+        - properties:
+            payload: { $ref: '#/components/schemas/FederationTransactionStatusRequest' }
+
+    ApiResponse_FederationTransactionStatus:
+      allOf:
+        - $ref: '#/components/schemas/ApiResponse'
+        - properties:
+            response: { $ref: '#/components/schemas/FederationTransactionStatusResponse' }
+
     # --- Proof Schemas ---
 
     ProofStatus:
@@ -3091,166 +3451,150 @@ components:
         direction:
           $ref: '#/components/schemas/ProofDirection'
 
-    BlockchainAnchor:
+    LedgerAnchor:
       type: object
-      description: "Blockchain anchoring details"
+      description: "Ledger anchor reference — where the Merkle root was committed on-chain."
+      required: [chain, network, txHash]
       properties:
+        chain:
+          type: string
+          description: "Ledger/chain name (e.g. ethereum, solana)."
+          example: "ethereum"
         network:
           type: string
-          description: "Blockchain network name"
-          example: "ethereum_sepolia"
+          description: "Network name (e.g. mainnet, sepolia, devnet)."
+          example: "sepolia"
         txHash:
           type: string
-          description: "Blockchain transaction hash containing the Merkle root"
+          description: "Hash of the anchoring transaction on the chain."
           example: "0x1234567890abcdef..."
-        blockNumber:
+        blockId:
+          type: string
+          nullable: true
+          description: "Block number/identifier (for block-based chains)."
+        slot:
           type: integer
           format: int64
-          description: "Block number where the anchor was confirmed"
-        blockTimestamp:
+          nullable: true
+          description: "Slot number (for Solana)."
+        timestamp:
           type: string
           format: date-time
-          description: "Block timestamp"
-        contractAddress:
-          type: string
-          description: "Smart contract address used for anchoring"
+          description: "Anchor timestamp."
 
-    VerificationInfo:
+    ProofVerificationEndpoints:
       type: object
-      description: "Information for independent verification"
+      description: "Links to endpoints for independent proof verification."
+      required: [leafDataEndpoint]
       properties:
-        algorithm:
-          type: string
-          description: "Hashing algorithm used"
-          default: "sha256"
         leafDataEndpoint:
           type: string
-          description: "Endpoint to retrieve raw leaf data for verification"
+          description: "Endpoint to retrieve the raw leaf data for verification."
           example: "/v1/transaction/proof/leaf"
 
     ProofDetails:
       type: object
-      description: "Complete Merkle proof details for a transaction"
+      description: "Complete Merkle proof details for a transaction."
       required: [txId, proofStatus]
       properties:
         txId:
           type: string
-          format: uri-reference
-          description: "Transaction ID"
-        leafHash:
-          type: string
-          description: "SHA-256 hash of the transaction leaf data (hex-encoded)"
+          description: "Transaction ID."
         merkleRoot:
           type: string
-          description: "Merkle tree root hash (hex-encoded)"
+          nullable: true
+          description: "Merkle tree root hash (hex-encoded)."
+        leafHash:
+          type: string
+          nullable: true
+          description: "Hash of the transaction leaf data (hex-encoded)."
+        leafIndex:
+          type: integer
+          nullable: true
+          description: "Position of this transaction's leaf in the Merkle tree."
         proofPath:
           type: array
           items:
             $ref: '#/components/schemas/ProofPathNode'
-          description: "Path from leaf to root for verification"
-        leafIndex:
-          type: integer
-          description: "Position of this transaction's leaf in the Merkle tree"
-        batchId:
+          description: "Sibling hashes from leaf to root, used to recompute the Merkle root."
+        stateCommitment:
           type: string
-          format: uri-reference
-          description: "Batch identifier grouping transactions in this Merkle tree"
+          nullable: true
+          description: "State commitment for the transaction."
         proofStatus:
           $ref: '#/components/schemas/ProofStatus'
-        anchor:
-          $ref: '#/components/schemas/BlockchainAnchor'
-        verification:
-          $ref: '#/components/schemas/VerificationInfo'
+        ledgerAnchors:
+          type: array
+          items:
+            $ref: '#/components/schemas/LedgerAnchor'
+          description: "Ledger anchors referencing where the Merkle root was committed on-chain."
         message:
           type: string
-          description: "Additional status message (e.g., for pending proofs)"
-
-    TokenTransactionSummary:
-      type: object
-      description: "Summary of a token transaction for Merkle leaf data"
-      required: [id, tokenId]
-      properties:
-        id:
-          type: string
-          format: uri-reference
-          description: "Token transaction ID"
-        tokenId:
-          type: string
-          format: uri-reference
-          description: "Token ID"
-        entryType:
-          type: string
-          enum: [debit, credit]
           nullable: true
-          description: "Double-entry bookkeeping type (for transfers)"
-        amount:
-          type: string
-          description: "Amount (as string for precision)"
-        identities:
-          type: array
-          items:
-            $ref: '#/components/schemas/Identity'
-        participants:
-          type: array
-          items:
-            $ref: '#/components/schemas/Participant'
+          description: "Additional status message (e.g. for pending proofs)."
+        verificationEndpoints:
+          $ref: '#/components/schemas/ProofVerificationEndpoints'
 
     ProofLeafData:
       type: object
-      description: "Raw transaction leaf data used in Merkle tree"
-      required: [txId, operation, tokenClass, status, createdAt, tokenTransactions]
+      description: "Raw leaf data for a transaction, used to independently recompute the leaf hash."
+      required: [txId, leafHash, stateCommitment, timestamp]
       properties:
         txId:
           type: string
-          format: uri-reference
-          description: "Transaction ID"
-        operation:
+          description: "Transaction ID."
+        leafHash:
           type: string
-          description: "Operation type (mint, transfer, burn, etc.)"
+          description: "Hash of the leaf data (hex-encoded)."
+        stateCommitment:
+          type: string
+          description: "State commitment for the transaction."
+        tokenId:
+          type: string
+          nullable: true
+          description: "Token ID associated with the transaction (if applicable)."
         tokenClass:
           type: string
-          description: "Token class identifier"
-        status:
+          nullable: true
+          description: "Token class identifier (if applicable)."
+        operation:
           type: string
-          description: "Transaction status"
-        createdAt:
+          nullable: true
+          description: "Operation type (mint, transfer, burn, etc.)."
+        timestamp:
           type: string
           format: date-time
-          description: "Transaction creation timestamp"
-        tokenTransactions:
-          type: array
-          items:
-            $ref: '#/components/schemas/TokenTransactionSummary'
-          description: "All token transactions included in this transaction"
+          description: "Transaction timestamp."
+        rawData:
+          type: object
+          additionalProperties: true
+          description: "Full data map that was hashed to produce the leaf hash."
 
     ProofVerificationResult:
       type: object
-      description: "Result of server-side proof verification"
-      required: [verified, verifiedAt]
+      description: "Result of server-side proof verification."
+      required: [txId, valid, leafHashValid, proofPathValid]
       properties:
-        verified:
+        txId:
+          type: string
+          description: "Transaction ID."
+        valid:
           type: boolean
-          description: "Overall verification result"
+          description: "Overall verification result."
         leafHashValid:
           type: boolean
-          description: "Whether the leaf hash matches the transaction data"
+          description: "Whether the leaf hash matches the stored transaction data."
         proofPathValid:
           type: boolean
-          description: "Whether the proof path correctly computes to the Merkle root"
+          description: "Whether the proof path correctly computes to the Merkle root."
         anchorValid:
           type: boolean
           nullable: true
-          description: "Whether the Merkle root exists on the blockchain (null if not yet anchored)"
-        error:
-          type: string
-          description: "Error message if verification failed"
+          description: "Whether the anchor exists on-chain (null if not yet anchored)."
         message:
           type: string
-          description: "Additional information about verification status"
-        verifiedAt:
-          type: string
-          format: date-time
-          description: "Timestamp of verification"
+          nullable: true
+          description: "Additional information about the verification result."
 
     # --- Proof API Request Payloads ---
 

--- a/api/token-interfaces.yaml
+++ b/api/token-interfaces.yaml
@@ -3724,8 +3724,6 @@ components:
       bearerFormat: "JWT or Opaque"
       description: |
         A JWT or Opaque token that identifies the calling B2B developer/backend service.
-        This is passed in the standard `Authorization: Bearer <token>` header.
-        (This can also be passed in the `context.developerToken` as a fallback).
 
     developerSignature:
       type: apiKey

--- a/api/token-interfaces.yaml
+++ b/api/token-interfaces.yaml
@@ -844,7 +844,7 @@ paths:
                         roles: ["owner"]
                     initialSupply: "1000000000000"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               INRT:
                 summary: "Mint INRT - 10K tokens"
@@ -867,7 +867,7 @@ paths:
                         roles: ["owner"]
                     initialSupply: "1000000"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               NFH-T:
                 summary: "Mint NFH-T - 5K tokens with constraints"
@@ -890,7 +890,7 @@ paths:
                         roles: ["owner"]
                     initialSupply: "500000"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               ART-NFT:
                 summary: "Mint ART-NFT - Digital Art"
@@ -929,7 +929,7 @@ paths:
                         roles: ["owner"]
                     initialSupply: "1"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               RWA-NFT:
                 summary: "Mint RWA-NFT - Property Deed"
@@ -961,7 +961,7 @@ paths:
                         roles: ["owner"]
                     initialSupply: "1"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
       responses:
         '200':
@@ -1167,7 +1167,7 @@ paths:
                     to: "bob"
                     value: "100000000"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               TransferINRT:
                 summary: "Transfer - INRT (Cross-Border Remittance)"
@@ -1185,7 +1185,7 @@ paths:
                     to: "lakshmi"
                     value: "5000000000000"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               TransferARTNFT:
                 summary: "Transfer - ART-NFT (Art Sale)"
@@ -1203,7 +1203,7 @@ paths:
                     to: "charlie"
                     value: "1"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               TransferRWANFT:
                 summary: "Transfer - RWA-NFT (Property Sale)"
@@ -1226,7 +1226,7 @@ paths:
                       closingDate: "2025-03-15"
                       escrowAgent: "titlecompany"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               BurnUSDT:
                 summary: "Burn - USDT (Redemption)"
@@ -1244,7 +1244,7 @@ paths:
                     value: "1000000000"
                     reason: "Fiat withdrawal - Bank transfer to Tether redemption account"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               BurnNFHT:
                 summary: "Burn - NFH-T (Community Token Burn)"
@@ -1262,7 +1262,7 @@ paths:
                     value: "500000000000000000000"
                     reason: "Deflationary burn event - Q1 2025"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               FreezeINRT:
                 summary: "Freeze - INRT (Compliance Hold)"
@@ -1280,7 +1280,7 @@ paths:
                     reason: "AML investigation - Case #AML-2025-001"
                     frozenBy: "hdfc:compliance"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               UnfreezeToken:
                 summary: "Unfreeze a token"
@@ -1297,7 +1297,7 @@ paths:
                     tokenId: "1ab71000-5054-4001-8001-000000000001"
                     reason: "Compliance review completed"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               LockEURC:
                 summary: "Lock - EURC (DeFi Collateral)"
@@ -1316,7 +1316,7 @@ paths:
                     reason: "Collateral for DeFi loan - Protocol: Aave"
                     lockUntil: "2025-12-31T23:59:59Z"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               LockGBPT:
                 summary: "Lock - GBPT (Escrow for Trade)"
@@ -1335,7 +1335,7 @@ paths:
                     reason: "Escrow for international trade - Invoice #INV-2025-001"
                     lockUntil: "2025-06-30T23:59:59Z"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               UnlockToken:
                 summary: "Unlock previously locked tokens"
@@ -1353,7 +1353,7 @@ paths:
                     value: "500000000"
                     reason: "Loan repaid"
                   signature:
-                    key_id: "0f8fad5b-d9cb-469f-a165-70867728950e"
+                    keyId: "0f8fad5b-d9cb-469f-a165-70867728950e"
                     jws: "eyJhbGciOiJFUzI1NksifQ..aBcDeFgHiJkLmNoPqRsTuVwXyZ"
               UpdateToken:
                 summary: "Update token data and metadata"
@@ -2141,9 +2141,9 @@ components:
         error: { $ref: '#/components/schemas/ErrorPayload' }
     Signature:
       type: object
-      required: [key_id, jws]
+      required: [keyId, jws]
       properties:
-        key_id: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
+        keyId: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
         jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object" }
     ErrorPayload:
       type: object
@@ -2656,20 +2656,20 @@ components:
 
     AddTokenRequest:
       type: object
-      required: [tokenClass, owner]
+      required: [tokenClass]
       description: |
         Request to add a token. Supports two shapes (selected via `oneOf`):
           - **Credential token** (W3C VC): requires `credential` + `metadata`.
           - **Proxy token** (USDC, ETH, SOL, etc.): requires `chainId`,
-            `contractAddress`, `walletAddress`, `value`.
+            `contractAddress`, `walletAddress`; `value` only when creating (a duplicate add from the owner reconciles and omits it).
 
         Called backend-to-backend by the Finternet App Backend (no end-user JWT).
-        The token owner address must be provided in the payload.
+        The token owner is optional: when omitted, the server derives it from the authenticated session.
       oneOf:
         - title: "Credential Token"
           required: [credential, metadata]
         - title: "Proxy Token"
-          required: [chainId, contractAddress, walletAddress, value]
+          required: [chainId, contractAddress, walletAddress]
       properties:
         tokenClass:
           type: string

--- a/api/token-interfaces.yaml
+++ b/api/token-interfaces.yaml
@@ -131,7 +131,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.tokenclasses.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
                     developerToken: "fnt_..."
@@ -141,7 +141,6 @@ paths:
                     tokenStandard: "UNITS-FT"
                     name: "USD Coin"
                     description: "Circle USD stablecoin pegged 1:1 to USD"
-                    status: "active"
                     schema:
                       type: "object"
                       properties:
@@ -166,7 +165,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.tokenclasses.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef"
                     developerToken: "fnt_..."
@@ -200,7 +199,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.tokenclasses.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
                     developerToken: "fnt_..."
@@ -234,7 +233,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.tokenclasses.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef"
                     developerToken: "fnt_..."
@@ -268,7 +267,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.tokenclasses.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef1"
                     developerToken: "fnt_..."
@@ -302,7 +301,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.tokenclasses.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef12"
                     developerToken: "fnt_..."
@@ -337,7 +336,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.tokenclasses.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "a7b8c9d0-e1f2-3456-7890-abcdef123"
                     developerToken: "fnt_..."
@@ -375,7 +374,7 @@ paths:
                 value:
                   context:
                     id: "api.registry.tokenclasses.register"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "b8c9d0e1-f2a3-4567-8901-bcdef1234"
                     developerToken: "fnt_..."
@@ -413,7 +412,7 @@ paths:
               example:
                 context:
                   id: "api.registry.tokenclasses.register"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2025-01-04T10:00:00Z"
                   msgId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
                   status: "successful"
@@ -474,7 +473,7 @@ paths:
             example:
               context:
                 id: "api.registry.tokenclasses.update"
-                version: "1.0"
+                version: "v1"
                 ts: "2025-01-04T11:00:00Z"
                 msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef"
                 developerToken: "fnt_..."
@@ -521,7 +520,7 @@ paths:
             example:
               context:
                 id: "api.registry.tokenclasses.get"
-                version: "1.0"
+                version: "v1"
                 ts: "2025-01-04T10:00:00Z"
                 msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef12"
                 developerToken: "fnt_..."
@@ -538,7 +537,7 @@ paths:
               example:
                 context:
                   id: "api.registry.tokenclasses.get"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2025-01-04T10:00:00Z"
                   msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
                   status: "successful"
@@ -593,7 +592,7 @@ paths:
             example:
               context:
                 id: "api.registry.tokenclasses.search"
-                version: "1.0"
+                version: "v1"
                 ts: "2025-01-04T10:00:00Z"
                 msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef123"
                 developerToken: "fnt_..."
@@ -618,7 +617,7 @@ paths:
               example:
                 context:
                   id: "api.registry.tokenclasses.search"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2025-01-04T10:00:00Z"
                   msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef"
                   status: "successful"
@@ -707,7 +706,7 @@ paths:
                 value:
                   context:
                     id: "api.token.get"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                     developerToken: "fnt_..."
@@ -719,7 +718,7 @@ paths:
                 value:
                   context:
                     id: "api.token.get"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdf0"
                     developerToken: "fnt_..."
@@ -740,7 +739,7 @@ paths:
                   value:
                     context:
                       id: "api.token.get"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-01-04T10:00:01Z"
                       msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                       status: "successful"
@@ -772,7 +771,7 @@ paths:
                   value:
                     context:
                       id: "api.token.get"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-01-04T10:00:01Z"
                       msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdf0"
                       status: "successful"
@@ -829,7 +828,7 @@ paths:
                 value:
                   context:
                     id: "api.token.mint"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "c1d2e3f4-a5b6-7890-1234-567890abcdef"
                     developerToken: "fnt_..."
@@ -852,7 +851,7 @@ paths:
                 value:
                   context:
                     id: "api.token.mint"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "d2e3f4a5-b6c7-8901-2345-67890abcdef"
                     developerToken: "fnt_..."
@@ -875,7 +874,7 @@ paths:
                 value:
                   context:
                     id: "api.token.mint"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "e3f4a5b6-c7d8-9012-3456-7890abcdef1"
                     developerToken: "fnt_..."
@@ -898,7 +897,7 @@ paths:
                 value:
                   context:
                     id: "api.token.mint"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "f4a5b6c7-d8e9-0123-4567-890abcdef12"
                     developerToken: "fnt_..."
@@ -937,7 +936,7 @@ paths:
                 value:
                   context:
                     id: "api.token.mint"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "a5b6c7d8-e9f0-1234-5678-90abcdef123"
                     developerToken: "fnt_..."
@@ -974,7 +973,7 @@ paths:
               example:
                 context:
                   id: "api.token.mint"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2025-01-04T10:00:00Z"
                   msgId: "c1d2e3f4-a5b6-7890-1234-567890abcdef"
                   status: "successful"
@@ -1012,7 +1011,7 @@ paths:
                 value:
                   context:
                     id: "api.token.search"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
                     developerToken: "fnt_..."
@@ -1035,7 +1034,7 @@ paths:
                 value:
                   context:
                     id: "api.token.search"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:00:00Z"
                     msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef2"
                     developerToken: "fnt_..."
@@ -1061,7 +1060,7 @@ paths:
                   value:
                     context:
                       id: "api.token.search"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-01-04T10:00:01Z"
                       msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
                       status: "successful"
@@ -1091,7 +1090,7 @@ paths:
                   value:
                     context:
                       id: "api.token.search"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-01-04T10:00:01Z"
                       msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef2"
                       status: "successful"
@@ -1157,7 +1156,7 @@ paths:
                 value:
                   context:
                     id: "api.token.transact"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:15:00Z"
                     msgId: "f1a2b3c4-d5e6-7890-1234-567890abcdef"
                     developerToken: "fnt_..."
@@ -1175,7 +1174,7 @@ paths:
                 value:
                   context:
                     id: "api.token.transact"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:15:00Z"
                     msgId: "g2b3c4d5-e6f7-8901-2345-67890abcdef"
                     developerToken: "fnt_..."
@@ -1193,7 +1192,7 @@ paths:
                 value:
                   context:
                     id: "api.token.transact"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:15:00Z"
                     msgId: "h3c4d5e6-f7a8-9012-3456-7890abcdef1"
                     developerToken: "fnt_..."
@@ -1211,7 +1210,7 @@ paths:
                 value:
                   context:
                     id: "api.token.transact"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:15:00Z"
                     msgId: "i4d5e6f7-a8b9-0123-4567-890abcdef12"
                     developerToken: "fnt_..."
@@ -1234,7 +1233,7 @@ paths:
                 value:
                   context:
                     id: "api.token.transact"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:05:00Z"
                     msgId: "d1e2f3a4-b5c6-7890-1234-567890abcdef"
                     developerToken: "fnt_..."
@@ -1252,7 +1251,7 @@ paths:
                 value:
                   context:
                     id: "api.token.transact"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:05:00Z"
                     msgId: "d2e3f4a5-b6c7-8901-2345-67890abcdef"
                     developerToken: "fnt_..."
@@ -1270,7 +1269,7 @@ paths:
                 value:
                   context:
                     id: "api.token.transact"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:10:00Z"
                     msgId: "e1f2a3b4-c5d6-7890-1234-567890abcdef"
                     developerToken: "fnt_..."
@@ -1288,7 +1287,7 @@ paths:
                 value:
                   context:
                     id: "api.token.transact"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:10:00Z"
                     msgId: "e2f3a4b5-c6d7-8901-2345-67890abcdef"
                     developerToken: "fnt_..."
@@ -1305,7 +1304,7 @@ paths:
                 value:
                   context:
                     id: "api.token.transact"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:20:00Z"
                     msgId: "f3a4b5c6-d7e8-9012-3456-7890abcdef1"
                     developerToken: "fnt_..."
@@ -1324,7 +1323,7 @@ paths:
                 value:
                   context:
                     id: "api.token.transact"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:20:00Z"
                     msgId: "f4a5b6c7-d8e9-0123-4567-890abcdef12"
                     developerToken: "fnt_..."
@@ -1343,7 +1342,7 @@ paths:
                 value:
                   context:
                     id: "api.token.transact"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:20:00Z"
                     msgId: "f5a6b7c8-d9e0-1234-5678-90abcdef123"
                     developerToken: "fnt_..."
@@ -1361,7 +1360,7 @@ paths:
                 value:
                   context:
                     id: "api.token.transact"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-04T10:20:00Z"
                     msgId: "a2b3c4d5-e6f7-8901-2345-67890abcdef"
                     developerToken: "fnt_..."
@@ -1385,7 +1384,7 @@ paths:
                   value:
                     context:
                       id: "api.token.transact"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-01-04T10:15:00Z"
                       msgId: "f1a2b3c4-d5e6-7890-1234-567890abcdef"
                       status: "accepted"
@@ -1401,7 +1400,7 @@ paths:
                   value:
                     context:
                       id: "api.token.transact"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-01-04T10:05:00Z"
                       msgId: "d1e2f3a4-b5c6-7890-1234-567890abcdef"
                       status: "accepted"
@@ -1453,7 +1452,7 @@ paths:
             example:
               context:
                 id: "api.transaction.status"
-                version: "1.0"
+                version: "v1"
                 ts: "2025-01-04T10:00:02Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -1473,7 +1472,7 @@ paths:
                   value:
                     context:
                       id: "api.transaction.status"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-01-04T10:00:02Z"
                       msgId: "..."
                       status: "successful"
@@ -1487,7 +1486,7 @@ paths:
                   value:
                     context:
                       id: "api.transaction.status"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-01-04T10:00:05Z"
                       msgId: "..."
                       status: "successful"
@@ -1504,7 +1503,7 @@ paths:
                   value:
                     context:
                       id: "api.transaction.status"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-01-04T10:00:02Z"
                       msgId: "..."
                       status: "successful"
@@ -1545,7 +1544,7 @@ paths:
             example:
               context:
                 id: "api.transaction.get"
-                version: "1.0"
+                version: "v1"
                 ts: "2025-01-04T10:00:10Z"
                 msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef"
                 developerToken: "fnt_..."
@@ -1584,7 +1583,7 @@ paths:
             example:
               context:
                 id: "api.transaction.search"
-                version: "1.0"
+                version: "v1"
                 ts: "2025-01-04T10:00:00Z"
                 msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
                 developerToken: "fnt_..."
@@ -1641,7 +1640,7 @@ paths:
             example:
               context:
                 id: "api.transactions.status"
-                version: "1.0"
+                version: "v1"
                 ts: "2025-01-04T10:00:02Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -1658,7 +1657,7 @@ paths:
               example:
                 context:
                   id: "api.transactions.status"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2025-01-04T10:00:05Z"
                   msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "successful"
@@ -1705,7 +1704,7 @@ paths:
             example:
               context:
                 id: "api.token.transactions"
-                version: "1.0"
+                version: "v1"
                 ts: "2025-01-04T10:00:00Z"
                 msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef"
                 developerToken: "fnt_..."
@@ -1768,7 +1767,7 @@ paths:
                 value:
                   context:
                     id: "api.token.add"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-28T10:15:00Z"
                     msgId: "550e8400-e29b-41d4-a716-446655440000"
                     developerToken: "fnt_..."
@@ -1799,7 +1798,7 @@ paths:
                 value:
                   context:
                     id: "api.token.add"
-                    version: "1.0"
+                    version: "v1"
                     ts: "2025-01-28T10:15:00Z"
                     msgId: "550e8400-e29b-41d4-a716-446655440001"
                     developerToken: "fnt_..."
@@ -1820,7 +1819,7 @@ paths:
               example:
                 context:
                   id: "api.token.add"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2025-01-28T10:15:05Z"
                   msgId: "550e8400-e29b-41d4-a716-446655440002"
                   status: "successful"
@@ -1867,7 +1866,7 @@ paths:
             example:
               context:
                 id: "api.transaction.proof"
-                version: "1.0"
+                version: "v1"
                 ts: "2025-01-04T10:00:02Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -1887,7 +1886,7 @@ paths:
                   value:
                     context:
                       id: "api.transaction.proof"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-01-04T10:00:02Z"
                       msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                       status: "successful"
@@ -1916,7 +1915,7 @@ paths:
                   value:
                     context:
                       id: "api.transaction.proof"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-01-04T10:00:02Z"
                       msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                       status: "successful"
@@ -1958,7 +1957,7 @@ paths:
             example:
               context:
                 id: "api.transaction.proof.leaf"
-                version: "1.0"
+                version: "v1"
                 ts: "2025-01-04T10:00:02Z"
                 msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef"
                 developerToken: "fnt_..."
@@ -1975,7 +1974,7 @@ paths:
               example:
                 context:
                   id: "api.transaction.proof.leaf"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2025-01-04T10:00:02Z"
                   msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef"
                   status: "successful"
@@ -2030,7 +2029,7 @@ paths:
             example:
               context:
                 id: "api.transaction.proof.verify"
-                version: "1.0"
+                version: "v1"
                 ts: "2025-01-04T10:00:02Z"
                 msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
                 developerToken: "fnt_..."
@@ -2050,7 +2049,7 @@ paths:
                   value:
                     context:
                       id: "api.transaction.proof.verify"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-01-04T10:00:02Z"
                       msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
                       status: "successful"
@@ -2065,7 +2064,7 @@ paths:
                   value:
                     context:
                       id: "api.transaction.proof.verify"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-01-04T10:00:02Z"
                       msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
                       status: "successful"
@@ -2081,7 +2080,7 @@ paths:
                   value:
                     context:
                       id: "api.transaction.proof.verify"
-                      version: "1.0"
+                      version: "v1"
                       ts: "2025-01-04T10:00:02Z"
                       msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef"
                       status: "successful"
@@ -2115,7 +2114,7 @@ components:
       required: [id, version, ts, msgId]
       properties:
         id: { type: string, example: "api.token.get" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
@@ -2137,7 +2136,7 @@ components:
       required: [id, version, ts, msgId, status]
       properties:
         id: { type: string, example: "api.token.get" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true }
@@ -2515,7 +2514,7 @@ components:
 
     MintTokenRequest:
       type: object
-      required: [tokenClass, initialSupply]
+      required: [tokenClass, initialSupply, identities]
       description: "Request to mint a new token instance"
       properties:
         tokenClass:
@@ -2534,10 +2533,6 @@ components:
           type: array
           items: { $ref: '#/components/schemas/Identity' }
           description: "Identity relationships for this token"
-        claims:
-          type: array
-          items: { $ref: '#/components/schemas/Claim' }
-          description: "Initial verifiable claims (optional)"
         initialSupply:
           type: string
           description: "Initial token supply (for fungible tokens). Format depends on `context.valueFormat` (raw: integer string, display: decimal string)."
@@ -2664,20 +2659,20 @@ components:
 
     AddTokenRequest:
       type: object
-      required: [tokenClass, owner]
+      required: [tokenClass]
       description: |
         Request to add a token. Supports two shapes (selected via `oneOf`):
           - **Credential token** (W3C VC): requires `credential` + `metadata`.
           - **Proxy token** (USDC, ETH, SOL, etc.): requires `chainId`,
-            `contractAddress`, `walletAddress`, `value`.
+            `contractAddress`, `walletAddress`; `value` is required only when creating (a duplicate add from the owner is a balance refresh and omits it).
 
         Called backend-to-backend by the Finternet App Backend (no end-user JWT).
-        The token owner address must be provided in the payload.
+        The token owner address is optional: when omitted, the server resolves it from the forwarded end-user session.
       oneOf:
         - title: "Credential Token"
           required: [credential, metadata]
         - title: "Proxy Token"
-          required: [chainId, contractAddress, walletAddress, value]
+          required: [chainId, contractAddress, walletAddress]
       properties:
         tokenClass:
           type: string
@@ -3129,7 +3124,6 @@ components:
     TokenTransactionsRequest:
       type: object
       description: "Request for token transaction history with filters and pagination at payload level"
-      required: [filters]
       properties:
         filters:
           type: object

--- a/api/token-interfaces.yaml
+++ b/api/token-interfaces.yaml
@@ -7,20 +7,47 @@ info:
     This API enables creation, management, and lifecycle operations for universal tokens
     following the UNITS Token Specification.
 
-    ### Envelope
+    ### Protocol-Agnostic Envelope
+    All API interactions use a standard JSON envelope.
 
-    All endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
-    On failure `context.status` is `failed`, `context.error` carries a `code` and a
-    `message`, and `response` is empty.
+    **Request Envelope:**
+    ```json
+    {
+      "context": { ... },
+      "payload": { ... },
+      "signature": { ... } // Optional
+    }
+    ```
 
-    ### Authentication
+    **Response Envelope (Success):**
+    ```json
+    {
+      "context": { ..., "status": "successful" },
+      "response": { ... }
+    }
+    ```
 
-    * `context.developerToken`: the calling application's developer token. Required on
-      every endpoint.
-    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
-      `Signature` header.
-    * `context.authorization`: the end user's session token, required by the endpoints
-      that act on a signed-in user. Each operation states when it is needed.
+    **Response Envelope (Error):**
+    ```json
+    {
+      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." }},
+      "response": {} // Empty on error
+    }
+    ```
+    (Error details are in the context.error object)
+
+    ### Authentication and Authorization
+    This API uses the same two-level authorization model as the Account service:
+
+    1.  **Platform-Level (Developer) Authentication:**
+        * `context.developerToken`: The B2B Developer's API Key/Token.
+        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
+
+    2.  **User-Level (End-User) Authorization:**
+        * `context.authorization`: The end-user's JWT session token (for session-based calls).
+        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
+
+    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header.
 
     ### RBAC Scopes
 
@@ -50,9 +77,10 @@ info:
 
     ### Rate limiting
 
-    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
-    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
-    the tier assigned to the calling client.
+    All endpoints are protected by a scope-tier sliding-window rate limiter. When the
+    limit is exceeded the service responds with `429 Too Many Requests` and a
+    `Retry-After` header indicating when the caller may retry. The shared
+    `RateLimitedError` response component documents the body shape.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -424,8 +452,6 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '409':
           description: "Token class already exists"
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/tokenclasses/update:
     post:
@@ -475,8 +501,6 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '404':
           $ref: '#/components/responses/NotFoundError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/tokenclasses/get:
     post:
@@ -549,10 +573,6 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/tokenclasses/search:
     post:
@@ -663,10 +683,6 @@ paths:
                     offset: 0
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   # -------------------- Token --------------------
   /v1/token/get:
@@ -674,7 +690,7 @@ paths:
       tags:
         - "Token"
       summary: "Get token details"
-      description: "Retrieves detailed information about a specific token by its ID. Requires a user session token."
+      description: "Retrieves detailed information about a specific token by its ID. Requires Developer and User auth."
       security:
         - developerToken: []
         - userToken: []
@@ -786,10 +802,6 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/token/mint:
     post:
@@ -977,15 +989,13 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/token/search:
     post:
       tags:
         - "Token"
       summary: "Search tokens"
-      description: "Search tokens with filters (type, status, and so on). Results are limited to the tokens the caller may see. Supports pagination."
+      description: "Search tokens with filters (type, status, etc.). Owner filtering inferred from JWT/ACL. Supports pagination. Requires Developer auth."
       security:
         - developerToken: []
         - developerSignature: []
@@ -1107,10 +1117,6 @@ paths:
                         offset: 0
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/token/transact:
     post:
@@ -1121,19 +1127,20 @@ paths:
         Unified endpoint for all token write operations. The operation is specified in the payload.
 
         **Supported Operations:**
-        - `burn`: burn or destroy the token (terminal state)
-        - `freeze`: freeze the token (compliance or regulatory hold)
-        - `unfreeze`: unfreeze the token
-        - `lock`: lock the token (for escrow or collateral)
-        - `unlock`: unlock the token
-        - `redeem`: redeem the token (for redeemable assets)
-        - `transfer`: transfer ownership of the token
-        - `update`: update the token's data or metadata fields
+        - `burn` - Burn/destroy token (terminal state)
+        - `freeze` - Freeze token (compliance/regulatory hold)
+        - `unfreeze` - Unfreeze token
+        - `lock` - Lock token (for escrow/collateral)
+        - `unlock` - Unlock token
+        - `redeem` - Redeem token (for redeemable assets)
+        - `transfer` - Transfer token ownership
+        - `update` - Update token data or metadata fields
 
         **Note:** `mint` operation has a dedicated `/v1/token/mint` endpoint with separate ACL controls.
 
-        **Signature required:** a top-level end user `signature` over the payload is mandatory
-        for every transact operation. A request without a valid `signature` is rejected.
+        **Signature required:** a top-level end-user payload `signature` is mandatory for
+        every transact operation. units-api enforces this via a `RequireSignature`
+        middleware on this route; a request without a valid `signature` is rejected.
       security:
         - developerToken: []
         - developerSignature: []
@@ -1412,8 +1419,6 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '409':
           $ref: '#/components/responses/ConflictError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   # -------------------- Transaction APIs --------------------
   /v1/transaction/status:
@@ -1515,10 +1520,6 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/transaction/get:
     post:
@@ -1560,10 +1561,6 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/transaction/search:
     post:
@@ -1611,10 +1608,6 @@ paths:
                 $ref: '#/components/schemas/ApiResponse_TransactionList'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/transactions/status:
     post:
@@ -1689,8 +1682,6 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '404':
           $ref: '#/components/responses/NotFoundError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/token/transactions:
     post:
@@ -1737,10 +1728,6 @@ paths:
                 $ref: '#/components/schemas/ApiResponse_TokenTransactionList'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   /v1/token/add:
     post:
@@ -1847,10 +1834,6 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '409':
           $ref: '#/components/responses/ConflictError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '429':
-          $ref: '#/components/responses/RateLimitedError'
 
   # -------------------- Proof APIs --------------------
   /v1/transaction/proof:
@@ -1867,7 +1850,7 @@ paths:
         - `proven`: Merkle proof generated
         - `anchored`: proof anchored to a public ledger, fully verifiable
 
-        Requires a user session token.
+        Requires Developer + User auth.
       security:
         - developerToken: []
         - userToken: []
@@ -1958,7 +1941,7 @@ paths:
         Merkle tree. Enables independent verification: fetch this data, hash it, and
         confirm it matches the `leafHash` returned by `/v1/transaction/proof`.
 
-        Requires a user session token.
+        Requires Developer + User auth.
       security:
         - developerToken: []
         - userToken: []
@@ -2030,7 +2013,7 @@ paths:
         For trustless verification, clients should verify independently using the data
         from `/v1/transaction/proof` and `/v1/transaction/proof/leaf`.
 
-        Requires a user session token.
+        Requires Developer + User auth.
       security:
         - developerToken: []
         - userToken: []
@@ -2103,7 +2086,7 @@ paths:
                       valid: false
                       leafHashValid: false
                       proofPathValid: true
-                      message: "Leaf hash mismatch; the transaction data may have been modified."
+                      message: "Leaf hash mismatch; transaction data may have been modified."
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':
@@ -2144,7 +2127,7 @@ components:
             - `raw` (default): Smallest-unit integer strings (e.g., "100500000" for 100.5 USDC with 6 decimals).
             - `display`: Human-readable decimal strings (e.g., "100.50" for 100.5 USDC).
             The service layer performs decimal conversion using token class metadata.
-            Amounts are always opaque strings and are never parsed as a float.
+            Amounts are always opaque strings, never parsed as float by any system.
     ResponseContext:
       type: object
       required: [id, version, ts, msgId, status]
@@ -2612,7 +2595,7 @@ components:
         **For update:** `operation`, `tokenId`, `data` (optional), `metadata` (optional)
         **For burn/freeze/lock/transfer:** `operation`, `tokenId`, plus operation-specific params at root level
 
-        `operation` is an open string. Common lifecycle operations (burn, freeze,
+        `operation` is an open string; common lifecycle operations (burn, freeze,
         transfer, …) as well as domain-specific operations (e.g. `loan_disbursed`,
         `emi_due`) are accepted.
 
@@ -2680,8 +2663,8 @@ components:
           - **Proxy token** (USDC, ETH, SOL, etc.): requires `chainId`,
             `contractAddress`, `walletAddress`; `value` only when creating (a duplicate add from the owner reconciles and omits it).
 
-        Called by the application backend; no user session token is required. The token owner
-        is optional: when omitted it is taken from the authenticated session.
+        Called backend-to-backend by the Finternet App Backend (no end-user JWT).
+        The token owner is optional: when omitted, the server derives it from the authenticated session.
       oneOf:
         - title: "Credential Token"
           required: [credential, metadata]
@@ -3680,7 +3663,7 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
+      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -3688,12 +3671,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "The caller does not have the scope required by this endpoint."
+      description: "Forbidden. Insufficient permissions."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -3720,7 +3703,9 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "CONFLICT", message: "Operation conflicts with current token state." } }
             response: {}
     RateLimitedError:
-      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }
@@ -3753,5 +3738,6 @@ components:
       scheme: bearer
       bearerFormat: JWT
       description: |
-        End user's session token, obtained from `/v1/account/login` and passed in
-        `context.authorization` as `Bearer <token>`.
+        A JWT token that identifies the end-user making the request. This is obtained
+        after user authentication (e.g., via `/v1/account/login`) and is passed in
+        the `context.authorization` field as `Bearer <token>`.

--- a/api/token-interfaces.yaml
+++ b/api/token-interfaces.yaml
@@ -2656,20 +2656,20 @@ components:
 
     AddTokenRequest:
       type: object
-      required: [tokenClass]
+      required: [tokenClass, owner]
       description: |
         Request to add a token. Supports two shapes (selected via `oneOf`):
           - **Credential token** (W3C VC): requires `credential` + `metadata`.
           - **Proxy token** (USDC, ETH, SOL, etc.): requires `chainId`,
-            `contractAddress`, `walletAddress`; `value` is required only when creating (a duplicate add from the owner is a balance refresh and omits it).
+            `contractAddress`, `walletAddress`, `value`.
 
         Called backend-to-backend by the Finternet App Backend (no end-user JWT).
-        The token owner address is optional: when omitted, the server resolves it from the forwarded end-user session.
+        The token owner address must be provided in the payload.
       oneOf:
         - title: "Credential Token"
           required: [credential, metadata]
         - title: "Proxy Token"
-          required: [chainId, contractAddress, walletAddress]
+          required: [chainId, contractAddress, walletAddress, value]
       properties:
         tokenClass:
           type: string

--- a/api/token-interfaces.yaml
+++ b/api/token-interfaces.yaml
@@ -1727,8 +1727,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse_TokenTransactionList'
-        '404':
-          $ref: '#/components/responses/NotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
 

--- a/api/token-interfaces.yaml
+++ b/api/token-interfaces.yaml
@@ -41,13 +41,10 @@ info:
 
     1.  **Platform-Level (Developer) Authentication:**
         * `context.developerToken`: The B2B Developer's API Key/Token.
-        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
 
     2.  **User-Level (End-User) Authorization:**
         * `context.authorization`: The end-user's JWT session token (for session-based calls).
         * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
-
-    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header.
 
     ### RBAC Scopes
 
@@ -118,7 +115,6 @@ paths:
         Only authorized administrators can register token classes.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -463,7 +459,6 @@ paths:
         Can be used to add/remove authorized minters or update class properties.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -815,7 +810,6 @@ paths:
         Requires both developer authentication and end-user signature.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -998,7 +992,6 @@ paths:
       description: "Search tokens with filters (type, status, etc.). Owner filtering inferred from JWT/ACL. Supports pagination. Requires Developer auth."
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -1143,7 +1136,6 @@ paths:
         middleware on this route; a request without a valid `signature` is rejected.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -1751,7 +1743,6 @@ paths:
         tracks it.
       security:
         - developerToken: []
-        - developerSignature: []
       requestBody:
         required: true
         content:
@@ -2115,8 +2106,7 @@ components:
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "B2B Developer API Key/Token" }
-        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "B2B Developer Signature" }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token" }
         valueFormat:
           type: string
@@ -3722,17 +3712,7 @@ components:
       type: http
       scheme: bearer
       bearerFormat: "JWT or Opaque"
-      description: |
-        A JWT or Opaque token that identifies the calling B2B developer/backend service.
-
-    developerSignature:
-      type: apiKey
-      in: header
-      name: Signature
-      description: |
-        The IETF HTTP Signature (RFC 9421) used by B2B developers to ensure message
-        integrity and non-repudiation. This is passed in the `Signature` header.
-
+      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."
     userToken:
       type: http
       scheme: bearer

--- a/api/token-interfaces.yaml
+++ b/api/token-interfaces.yaml
@@ -7,47 +7,20 @@ info:
     This API enables creation, management, and lifecycle operations for universal tokens
     following the UNITS Token Specification.
 
-    ### Protocol-Agnostic Envelope
-    All API interactions use a standard JSON envelope.
+    ### Envelope
 
-    **Request Envelope:**
-    ```json
-    {
-      "context": { ... },
-      "payload": { ... },
-      "signature": { ... } // Optional
-    }
-    ```
+    All endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
+    On failure `context.status` is `failed`, `context.error` carries a `code` and a
+    `message`, and `response` is empty.
 
-    **Response Envelope (Success):**
-    ```json
-    {
-      "context": { ..., "status": "successful" },
-      "response": { ... }
-    }
-    ```
+    ### Authentication
 
-    **Response Envelope (Error):**
-    ```json
-    {
-      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." }},
-      "response": {} // Empty on error
-    }
-    ```
-    (Error details are in the context.error object)
-
-    ### Authentication and Authorization
-    This API uses the same two-level authorization model as the Account service:
-
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
-        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
-
-    2.  **User-Level (End-User) Authorization:**
-        * `context.authorization`: The end-user's JWT session token (for session-based calls).
-        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
-
-    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header.
+    * `context.developerToken`: the calling application's developer token. Required on
+      every endpoint.
+    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
+      `Signature` header.
+    * `context.authorization`: the end user's session token, required by the endpoints
+      that act on a signed-in user. Each operation states when it is needed.
 
     ### RBAC Scopes
 
@@ -77,10 +50,9 @@ info:
 
     ### Rate limiting
 
-    All endpoints are protected by a scope-tier sliding-window rate limiter. When the
-    limit is exceeded the service responds with `429 Too Many Requests` and a
-    `Retry-After` header indicating when the caller may retry. The shared
-    `RateLimitedError` response component documents the body shape.
+    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
+    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
+    the tier assigned to the calling client.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -452,6 +424,8 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '409':
           description: "Token class already exists"
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/tokenclasses/update:
     post:
@@ -501,6 +475,8 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '404':
           $ref: '#/components/responses/NotFoundError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/tokenclasses/get:
     post:
@@ -573,6 +549,10 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/registry/tokenclasses/search:
     post:
@@ -683,6 +663,10 @@ paths:
                     offset: 0
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   # -------------------- Token --------------------
   /v1/token/get:
@@ -690,7 +674,7 @@ paths:
       tags:
         - "Token"
       summary: "Get token details"
-      description: "Retrieves detailed information about a specific token by its ID. Requires Developer and User auth."
+      description: "Retrieves detailed information about a specific token by its ID. Requires a user session token."
       security:
         - developerToken: []
         - userToken: []
@@ -702,7 +686,7 @@ paths:
               $ref: '#/components/schemas/ApiRequest_GetTokenRequest'
             examples:
               raw_get:
-                summary: "Get token — raw mode (default)"
+                summary: "Get token, raw mode (default)"
                 value:
                   context:
                     id: "api.token.get"
@@ -714,7 +698,7 @@ paths:
                   payload:
                     tokenId: "urn:uuid:a1b2c3d4-e5f6-7890-abcd-1234567890ab"
               display_get:
-                summary: "Get token — display mode (human-readable)"
+                summary: "Get token, display mode (human-readable)"
                 value:
                   context:
                     id: "api.token.get"
@@ -735,7 +719,7 @@ paths:
                 $ref: '#/components/schemas/ApiResponse_TokenDetails'
               examples:
                 raw_token:
-                  summary: "Token response — raw (smallest-unit integers)"
+                  summary: "Token response, raw (smallest-unit integers)"
                   value:
                     context:
                       id: "api.token.get"
@@ -767,7 +751,7 @@ paths:
                           circulatingSupply: "500000000000"
                         stateCommitment: "0xabcdef1234567890"
                 display_token:
-                  summary: "Token response — display (human-readable decimals)"
+                  summary: "Token response, display (human-readable decimals)"
                   value:
                     context:
                       id: "api.token.get"
@@ -802,6 +786,10 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/token/mint:
     post:
@@ -989,13 +977,15 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/token/search:
     post:
       tags:
         - "Token"
       summary: "Search tokens"
-      description: "Search tokens with filters (type, status, etc.). Owner filtering inferred from JWT/ACL. Supports pagination. Requires Developer auth."
+      description: "Search tokens with filters (type, status, and so on). Results are limited to the tokens the caller may see. Supports pagination."
       security:
         - developerToken: []
         - developerSignature: []
@@ -1007,7 +997,7 @@ paths:
               $ref: '#/components/schemas/ApiRequest_SearchTokensRequest'
             examples:
               raw_search:
-                summary: "Search tokens — raw mode (default)"
+                summary: "Search tokens, raw mode (default)"
                 value:
                   context:
                     id: "api.token.search"
@@ -1030,7 +1020,7 @@ paths:
                       field: "createdAt"
                       order: "desc"
               display_search:
-                summary: "Search tokens — display mode (human-readable)"
+                summary: "Search tokens, display mode (human-readable)"
                 value:
                   context:
                     id: "api.token.search"
@@ -1056,7 +1046,7 @@ paths:
                 $ref: '#/components/schemas/ApiResponse_TokenList'
               examples:
                 raw_results:
-                  summary: "Search results — raw (smallest-unit integers)"
+                  summary: "Search results, raw (smallest-unit integers)"
                   value:
                     context:
                       id: "api.token.search"
@@ -1086,7 +1076,7 @@ paths:
                         limit: 50
                         offset: 0
                 display_results:
-                  summary: "Search results — display (human-readable decimals)"
+                  summary: "Search results, display (human-readable decimals)"
                   value:
                     context:
                       id: "api.token.search"
@@ -1117,6 +1107,10 @@ paths:
                         offset: 0
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/token/transact:
     post:
@@ -1127,20 +1121,19 @@ paths:
         Unified endpoint for all token write operations. The operation is specified in the payload.
 
         **Supported Operations:**
-        - `burn` - Burn/destroy token (terminal state)
-        - `freeze` - Freeze token (compliance/regulatory hold)
-        - `unfreeze` - Unfreeze token
-        - `lock` - Lock token (for escrow/collateral)
-        - `unlock` - Unlock token
-        - `redeem` - Redeem token (for redeemable assets)
-        - `transfer` - Transfer token ownership
-        - `update` - Update token data or metadata fields
+        - `burn`: burn or destroy the token (terminal state)
+        - `freeze`: freeze the token (compliance or regulatory hold)
+        - `unfreeze`: unfreeze the token
+        - `lock`: lock the token (for escrow or collateral)
+        - `unlock`: unlock the token
+        - `redeem`: redeem the token (for redeemable assets)
+        - `transfer`: transfer ownership of the token
+        - `update`: update the token's data or metadata fields
 
         **Note:** `mint` operation has a dedicated `/v1/token/mint` endpoint with separate ACL controls.
 
-        **Signature required:** a top-level end-user payload `signature` is mandatory for
-        every transact operation. units-api enforces this via a `RequireSignature`
-        middleware on this route; a request without a valid `signature` is rejected.
+        **Signature required:** a top-level end user `signature` over the payload is mandatory
+        for every transact operation. A request without a valid `signature` is rejected.
       security:
         - developerToken: []
         - developerSignature: []
@@ -1419,6 +1412,8 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '409':
           $ref: '#/components/responses/ConflictError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   # -------------------- Transaction APIs --------------------
   /v1/transaction/status:
@@ -1520,6 +1515,10 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/transaction/get:
     post:
@@ -1561,6 +1560,10 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/transaction/search:
     post:
@@ -1608,6 +1611,10 @@ paths:
                 $ref: '#/components/schemas/ApiResponse_TransactionList'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/transactions/status:
     post:
@@ -1682,6 +1689,8 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '404':
           $ref: '#/components/responses/NotFoundError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/token/transactions:
     post:
@@ -1728,6 +1737,10 @@ paths:
                 $ref: '#/components/schemas/ApiResponse_TokenTransactionList'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   /v1/token/add:
     post:
@@ -1834,6 +1847,10 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '409':
           $ref: '#/components/responses/ConflictError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/RateLimitedError'
 
   # -------------------- Proof APIs --------------------
   /v1/transaction/proof:
@@ -1846,11 +1863,11 @@ paths:
         that the transaction was included in a state commitment / batched Merkle tree.
 
         **Proof status:**
-        - `pending` — awaiting proof generation
-        - `proven` — Merkle proof generated
-        - `anchored` — proof anchored to a public ledger, fully verifiable
+        - `pending`: awaiting proof generation
+        - `proven`: Merkle proof generated
+        - `anchored`: proof anchored to a public ledger, fully verifiable
 
-        Requires Developer + User auth.
+        Requires a user session token.
       security:
         - developerToken: []
         - userToken: []
@@ -1941,7 +1958,7 @@ paths:
         Merkle tree. Enables independent verification: fetch this data, hash it, and
         confirm it matches the `leafHash` returned by `/v1/transaction/proof`.
 
-        Requires Developer + User auth.
+        Requires a user session token.
       security:
         - developerToken: []
         - userToken: []
@@ -2013,7 +2030,7 @@ paths:
         For trustless verification, clients should verify independently using the data
         from `/v1/transaction/proof` and `/v1/transaction/proof/leaf`.
 
-        Requires Developer + User auth.
+        Requires a user session token.
       security:
         - developerToken: []
         - userToken: []
@@ -2086,7 +2103,7 @@ paths:
                       valid: false
                       leafHashValid: false
                       proofPathValid: true
-                      message: "Leaf hash mismatch — transaction data may have been modified."
+                      message: "Leaf hash mismatch; the transaction data may have been modified."
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':
@@ -2127,7 +2144,7 @@ components:
             - `raw` (default): Smallest-unit integer strings (e.g., "100500000" for 100.5 USDC with 6 decimals).
             - `display`: Human-readable decimal strings (e.g., "100.50" for 100.5 USDC).
             The service layer performs decimal conversion using token class metadata.
-            Amounts are always opaque strings — never parsed as float by any system.
+            Amounts are always opaque strings and are never parsed as a float.
     ResponseContext:
       type: object
       required: [id, version, ts, msgId, status]
@@ -2548,12 +2565,12 @@ components:
             Search filters for tokens. Owner filtering inferred from JWT/ACL.
 
             Known column filters:
-            - `tokenClass` — Token class name (e.g., "USDC")
-            - `tokenStandard` — Protocol standard (e.g., "UNITS-FT")
-            - `tokenClassId` — Token class UUID
-            - `chainId` — CAIP-2 chain ID (e.g., "eip155:1"). Filters to tokens
+            - `tokenClass`: Token class name (e.g., "USDC")
+            - `tokenStandard`: Protocol standard (e.g., "UNITS-FT")
+            - `tokenClassId`: Token class UUID
+            - `chainId`: CAIP-2 chain ID (e.g., "eip155:1"). Filters to tokens
               backed by assets on the specified chain. Omit to see all tokens.
-            - `contractId` — Contract address on source chain
+            - `contractId`: Contract address on source chain
 
             Use explicit paths for JSONB fields (e.g., metadata.category, data.field).
 
@@ -2595,7 +2612,7 @@ components:
         **For update:** `operation`, `tokenId`, `data` (optional), `metadata` (optional)
         **For burn/freeze/lock/transfer:** `operation`, `tokenId`, plus operation-specific params at root level
 
-        `operation` is an open string — common lifecycle operations (burn, freeze,
+        `operation` is an open string. Common lifecycle operations (burn, freeze,
         transfer, …) as well as domain-specific operations (e.g. `loan_disbursed`,
         `emi_due`) are accepted.
 
@@ -2663,8 +2680,8 @@ components:
           - **Proxy token** (USDC, ETH, SOL, etc.): requires `chainId`,
             `contractAddress`, `walletAddress`; `value` only when creating (a duplicate add from the owner reconciles and omits it).
 
-        Called backend-to-backend by the Finternet App Backend (no end-user JWT).
-        The token owner is optional: when omitted, the server derives it from the authenticated session.
+        Called by the application backend; no user session token is required. The token owner
+        is optional: when omitted it is taken from the authenticated session.
       oneOf:
         - title: "Credential Token"
           required: [credential, metadata]
@@ -3448,7 +3465,7 @@ components:
 
     LedgerAnchor:
       type: object
-      description: "Ledger anchor reference — where the Merkle root was committed on-chain."
+      description: "Ledger anchor reference: where the Merkle root was committed on-chain."
       required: [chain, network, txHash]
       properties:
         chain:
@@ -3663,7 +3680,7 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
+      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -3671,12 +3688,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "Forbidden. Insufficient permissions."
+      description: "The caller does not have the scope required by this endpoint."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
+            context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -3703,9 +3720,7 @@ components:
             context: { id: "...", ts: "...", msgId: "...", status: "failed", error: { code: "CONFLICT", message: "Operation conflicts with current token state." } }
             response: {}
     RateLimitedError:
-      description: |
-        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
-        response header indicates how long the caller should wait before retrying.
+      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }
@@ -3738,6 +3753,5 @@ components:
       scheme: bearer
       bearerFormat: JWT
       description: |
-        A JWT token that identifies the end-user making the request. This is obtained
-        after user authentication (e.g., via `/v1/account/login`) and is passed in
-        the `context.authorization` field as `Bearer <token>`.
+        End user's session token, obtained from `/v1/account/login` and passed in
+        `context.authorization` as `Bearer <token>`.

--- a/api/token-program-interfaces.yaml
+++ b/api/token-program-interfaces.yaml
@@ -1,0 +1,566 @@
+openapi: 3.0.4
+info:
+  title: "Finternet API - Token Program Registry"
+  description: |
+    The official API specification for the Finternet Token Program Registry service.
+
+    A **token program** is a registry entry describing a token implementation:
+    the standards it supports (e.g. `FT`, `NFT`), the operations it exposes
+    (e.g. `Transfer`, `Burn`, `Freeze`), a version, and optional configuration.
+
+    ### Protocol-Agnostic Envelope
+    All API interactions use a standard JSON envelope.
+
+    **Request Envelope:**
+    ```json
+    {
+      "context": { ... },
+      "payload": { ... },
+      "signature": { ... } // Optional
+    }
+    ```
+
+    **Response Envelope (Success):**
+    ```json
+    {
+      "context": { ..., "status": "successful" },
+      "response": { ... }
+    }
+    ```
+
+    **Response Envelope (Error):**
+    ```json
+    {
+      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." },
+      "response": {} // Empty on error
+    }
+    ```
+    (Error details are in the context.error object)
+
+    ### Authentication and Authorization
+    This API uses a two-level authorization model contained within the `context`:
+
+    1.  **Platform-Level (Developer) Authentication:**
+        * `context.developerToken`: The B2B Developer's API Key/Token.
+        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
+
+    2.  **User-Level (End-User) Authorization:**
+        * `context.authorization`: The end-user's JWT session token (for session-based calls).
+        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
+
+    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
+
+    All token program endpoints require **both** developer authentication and a
+    valid end-user session token.
+
+    ### RBAC Scopes
+
+    | Endpoint | Required scope |
+    |----------|----------------|
+    | `POST /v1/tokenprogram/register` | `registry-programs:create` |
+    | `POST /v1/tokenprogram/update` | `registry-programs:manage` |
+    | `POST /v1/tokenprogram/get` | `registry-programs:view` |
+    | `POST /v1/tokenprogram/search` | `registry-programs:view` |
+
+    Scope keys are resolved from the server-side `scope_api` mapping table. Calls
+    failing the scope check return `403 PERMISSION_DENIED`.
+
+    ### Rate limiting
+
+    All endpoints are protected by a scope-tier sliding-window rate limiter; on
+    breach the response is `429 Too Many Requests` with a `Retry-After` header.
+  version: "1.0.0"
+servers:
+  - url: "https://foundry.finternetlab.io"
+    description: "Development Environment"
+  - url: "http://localhost:3000"
+    description: "Local Server"
+tags:
+  - name: "Token Program"
+    description: "Endpoints for registering, updating, retrieving, and searching token programs."
+
+# ===============================================================
+#   PATHS
+# ===============================================================
+
+paths:
+  # -------------------- Token Program --------------------
+  /v1/tokenprogram/register:
+    post:
+      tags: [Token Program]
+      summary: "Register a new token program"
+      description: |
+        Registers a new token program in the registry. Requires developer
+        authentication and a valid end-user session token.
+      operationId: registerTokenProgram
+      security:
+        - developerToken: []
+        - developerSignature: []
+      x-scopes: ["registry-programs:create"]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ApiRequest_RegisterTokenProgramRequest' }
+            example:
+              context:
+                id: "api.tokenprogram.register"
+                version: "1.0"
+                ts: "2026-07-09T12:00:00Z"
+                msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                programId: "reference-ft"
+                name: "Reference FT"
+                version: "1.0.0"
+                supportedStandards: ["FT"]
+                supportedOperations: ["Transfer", "Burn", "Freeze"]
+      responses:
+        '201':
+          description: "Token program registered successfully."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiResponse_TokenProgram' }
+              example:
+                context:
+                  id: "api.tokenprogram.register"
+                  version: "1.0"
+                  ts: "2026-07-09T12:00:01Z"
+                  msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
+                  status: "successful"
+                response:
+                  id: "b50db0e7-d5f7-6bfe-fcbf-7f45ae7683e1"
+                  programId: "reference-ft"
+                  name: "Reference FT"
+                  version: "1.0.0"
+                  supportedStandards: ["FT"]
+                  supportedOperations: ["Transfer", "Burn", "Freeze"]
+                  status: "active"
+                  createdAt: "2026-07-09T12:00:01Z"
+                  updatedAt: "2026-07-09T12:00:01Z"
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '409': { $ref: '#/components/responses/ConflictError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+  /v1/tokenprogram/update:
+    post:
+      tags: [Token Program]
+      summary: "Update a token program"
+      description: |
+        Updates token program details, identified by `programId`. Only the
+        provided fields are changed. Requires developer authentication and a
+        valid end-user session token.
+      operationId: updateTokenProgram
+      security:
+        - developerToken: []
+        - developerSignature: []
+      x-scopes: ["registry-programs:manage"]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ApiRequest_UpdateTokenProgramRequest' }
+            example:
+              context:
+                id: "api.tokenprogram.update"
+                version: "1.0"
+                ts: "2026-07-09T12:05:00Z"
+                msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef23"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                programId: "reference-ft"
+                version: "1.0.1"
+      responses:
+        '200':
+          description: "Token program updated successfully."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiResponse_TokenProgram' }
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '404': { $ref: '#/components/responses/NotFoundError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+  /v1/tokenprogram/get:
+    post:
+      tags: [Token Program]
+      summary: "Get a token program"
+      description: |
+        Retrieves token program details by `programId`. Requires developer
+        authentication and a valid end-user session token.
+      operationId: getTokenProgram
+      security:
+        - developerToken: []
+        - developerSignature: []
+      x-scopes: ["registry-programs:view"]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ApiRequest_GetTokenProgramRequest' }
+            example:
+              context:
+                id: "api.tokenprogram.get"
+                version: "1.0"
+                ts: "2026-07-09T12:10:00Z"
+                msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef234"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                programId: "reference-ft"
+      responses:
+        '200':
+          description: "Token program retrieved successfully."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiResponse_TokenProgram' }
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '404': { $ref: '#/components/responses/NotFoundError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+  /v1/tokenprogram/search:
+    post:
+      tags: [Token Program]
+      summary: "Search token programs"
+      description: |
+        Searches token programs with filters, pagination, and sorting. Requires
+        developer authentication and a valid end-user session token.
+      operationId: searchTokenPrograms
+      security:
+        - developerToken: []
+        - developerSignature: []
+      x-scopes: ["registry-programs:view"]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ApiRequest_SearchTokenProgramRequest' }
+            example:
+              context:
+                id: "api.tokenprogram.search"
+                version: "1.0"
+                ts: "2026-07-09T12:15:00Z"
+                msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef2345"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                filters: {}
+                pagination: { limit: 50, offset: 0 }
+      responses:
+        '200':
+          description: "Token programs retrieved successfully."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiResponse_SearchTokenProgram' }
+              example:
+                context:
+                  id: "api.tokenprogram.search"
+                  version: "1.0"
+                  ts: "2026-07-09T12:15:01Z"
+                  msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef23456"
+                  status: "successful"
+                response:
+                  tokenPrograms:
+                    - id: "b50db0e7-d5f7-6bfe-fcbf-7f45ae7683e1"
+                      programId: "reference-ft"
+                      name: "Reference FT"
+                      version: "1.0.0"
+                      supportedStandards: ["FT"]
+                      supportedOperations: ["Transfer", "Burn", "Freeze"]
+                      status: "active"
+                      createdAt: "2026-07-09T12:00:01Z"
+                      updatedAt: "2026-07-09T12:00:01Z"
+                  pagination: { total: 1, limit: 50, offset: 0 }
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+# ===============================================================
+#   COMPONENTS
+# ===============================================================
+
+components:
+  # -------------------- Schemas --------------------
+  schemas:
+    # --- API Envelope Schemas ---
+    Context:
+      type: object
+      required: [id, version, ts, msgId]
+      properties:
+        id: { type: string, example: "api.tokenprogram.register" }
+        version: { type: string, example: "1.0" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "B2B Developer API Key/Token" }
+        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "B2B Developer Signature (e.g., HMAC)" }
+        authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token." }
+    ResponseContext:
+      type: object
+      required: [id, version, ts, msgId, status]
+      properties:
+        id: { type: string, example: "api.tokenprogram.register" }
+        version: { type: string, example: "1.0" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        transactionId: { type: string, format: uuid, nullable: true }
+        status: { type: string, enum: [successful, failed, pending] }
+        error:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/ErrorPayload'
+    Signature:
+      type: object
+      required: [key_id, jws]
+      properties:
+        key_id: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
+        jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object." }
+    ErrorPayload:
+      type: object
+      required: [code, message]
+      properties:
+        code: { type: string, example: "RESOURCE_NOT_FOUND" }
+        message: { type: string }
+
+    # --- Base Request/Response Schemas ---
+    RequestContext:
+      type: object
+      required: [context, payload]
+      properties:
+        context: { $ref: '#/components/schemas/Context' }
+        payload: { type: object }
+        signature:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Signature'
+    ApiResponse:
+      type: object
+      required: [context, response]
+      properties:
+        context: { $ref: '#/components/schemas/ResponseContext' }
+        response: { type: object }
+    ApiError:
+      type: object
+      required: [context, response]
+      properties:
+        context: { $ref: '#/components/schemas/ResponseContext' }
+        response: { type: object, description: "Always empty on error.", example: {} }
+
+    # --- Core Data Schemas (Payloads) ---
+    RegisterTokenProgramRequest:
+      type: object
+      required: [programId, name, version, supportedStandards, supportedOperations]
+      properties:
+        programId: { type: string, example: "reference-ft" }
+        name: { type: string, example: "Reference FT" }
+        description: { type: string, nullable: true }
+        version: { type: string, example: "1.0.0" }
+        supportedStandards:
+          type: array
+          items: { type: string }
+          example: ["FT"]
+        supportedOperations:
+          type: array
+          items: { type: string }
+          example: ["Transfer", "Burn", "Freeze"]
+        config:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: "Free-form program configuration object."
+      additionalProperties: true
+    UpdateTokenProgramRequest:
+      type: object
+      required: [programId]
+      description: "All fields other than programId are optional; only provided fields are updated."
+      properties:
+        programId: { type: string, example: "reference-ft" }
+        name: { type: string, nullable: true }
+        description: { type: string, nullable: true }
+        version: { type: string, example: "1.0.1", nullable: true }
+        supportedStandards:
+          type: array
+          nullable: true
+          items: { type: string }
+        supportedOperations:
+          type: array
+          nullable: true
+          items: { type: string }
+        config:
+          type: object
+          nullable: true
+          additionalProperties: true
+        status: { type: string, nullable: true, example: "active" }
+      additionalProperties: true
+    GetTokenProgramRequest:
+      type: object
+      required: [programId]
+      properties:
+        programId: { type: string, example: "reference-ft" }
+      additionalProperties: false
+    SearchTokenProgramRequest:
+      type: object
+      properties:
+        filters:
+          type: object
+          additionalProperties: true
+          description: "Free-form filter object applied server-side."
+        pagination:
+          type: object
+          properties:
+            limit: { type: integer, minimum: 0 }
+            offset: { type: integer, minimum: 0 }
+          additionalProperties: false
+        sortBy:
+          type: object
+          properties:
+            field: { type: string }
+            order: { type: string, enum: [asc, desc] }
+          additionalProperties: false
+      additionalProperties: true
+
+    TokenProgramResponse:
+      type: object
+      required: [id, programId, name, version, supportedStandards, supportedOperations, status, createdAt, updatedAt]
+      properties:
+        id: { type: string, example: "b50db0e7-d5f7-6bfe-fcbf-7f45ae7683e1" }
+        programId: { type: string, example: "reference-ft" }
+        name: { type: string, example: "Reference FT" }
+        description: { type: string, description: "Omitted when empty." }
+        version: { type: string, example: "1.0.0" }
+        supportedStandards:
+          type: array
+          items: { type: string }
+          example: ["FT"]
+        supportedOperations:
+          type: array
+          items: { type: string }
+          example: ["Transfer", "Burn", "Freeze"]
+        config:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: "Free-form program configuration. Omitted when empty."
+        identities:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: "Owning/associated identities. Server-populated; omitted when empty. Exact shape unspecified in source (Go type is interface{})."
+        status: { type: string, example: "active" }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+    PaginationInfo:
+      type: object
+      properties:
+        total: { type: integer, example: 1 }
+        limit: { type: integer, example: 50 }
+        offset: { type: integer, example: 0 }
+    SearchTokenProgramResponse:
+      type: object
+      required: [tokenPrograms, pagination]
+      properties:
+        tokenPrograms:
+          type: array
+          items: { $ref: '#/components/schemas/TokenProgramResponse' }
+        pagination: { $ref: '#/components/schemas/PaginationInfo' }
+
+    # --- Specific Request Envelopes ---
+    ApiRequest_RegisterTokenProgramRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/RegisterTokenProgramRequest' } } } ] }
+    ApiRequest_UpdateTokenProgramRequest:   { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/UpdateTokenProgramRequest' } } } ] }
+    ApiRequest_GetTokenProgramRequest:      { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/GetTokenProgramRequest' } } } ] }
+    ApiRequest_SearchTokenProgramRequest:   { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/SearchTokenProgramRequest' } } } ] }
+
+    # --- Specific Response Envelopes ---
+    ApiResponse_TokenProgram:       { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/TokenProgramResponse' } } } ] }
+    ApiResponse_SearchTokenProgram: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/SearchTokenProgramResponse' } } } ] }
+
+  # -------------------- Responses --------------------
+  responses:
+    UnauthorizedError:
+      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "AUTHENTICATION_FAILED", message: "Token invalid or expired." } }
+            response: {}
+    ForbiddenError:
+      description: "Forbidden. Insufficient permissions (scope check failed)."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "PERMISSION_DENIED", message: "Insufficient permissions to perform this action." } }
+            response: {}
+    NotFoundError:
+      description: "Resource not found."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "The requested token program was not found." } }
+            response: {}
+    BadRequestError:
+      description: "Invalid request."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "Invalid request parameters." } }
+            response: {}
+    ConflictError:
+      description: "Conflict with existing resource."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RESOURCE_CONFLICT", message: "A token program with this programId already exists." } }
+            response: {}
+    RateLimitedError:
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
+      headers:
+        Retry-After:
+          schema: { type: integer, description: "Seconds to wait before retrying." }
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
+            response: {}
+
+  # -------------------- Security --------------------
+  securitySchemes:
+    # This section is for documentation purposes.
+    # The server will check for the HTTP header first and fallbacks to context in case the headers are missing.
+
+    # 1. The Developer's Identity Token (Who they are)
+    developerToken:
+      type: http
+      scheme: bearer
+      bearerFormat: "JWT or Opaque"
+      description: |
+        A JWT or Opaque token that identifies the calling B2B developer/backend service.
+        This is passed in the standard `Authorization: Bearer <token>` header.
+        (This can also be passed in the `context.developerToken` as a fallback).
+
+    # 2. The Developer's Request Signature (What they're attesting to)
+    developerSignature:
+      type: apiKey
+      in: header
+      name: Signature
+      description: |
+        The IETF HTTP Signature (RFC 9421) used by B2B developers to ensure message
+        integrity and non-repudiation. This is passed in the `Signature` header.
+
+        Example Format:
+        Signature keyId="...",algorithm="...",created="...",expires="...",headers="...",signature="..."

--- a/api/token-program-interfaces.yaml
+++ b/api/token-program-interfaces.yaml
@@ -37,18 +37,14 @@ info:
     ```
     (Error details are in the context.error object)
 
-    ### Authentication and Authorization
-    This API uses a two-level authorization model contained within the `context`:
+    ### Authentication
 
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
-
-    2.  **User-Level (End-User) Authorization:**
-        * `context.authorization`: The end-user's JWT session token (for session-based calls).
-        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
-
-    All token program endpoints require **both** developer authentication and a
-    valid end-user session token.
+    * `context.developerToken`: the developer token of the calling application. Required on
+      every endpoint.
+    * `context.authorization`: the end user's session token. Required on the endpoints that
+      act on a signed-in user; each operation states when it is needed.
+    * `signature` (top level): the end user's JWS over the payload, for operations that must
+      be signed by the user.
 
     ### RBAC Scopes
 
@@ -87,11 +83,10 @@ paths:
       tags: [Token Program]
       summary: "Register a new token program"
       description: |
-        Registers a new token program in the registry. Requires developer
-        authentication and a valid end-user session token.
+        Registers a new token program in the registry.
+
+        Requires a user session token in `context.authorization`.
       operationId: registerTokenProgram
-      security:
-        - developerToken: []
       x-scopes: ["registry-programs:create"]
       requestBody:
         required: true
@@ -104,7 +99,7 @@ paths:
                 version: "v1"
                 ts: "2026-07-09T12:00:00Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 programId: "reference-ft"
@@ -147,11 +142,10 @@ paths:
       summary: "Update a token program"
       description: |
         Updates token program details, identified by `programId`. Only the
-        provided fields are changed. Requires developer authentication and a
-        valid end-user session token.
+        provided fields are changed.
+
+        Requires a user session token in `context.authorization`.
       operationId: updateTokenProgram
-      security:
-        - developerToken: []
       x-scopes: ["registry-programs:manage"]
       requestBody:
         required: true
@@ -164,7 +158,7 @@ paths:
                 version: "v1"
                 ts: "2026-07-09T12:05:00Z"
                 msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef23"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 programId: "reference-ft"
@@ -186,11 +180,10 @@ paths:
       tags: [Token Program]
       summary: "Get a token program"
       description: |
-        Retrieves token program details by `programId`. Requires developer
-        authentication and a valid end-user session token.
+        Retrieves token program details by `programId`.
+
+        Requires a user session token in `context.authorization`.
       operationId: getTokenProgram
-      security:
-        - developerToken: []
       x-scopes: ["registry-programs:view"]
       requestBody:
         required: true
@@ -203,7 +196,7 @@ paths:
                 version: "v1"
                 ts: "2026-07-09T12:10:00Z"
                 msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef234"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 programId: "reference-ft"
@@ -224,11 +217,10 @@ paths:
       tags: [Token Program]
       summary: "Search token programs"
       description: |
-        Searches token programs with filters, pagination, and sorting. Requires
-        developer authentication and a valid end-user session token.
+        Searches token programs with filters, pagination, and sorting.
+
+        Requires a user session token in `context.authorization`.
       operationId: searchTokenPrograms
-      security:
-        - developerToken: []
       x-scopes: ["registry-programs:view"]
       requestBody:
         required: true
@@ -241,7 +233,7 @@ paths:
                 version: "v1"
                 ts: "2026-07-09T12:15:00Z"
                 msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef2345"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 filters: {}
@@ -286,14 +278,13 @@ components:
     # --- API Envelope Schemas ---
     Context:
       type: object
-      required: [id, version, ts, msgId]
+      required: [id, version, ts, msgId, developerToken]
       properties:
         id: { type: string, example: "api.tokenprogram.register" }
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token." }
     ResponseContext:
       type: object
@@ -328,6 +319,26 @@ components:
       required: [context, payload]
       properties:
         context: { $ref: '#/components/schemas/Context' }
+        payload: { type: object }
+        signature:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Signature'
+    UserContext:
+      type: object
+      required: [id, version, ts, msgId, developerToken, authorization]
+      properties:
+        id: { type: string, example: "api.tokenprogram.register" }
+        version: { type: string, example: "v1" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
+        authorization: { type: string, example: "Bearer eyJ...", description: "End-user's session token." }
+    UserRequestContext:
+      type: object
+      required: [context, payload]
+      properties:
+        context: { $ref: '#/components/schemas/UserContext' }
         payload: { type: object }
         signature:
           nullable: true
@@ -465,10 +476,10 @@ components:
         pagination: { $ref: '#/components/schemas/PaginationInfo' }
 
     # --- Specific Request Envelopes ---
-    ApiRequest_RegisterTokenProgramRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/RegisterTokenProgramRequest' } } } ] }
-    ApiRequest_UpdateTokenProgramRequest:   { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/UpdateTokenProgramRequest' } } } ] }
-    ApiRequest_GetTokenProgramRequest:      { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/GetTokenProgramRequest' } } } ] }
-    ApiRequest_SearchTokenProgramRequest:   { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/SearchTokenProgramRequest' } } } ] }
+    ApiRequest_RegisterTokenProgramRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/RegisterTokenProgramRequest' } } } ] }
+    ApiRequest_UpdateTokenProgramRequest:   { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/UpdateTokenProgramRequest' } } } ] }
+    ApiRequest_GetTokenProgramRequest:      { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/GetTokenProgramRequest' } } } ] }
+    ApiRequest_SearchTokenProgramRequest:   { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/SearchTokenProgramRequest' } } } ] }
 
     # --- Specific Response Envelopes ---
     ApiResponse_TokenProgram:       { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/TokenProgramResponse' } } } ] }
@@ -529,16 +540,3 @@ components:
           example:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
-
-  # -------------------- Security --------------------
-  securitySchemes:
-    # This section is for documentation purposes.
-    # The server will check for the HTTP header first and fallbacks to context in case the headers are missing.
-
-    # 1. The Developer's Identity Token (Who they are)
-    developerToken:
-      type: http
-      scheme: bearer
-      bearerFormat: "JWT or Opaque"
-      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."
-    # 2. The Developer's Request Signature (What they're attesting to)

--- a/api/token-program-interfaces.yaml
+++ b/api/token-program-interfaces.yaml
@@ -42,13 +42,10 @@ info:
 
     1.  **Platform-Level (Developer) Authentication:**
         * `context.developerToken`: The B2B Developer's API Key/Token.
-        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
 
     2.  **User-Level (End-User) Authorization:**
         * `context.authorization`: The end-user's JWT session token (for session-based calls).
         * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
-
-    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
 
     All token program endpoints require **both** developer authentication and a
     valid end-user session token.
@@ -95,7 +92,6 @@ paths:
       operationId: registerTokenProgram
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: ["registry-programs:create"]
       requestBody:
         required: true
@@ -156,7 +152,6 @@ paths:
       operationId: updateTokenProgram
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: ["registry-programs:manage"]
       requestBody:
         required: true
@@ -196,7 +191,6 @@ paths:
       operationId: getTokenProgram
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: ["registry-programs:view"]
       requestBody:
         required: true
@@ -235,7 +229,6 @@ paths:
       operationId: searchTokenPrograms
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: ["registry-programs:view"]
       requestBody:
         required: true
@@ -300,8 +293,7 @@ components:
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "B2B Developer API Key/Token" }
-        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "B2B Developer Signature (e.g., HMAC)" }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token." }
     ResponseContext:
       type: object
@@ -548,17 +540,5 @@ components:
       type: http
       scheme: bearer
       bearerFormat: "JWT or Opaque"
-      description: |
-        A JWT or Opaque token that identifies the calling B2B developer/backend service.
-
+      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."
     # 2. The Developer's Request Signature (What they're attesting to)
-    developerSignature:
-      type: apiKey
-      in: header
-      name: Signature
-      description: |
-        The IETF HTTP Signature (RFC 9421) used by B2B developers to ensure message
-        integrity and non-repudiation. This is passed in the `Signature` header.
-
-        Example Format:
-        Signature keyId="...",algorithm="...",created="...",expires="...",headers="...",signature="..."

--- a/api/token-program-interfaces.yaml
+++ b/api/token-program-interfaces.yaml
@@ -319,9 +319,9 @@ components:
             - $ref: '#/components/schemas/ErrorPayload'
     Signature:
       type: object
-      required: [key_id, jws]
+      required: [keyId, jws]
       properties:
-        key_id: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
+        keyId: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
         jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object." }
     ErrorPayload:
       type: object

--- a/api/token-program-interfaces.yaml
+++ b/api/token-program-interfaces.yaml
@@ -550,8 +550,6 @@ components:
       bearerFormat: "JWT or Opaque"
       description: |
         A JWT or Opaque token that identifies the calling B2B developer/backend service.
-        This is passed in the standard `Authorization: Bearer <token>` header.
-        (This can also be passed in the `context.developerToken` as a fallback).
 
     # 2. The Developer's Request Signature (What they're attesting to)
     developerSignature:

--- a/api/token-program-interfaces.yaml
+++ b/api/token-program-interfaces.yaml
@@ -105,7 +105,7 @@ paths:
             example:
               context:
                 id: "api.tokenprogram.register"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-07-09T12:00:00Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -125,7 +125,7 @@ paths:
               example:
                 context:
                   id: "api.tokenprogram.register"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-07-09T12:00:01Z"
                   msgId: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
                   status: "successful"
@@ -166,7 +166,7 @@ paths:
             example:
               context:
                 id: "api.tokenprogram.update"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-07-09T12:05:00Z"
                 msgId: "c3d4e5f6-a7b8-9012-3456-7890abcdef23"
                 developerToken: "fnt_..."
@@ -206,7 +206,7 @@ paths:
             example:
               context:
                 id: "api.tokenprogram.get"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-07-09T12:10:00Z"
                 msgId: "d4e5f6a7-b8c9-0123-4567-890abcdef234"
                 developerToken: "fnt_..."
@@ -245,7 +245,7 @@ paths:
             example:
               context:
                 id: "api.tokenprogram.search"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-07-09T12:15:00Z"
                 msgId: "e5f6a7b8-c9d0-1234-5678-90abcdef2345"
                 developerToken: "fnt_..."
@@ -262,7 +262,7 @@ paths:
               example:
                 context:
                   id: "api.tokenprogram.search"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-07-09T12:15:01Z"
                   msgId: "f6a7b8c9-d0e1-2345-6789-0abcdef23456"
                   status: "successful"
@@ -296,7 +296,7 @@ components:
       required: [id, version, ts, msgId]
       properties:
         id: { type: string, example: "api.tokenprogram.register" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
@@ -308,7 +308,7 @@ components:
       required: [id, version, ts, msgId, status]
       properties:
         id: { type: string, example: "api.tokenprogram.register" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true }

--- a/api/token-program-interfaces.yaml
+++ b/api/token-program-interfaces.yaml
@@ -8,20 +8,50 @@ info:
     the standards it supports (e.g. `FT`, `NFT`), the operations it exposes
     (e.g. `Transfer`, `Burn`, `Freeze`), a version, and optional configuration.
 
-    ### Envelope
+    ### Protocol-Agnostic Envelope
+    All API interactions use a standard JSON envelope.
 
-    All endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
-    On failure `context.status` is `failed`, `context.error` carries a `code` and a
-    `message`, and `response` is empty.
+    **Request Envelope:**
+    ```json
+    {
+      "context": { ... },
+      "payload": { ... },
+      "signature": { ... } // Optional
+    }
+    ```
 
-    ### Authentication
+    **Response Envelope (Success):**
+    ```json
+    {
+      "context": { ..., "status": "successful" },
+      "response": { ... }
+    }
+    ```
 
-    * `context.developerToken`: the calling application's developer token. Required on
-      every endpoint.
-    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
-      `Signature` header.
-    * `context.authorization`: the end user's session token, required by the endpoints
-      that act on a signed-in user. Each operation states when it is needed.
+    **Response Envelope (Error):**
+    ```json
+    {
+      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." },
+      "response": {} // Empty on error
+    }
+    ```
+    (Error details are in the context.error object)
+
+    ### Authentication and Authorization
+    This API uses a two-level authorization model contained within the `context`:
+
+    1.  **Platform-Level (Developer) Authentication:**
+        * `context.developerToken`: The B2B Developer's API Key/Token.
+        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
+
+    2.  **User-Level (End-User) Authorization:**
+        * `context.authorization`: The end-user's JWT session token (for session-based calls).
+        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
+
+    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
+
+    All token program endpoints require **both** developer authentication and a
+    valid end-user session token.
 
     ### RBAC Scopes
 
@@ -32,13 +62,13 @@ info:
     | `POST /v1/tokenprogram/get` | `registry-programs:view` |
     | `POST /v1/tokenprogram/search` | `registry-programs:view` |
 
-    Calls failing the scope check return `403`.
+    Scope keys are resolved from the server-side `scope_api` mapping table. Calls
+    failing the scope check return `403 FORBIDDEN`.
 
     ### Rate limiting
 
-    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
-    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
-    the tier assigned to the calling client.
+    All endpoints are protected by a scope-tier sliding-window rate limiter; on
+    breach the response is `429 Too Many Requests` with a `Retry-After` header.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -60,7 +90,8 @@ paths:
       tags: [Token Program]
       summary: "Register a new token program"
       description: |
-        Registers a new token program in the registry. Requires a user session token.
+        Registers a new token program in the registry. Requires developer
+        authentication and a valid end-user session token.
       operationId: registerTokenProgram
       security:
         - developerToken: []
@@ -120,7 +151,8 @@ paths:
       summary: "Update a token program"
       description: |
         Updates token program details, identified by `programId`. Only the
-        provided fields are changed. Requires a user session token.
+        provided fields are changed. Requires developer authentication and a
+        valid end-user session token.
       operationId: updateTokenProgram
       security:
         - developerToken: []
@@ -159,7 +191,8 @@ paths:
       tags: [Token Program]
       summary: "Get a token program"
       description: |
-        Retrieves token program details by `programId`. Requires a user session token.
+        Retrieves token program details by `programId`. Requires developer
+        authentication and a valid end-user session token.
       operationId: getTokenProgram
       security:
         - developerToken: []
@@ -420,7 +453,7 @@ components:
           type: object
           nullable: true
           additionalProperties: true
-          description: "Owning or associated identities. Set by the service and omitted when empty. Any JSON value; the shape is not constrained by the API."
+          description: "Owning/associated identities. Server-populated; omitted when empty. Exact shape unspecified in source (Go type is interface{})."
         status: { type: string, example: "active" }
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
@@ -452,7 +485,7 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
+      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -460,12 +493,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "The caller does not have the scope required by this endpoint."
+      description: "Forbidden. Insufficient permissions (scope check failed)."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -492,7 +525,9 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "CONFLICT", message: "A token program with this programId already exists." } }
             response: {}
     RateLimitedError:
-      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }

--- a/api/token-program-interfaces.yaml
+++ b/api/token-program-interfaces.yaml
@@ -63,7 +63,7 @@ info:
     | `POST /v1/tokenprogram/search` | `registry-programs:view` |
 
     Scope keys are resolved from the server-side `scope_api` mapping table. Calls
-    failing the scope check return `403 PERMISSION_DENIED`.
+    failing the scope check return `403 FORBIDDEN`.
 
     ### Rate limiting
 
@@ -490,7 +490,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "AUTHENTICATION_FAILED", message: "Token invalid or expired." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
       description: "Forbidden. Insufficient permissions (scope check failed)."
@@ -498,7 +498,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "PERMISSION_DENIED", message: "Insufficient permissions to perform this action." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -514,7 +514,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "Invalid request parameters." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     ConflictError:
       description: "Conflict with existing resource."
@@ -522,7 +522,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RESOURCE_CONFLICT", message: "A token program with this programId already exists." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "CONFLICT", message: "A token program with this programId already exists." } }
             response: {}
     RateLimitedError:
       description: |
@@ -535,7 +535,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
 
   # -------------------- Security --------------------

--- a/api/token-program-interfaces.yaml
+++ b/api/token-program-interfaces.yaml
@@ -8,50 +8,20 @@ info:
     the standards it supports (e.g. `FT`, `NFT`), the operations it exposes
     (e.g. `Transfer`, `Burn`, `Freeze`), a version, and optional configuration.
 
-    ### Protocol-Agnostic Envelope
-    All API interactions use a standard JSON envelope.
+    ### Envelope
 
-    **Request Envelope:**
-    ```json
-    {
-      "context": { ... },
-      "payload": { ... },
-      "signature": { ... } // Optional
-    }
-    ```
+    All endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
+    On failure `context.status` is `failed`, `context.error` carries a `code` and a
+    `message`, and `response` is empty.
 
-    **Response Envelope (Success):**
-    ```json
-    {
-      "context": { ..., "status": "successful" },
-      "response": { ... }
-    }
-    ```
+    ### Authentication
 
-    **Response Envelope (Error):**
-    ```json
-    {
-      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." },
-      "response": {} // Empty on error
-    }
-    ```
-    (Error details are in the context.error object)
-
-    ### Authentication and Authorization
-    This API uses a two-level authorization model contained within the `context`:
-
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
-        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
-
-    2.  **User-Level (End-User) Authorization:**
-        * `context.authorization`: The end-user's JWT session token (for session-based calls).
-        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
-
-    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
-
-    All token program endpoints require **both** developer authentication and a
-    valid end-user session token.
+    * `context.developerToken`: the calling application's developer token. Required on
+      every endpoint.
+    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
+      `Signature` header.
+    * `context.authorization`: the end user's session token, required by the endpoints
+      that act on a signed-in user. Each operation states when it is needed.
 
     ### RBAC Scopes
 
@@ -62,13 +32,13 @@ info:
     | `POST /v1/tokenprogram/get` | `registry-programs:view` |
     | `POST /v1/tokenprogram/search` | `registry-programs:view` |
 
-    Scope keys are resolved from the server-side `scope_api` mapping table. Calls
-    failing the scope check return `403 FORBIDDEN`.
+    Calls failing the scope check return `403`.
 
     ### Rate limiting
 
-    All endpoints are protected by a scope-tier sliding-window rate limiter; on
-    breach the response is `429 Too Many Requests` with a `Retry-After` header.
+    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
+    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
+    the tier assigned to the calling client.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -90,8 +60,7 @@ paths:
       tags: [Token Program]
       summary: "Register a new token program"
       description: |
-        Registers a new token program in the registry. Requires developer
-        authentication and a valid end-user session token.
+        Registers a new token program in the registry. Requires a user session token.
       operationId: registerTokenProgram
       security:
         - developerToken: []
@@ -151,8 +120,7 @@ paths:
       summary: "Update a token program"
       description: |
         Updates token program details, identified by `programId`. Only the
-        provided fields are changed. Requires developer authentication and a
-        valid end-user session token.
+        provided fields are changed. Requires a user session token.
       operationId: updateTokenProgram
       security:
         - developerToken: []
@@ -191,8 +159,7 @@ paths:
       tags: [Token Program]
       summary: "Get a token program"
       description: |
-        Retrieves token program details by `programId`. Requires developer
-        authentication and a valid end-user session token.
+        Retrieves token program details by `programId`. Requires a user session token.
       operationId: getTokenProgram
       security:
         - developerToken: []
@@ -453,7 +420,7 @@ components:
           type: object
           nullable: true
           additionalProperties: true
-          description: "Owning/associated identities. Server-populated; omitted when empty. Exact shape unspecified in source (Go type is interface{})."
+          description: "Owning or associated identities. Set by the service and omitted when empty. Any JSON value; the shape is not constrained by the API."
         status: { type: string, example: "active" }
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
@@ -485,7 +452,7 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
+      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -493,12 +460,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "Forbidden. Insufficient permissions (scope check failed)."
+      description: "The caller does not have the scope required by this endpoint."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -525,9 +492,7 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "CONFLICT", message: "A token program with this programId already exists." } }
             response: {}
     RateLimitedError:
-      description: |
-        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
-        response header indicates how long the caller should wait before retrying.
+      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }

--- a/api/workflows-interfaces.yaml
+++ b/api/workflows-interfaces.yaml
@@ -332,9 +332,9 @@ components:
             - $ref: '#/components/schemas/ErrorPayload'
     Signature:
       type: object
-      required: [key_id, jws]
+      required: [keyId, jws]
       properties:
-        key_id: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
+        keyId: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
         jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object." }
     ErrorPayload:
       type: object

--- a/api/workflows-interfaces.yaml
+++ b/api/workflows-interfaces.yaml
@@ -114,7 +114,7 @@ paths:
             example:
               context:
                 id: "api.workflow.execute"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-07-09T12:00:00Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -134,7 +134,7 @@ paths:
               example:
                 context:
                   id: "api.workflow.execute"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-07-09T12:00:01Z"
                   msgId: "b1b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "successful"
@@ -151,7 +151,7 @@ paths:
               example:
                 context:
                   id: "api.workflow.execute"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-07-09T12:00:01Z"
                   msgId: "c1b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "accepted"
@@ -167,7 +167,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
               example:
-                context: { id: "api.workflow.execute", version: "1.0", ts: "...", msgId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "workflow not found: profile-update" } }
+                context: { id: "api.workflow.execute", version: "v1", ts: "...", msgId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "workflow not found: profile-update" } }
                 response: {}
         '429': { $ref: '#/components/responses/RateLimitedError' }
 
@@ -195,7 +195,7 @@ paths:
             example:
               context:
                 id: "api.workflow.status"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-07-09T12:10:00Z"
                 msgId: "d1b2c3d4-e5f6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -212,7 +212,7 @@ paths:
               example:
                 context:
                   id: "api.workflow.status"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-07-09T12:10:01Z"
                   msgId: "e1b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "successful"
@@ -229,7 +229,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
               example:
-                context: { id: "api.workflow.status", version: "1.0", ts: "...", msgId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "workflow not found: profile-update" } }
+                context: { id: "api.workflow.status", version: "v1", ts: "...", msgId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "workflow not found: profile-update" } }
                 response: {}
         '429': { $ref: '#/components/responses/RateLimitedError' }
 
@@ -258,7 +258,7 @@ paths:
             example:
               context:
                 id: "api.workflow.cancel"
-                version: "1.0"
+                version: "v1"
                 ts: "2026-07-09T12:20:00Z"
                 msgId: "f1b2c3d4-e5f6-7890-1234-567890abcdef"
                 developerToken: "fnt_..."
@@ -276,7 +276,7 @@ paths:
               example:
                 context:
                   id: "api.workflow.cancel"
-                  version: "1.0"
+                  version: "v1"
                   ts: "2026-07-09T12:20:01Z"
                   msgId: "a2b2c3d4-e5f6-7890-1234-567890abcdef"
                   status: "successful"
@@ -292,7 +292,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/ApiError' }
               example:
-                context: { id: "api.workflow.cancel", version: "1.0", ts: "...", msgId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "workflow not found: profile-update" } }
+                context: { id: "api.workflow.cancel", version: "v1", ts: "...", msgId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "workflow not found: profile-update" } }
                 response: {}
         '429': { $ref: '#/components/responses/RateLimitedError' }
 
@@ -309,7 +309,7 @@ components:
       required: [id, version, ts, msgId]
       properties:
         id: { type: string, example: "api.workflow.execute" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
@@ -321,7 +321,7 @@ components:
       required: [id, version, ts, msgId, status]
       properties:
         id: { type: string, example: "api.workflow.execute" }
-        version: { type: string, example: "1.0" }
+        version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true }

--- a/api/workflows-interfaces.yaml
+++ b/api/workflows-interfaces.yaml
@@ -35,25 +35,14 @@ info:
     ```
     (Error details are in the context.error object)
 
-    ### Authentication and Authorization
-    This API uses a two-level authorization model contained within the `context`:
+    ### Authentication
 
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
-
-    2.  **User-Level (End-User) Authorization:**
-        * `context.authorization`: The end-user's JWT session token (for session-based calls).
-        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
-
-    ### Per-endpoint authentication
-
-    All three endpoints require Developer auth **plus** an end-user JWT
-    (`context.authorization`). In addition:
-
-    * `POST /v1/workflows/execute`: requires an **active consent** (enforced by the
-      consent middleware) on top of the user JWT.
-    * `POST /v1/workflows/status`: user JWT only.
-    * `POST /v1/workflows/cancel`: requires an **active consent** on top of the user JWT.
+    * `context.developerToken`: the developer token of the calling application. Required on
+      every endpoint.
+    * `context.authorization`: the end user's session token. Required on the endpoints that
+      act on a signed-in user; each operation states when it is needed.
+    * `signature` (top level): the end user's JWS over the payload, for operations that must
+      be signed by the user.
 
     ### RBAC Scopes
 
@@ -96,10 +85,9 @@ paths:
         (**200 OK**, returning the signal/handler response). The `data` object is validated
         dynamically against the workflow's registered JSON schema for the given action.
 
-        Requires Developer auth, an end-user JWT (`context.authorization`), and an active
-        consent.
-      security:
-        - developerToken: []
+        Requires an active consent.
+
+        Requires a user session token in `context.authorization`.
       x-scopes: [workflows:create]
       requestBody:
         required: true
@@ -113,7 +101,7 @@ paths:
                 version: "v1"
                 ts: "2026-07-09T12:00:00Z"
                 msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 workflow: "profile-update"
@@ -177,9 +165,7 @@ paths:
         body is the raw status payload returned by the workflow runtime (`getStatus`
         query) and is therefore workflow-defined.
 
-        Requires Developer auth and an end-user JWT (`context.authorization`).
-      security:
-        - developerToken: []
+        Requires a user session token in `context.authorization`.
       x-scopes: [workflows:view]
       requestBody:
         required: true
@@ -193,7 +179,7 @@ paths:
                 version: "v1"
                 ts: "2026-07-09T12:10:00Z"
                 msgId: "d1b2c3d4-e5f6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 workflowId: "profile-update-3f2504e0-4f89-41d3-9a0c-0305e82c3301"
@@ -238,10 +224,9 @@ paths:
         Both the workflow instance ID and its workflow name are required (the name is
         used to resolve the runtime service).
 
-        Requires Developer auth, an end-user JWT (`context.authorization`), and an active
-        consent.
-      security:
-        - developerToken: []
+        Requires an active consent.
+
+        Requires a user session token in `context.authorization`.
       x-scopes: [workflows:manage]
       requestBody:
         required: true
@@ -255,7 +240,7 @@ paths:
                 version: "v1"
                 ts: "2026-07-09T12:20:00Z"
                 msgId: "f1b2c3d4-e5f6-7890-1234-567890abcdef"
-                developerToken: "fnt_..."
+                developerToken: "c2Et..."
                 authorization: "Bearer eyJ..."
               payload:
                 workflowId: "profile-update-3f2504e0-4f89-41d3-9a0c-0305e82c3301"
@@ -300,14 +285,13 @@ components:
     # --- API Envelope Schemas ---
     Context:
       type: object
-      required: [id, version, ts, msgId]
+      required: [id, version, ts, msgId, developerToken]
       properties:
         id: { type: string, example: "api.workflow.execute" }
         version: { type: string, example: "v1" }
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
-        transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token." }
     ResponseContext:
       type: object
@@ -347,6 +331,26 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/Signature'
+    UserContext:
+      type: object
+      required: [id, version, ts, msgId, developerToken, authorization]
+      properties:
+        id: { type: string, example: "api.workflow.execute" }
+        version: { type: string, example: "v1" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        developerToken: { type: string, example: "c2Et...", description: "Developer token for the calling application: base64 of `<clientId>:<clientSecret>`, as returned by `/v1/clients/register`." }
+        authorization: { type: string, example: "Bearer eyJ...", description: "End-user's session token." }
+    UserRequestContext:
+      type: object
+      required: [context, payload]
+      properties:
+        context: { $ref: '#/components/schemas/UserContext' }
+        payload: { type: object }
+        signature:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Signature'
     ApiResponse:
       type: object
       required: [context, response]
@@ -361,9 +365,9 @@ components:
         response: { type: object, description: "Always empty on error.", example: {} }
 
     # --- Specific Request Envelopes ---
-    ApiRequest_WorkflowExecuteRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/WorkflowExecuteRequest' } } } ] }
-    ApiRequest_WorkflowStatusRequest:  { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/WorkflowStatusRequest' } } } ] }
-    ApiRequest_WorkflowCancelRequest:  { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/WorkflowCancelRequest' } } } ] }
+    ApiRequest_WorkflowExecuteRequest: { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/WorkflowExecuteRequest' } } } ] }
+    ApiRequest_WorkflowStatusRequest:  { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/WorkflowStatusRequest' } } } ] }
+    ApiRequest_WorkflowCancelRequest:  { allOf: [ { $ref: '#/components/schemas/UserRequestContext' }, { properties: { payload: { $ref: '#/components/schemas/WorkflowCancelRequest' } } } ] }
 
     # --- Specific Response Envelopes ---
     ApiResponse_WorkflowStarted: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/WorkflowStartedResponse' } } } ] }
@@ -477,16 +481,3 @@ components:
           example:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
-
-  # -------------------- Security --------------------
-  securitySchemes:
-    # This section is for documentation purposes.
-    # The server will check for the HTTP header first and fallbacks to context in case the headers are missing.
-
-    # 1. The Developer's Identity Token (Who they are)
-    developerToken:
-      type: http
-      scheme: bearer
-      bearerFormat: "JWT or Opaque"
-      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."
-    # 2. The Developer's Request Signature (What they're attesting to)

--- a/api/workflows-interfaces.yaml
+++ b/api/workflows-interfaces.yaml
@@ -1,0 +1,513 @@
+openapi: 3.0.4
+info:
+  title: "Finternet API - Workflows"
+  description: |
+    The official API specification for the Finternet Workflows service. These
+    endpoints drive registered, multi-step workflow actions (started and signalled
+    through the Restate runtime), query their status, and cancel running instances.
+
+    ### Protocol-Agnostic Envelope
+    All API interactions use a standard JSON envelope.
+
+    **Request Envelope:**
+    ```json
+    {
+      "context": { ... },
+      "payload": { ... },
+      "signature": { ... } // Optional
+    }
+    ```
+
+    **Response Envelope (Success):**
+    ```json
+    {
+      "context": { ..., "status": "successful" },
+      "response": { ... }
+    }
+    ```
+
+    **Response Envelope (Error):**
+    ```json
+    {
+      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." },
+      "response": {} // Empty on error
+    }
+    ```
+    (Error details are in the context.error object)
+
+    ### Authentication and Authorization
+    This API uses a two-level authorization model contained within the `context`:
+
+    1.  **Platform-Level (Developer) Authentication:**
+        * `context.developerToken`: The B2B Developer's API Key/Token.
+        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
+
+    2.  **User-Level (End-User) Authorization:**
+        * `context.authorization`: The end-user's JWT session token (for session-based calls).
+        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
+
+    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
+
+    ### Per-endpoint authentication
+
+    All three endpoints require Developer auth **plus** an end-user JWT
+    (`context.authorization`). In addition:
+
+    * `POST /v1/workflows/execute` — requires an **active consent** (enforced by the
+      consent middleware) on top of the user JWT.
+    * `POST /v1/workflows/status` — user JWT only.
+    * `POST /v1/workflows/cancel` — requires an **active consent** on top of the user JWT.
+
+    ### RBAC Scopes
+
+    | Endpoint | Required scope |
+    |----------|----------------|
+    | `POST /v1/workflows/execute` | `workflows:create` |
+    | `POST /v1/workflows/status` | `workflows:view` |
+    | `POST /v1/workflows/cancel` | `workflows:manage` |
+
+    Calls failing the scope check return `403 PERMISSION_DENIED`.
+
+    ### Rate limiting
+
+    All endpoints are protected by a scope-tier sliding-window rate limiter; on
+    breach the response is `429 Too Many Requests` with a `Retry-After` header.
+  version: "1.0.0"
+servers:
+  - url: "https://foundry.finternetlab.io"
+    description: "Development Environment"
+  - url: "http://localhost:3000"
+    description: "Local Server"
+tags:
+  - name: "Workflow"
+    description: "Endpoints for executing, tracking, and cancelling registered workflow actions."
+
+# ===============================================================
+#   PATHS
+# ===============================================================
+
+paths:
+  /v1/workflows/execute:
+    post:
+      tags:
+        - "Workflow"
+      summary: "Execute a workflow action"
+      description: |
+        Executes a registered workflow action. If the action is the first step of the
+        workflow, a new workflow instance is started (**202 Accepted**, returning the
+        generated `workflowId`). For subsequent steps, the existing workflow is signalled
+        (**200 OK**, returning the signal/handler response). The `data` object is validated
+        dynamically against the workflow's registered JSON schema for the given action.
+
+        Requires Developer auth, an end-user JWT (`context.authorization`), and an active
+        consent.
+      security:
+        - developerToken: []
+        - developerSignature: []
+      x-scopes: [workflows:create]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_WorkflowExecuteRequest'
+            example:
+              context:
+                id: "api.workflow.execute"
+                version: "1.0"
+                ts: "2026-07-09T12:00:00Z"
+                msgId: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                workflow: "profile-update"
+                action: "initiate"
+                data:
+                  name: "Alice Smith-Jones"
+      responses:
+        '200':
+          description: "Workflow action signalled (subsequent step). Body is the handler/signal response, which is workflow-defined and may vary."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_WorkflowSignal'
+              example:
+                context:
+                  id: "api.workflow.execute"
+                  version: "1.0"
+                  ts: "2026-07-09T12:00:01Z"
+                  msgId: "b1b2c3d4-e5f6-7890-1234-567890abcdef"
+                  status: "successful"
+                response:
+                  workflowId: "profile-update-3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+                  action: "verify_current_ownership"
+                  status: "signaled"
+        '202':
+          description: "New workflow instance started (first step). Returns the generated workflow ID."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_WorkflowStarted'
+              example:
+                context:
+                  id: "api.workflow.execute"
+                  version: "1.0"
+                  ts: "2026-07-09T12:00:01Z"
+                  msgId: "c1b2c3d4-e5f6-7890-1234-567890abcdef"
+                  status: "accepted"
+                response:
+                  workflowId: "profile-update-3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+                  status: "accepted"
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '404':
+          description: "The named workflow is not registered."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+              example:
+                context: { id: "api.workflow.execute", version: "1.0", ts: "...", msgId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "workflow not found: profile-update" } }
+                response: {}
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+  /v1/workflows/status:
+    post:
+      tags:
+        - "Workflow"
+      summary: "Get workflow status"
+      description: |
+        Queries the current status of a running workflow by its instance ID. The response
+        body is the raw status payload returned by the workflow runtime (`getStatus`
+        query) and is therefore workflow-defined.
+
+        Requires Developer auth and an end-user JWT (`context.authorization`).
+      security:
+        - developerToken: []
+        - developerSignature: []
+      x-scopes: [workflows:view]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_WorkflowStatusRequest'
+            example:
+              context:
+                id: "api.workflow.status"
+                version: "1.0"
+                ts: "2026-07-09T12:10:00Z"
+                msgId: "d1b2c3d4-e5f6-7890-1234-567890abcdef"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                workflowId: "profile-update-3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+      responses:
+        '200':
+          description: "Current workflow status. The `response` object is workflow-defined (the runtime's getStatus payload)."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_WorkflowStatus'
+              example:
+                context:
+                  id: "api.workflow.status"
+                  version: "1.0"
+                  ts: "2026-07-09T12:10:01Z"
+                  msgId: "e1b2c3d4-e5f6-7890-1234-567890abcdef"
+                  status: "successful"
+                response:
+                  workflowId: "profile-update-3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+                  state: "running"
+                  currentStep: "verify_current_ownership"
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '404':
+          description: "No workflow found for the supplied ID (or the ID is malformed)."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+              example:
+                context: { id: "api.workflow.status", version: "1.0", ts: "...", msgId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "workflow not found: profile-update" } }
+                response: {}
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+  /v1/workflows/cancel:
+    post:
+      tags:
+        - "Workflow"
+      summary: "Cancel a running workflow"
+      description: |
+        Cancels a running workflow instance by rejecting all its outstanding promises.
+        Both the workflow instance ID and its workflow name are required (the name is
+        used to resolve the runtime service).
+
+        Requires Developer auth, an end-user JWT (`context.authorization`), and an active
+        consent.
+      security:
+        - developerToken: []
+        - developerSignature: []
+      x-scopes: [workflows:manage]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiRequest_WorkflowCancelRequest'
+            example:
+              context:
+                id: "api.workflow.cancel"
+                version: "1.0"
+                ts: "2026-07-09T12:20:00Z"
+                msgId: "f1b2c3d4-e5f6-7890-1234-567890abcdef"
+                developerToken: "fnt_..."
+                authorization: "Bearer eyJ..."
+              payload:
+                workflowId: "profile-update-3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+                workflowName: "profile-update"
+      responses:
+        '200':
+          description: "Workflow cancelled."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse_WorkflowCancel'
+              example:
+                context:
+                  id: "api.workflow.cancel"
+                  version: "1.0"
+                  ts: "2026-07-09T12:20:01Z"
+                  msgId: "a2b2c3d4-e5f6-7890-1234-567890abcdef"
+                  status: "successful"
+                response:
+                  workflowId: "profile-update-3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+                  status: "cancelled"
+        '400': { $ref: '#/components/responses/BadRequestError' }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
+        '404':
+          description: "No workflow found for the supplied name."
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+              example:
+                context: { id: "api.workflow.cancel", version: "1.0", ts: "...", msgId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "workflow not found: profile-update" } }
+                response: {}
+        '429': { $ref: '#/components/responses/RateLimitedError' }
+
+# ===============================================================
+#   COMPONENTS
+# ===============================================================
+
+components:
+  # -------------------- Schemas --------------------
+  schemas:
+    # --- API Envelope Schemas ---
+    Context:
+      type: object
+      required: [id, version, ts, msgId]
+      properties:
+        id: { type: string, example: "api.workflow.execute" }
+        version: { type: string, example: "1.0" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "B2B Developer API Key/Token" }
+        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "B2B Developer Signature (e.g., HMAC)" }
+        authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token." }
+    ResponseContext:
+      type: object
+      required: [id, version, ts, msgId, status]
+      properties:
+        id: { type: string, example: "api.workflow.execute" }
+        version: { type: string, example: "1.0" }
+        ts: { type: string, format: date-time }
+        msgId: { type: string, format: uuid }
+        transactionId: { type: string, format: uuid, nullable: true }
+        status: { type: string, enum: [successful, failed, pending, accepted], description: "`accepted` is used by 202 responses (e.g. a started workflow)." }
+        error:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/ErrorPayload'
+    Signature:
+      type: object
+      required: [key_id, jws]
+      properties:
+        key_id: { type: string, format: uuid, example: "0f8fad5b-d9cb-469f-a165-70867728950e", description: "UUID of the registered key that produced the signature." }
+        jws: { type: string, example: "eyJ...", description: "End-user's JWS of the payload object." }
+    ErrorPayload:
+      type: object
+      required: [code, message]
+      properties:
+        code: { type: string, example: "RESOURCE_NOT_FOUND" }
+        message: { type: string }
+
+    # --- Base Request/Response Schemas ---
+    RequestContext:
+      type: object
+      required: [context, payload]
+      properties:
+        context: { $ref: '#/components/schemas/Context' }
+        payload: { type: object }
+        signature:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Signature'
+    ApiResponse:
+      type: object
+      required: [context, response]
+      properties:
+        context: { $ref: '#/components/schemas/ResponseContext' }
+        response: { type: object }
+    ApiError:
+      type: object
+      required: [context, response]
+      properties:
+        context: { $ref: '#/components/schemas/ResponseContext' }
+        response: { type: object, description: "Always empty on error.", example: {} }
+
+    # --- Specific Request Envelopes ---
+    ApiRequest_WorkflowExecuteRequest: { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/WorkflowExecuteRequest' } } } ] }
+    ApiRequest_WorkflowStatusRequest:  { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/WorkflowStatusRequest' } } } ] }
+    ApiRequest_WorkflowCancelRequest:  { allOf: [ { $ref: '#/components/schemas/RequestContext' }, { properties: { payload: { $ref: '#/components/schemas/WorkflowCancelRequest' } } } ] }
+
+    # --- Specific Response Envelopes ---
+    ApiResponse_WorkflowStarted: { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/WorkflowStartedResponse' } } } ] }
+    ApiResponse_WorkflowSignal:  { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/WorkflowSignalResponse' } } } ] }
+    ApiResponse_WorkflowStatus:  { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/WorkflowStatusResponse' } } } ] }
+    ApiResponse_WorkflowCancel:  { allOf: [ { $ref: '#/components/schemas/ApiResponse' }, { properties: { response: { $ref: '#/components/schemas/WorkflowCancelResponse' } } } ] }
+
+    # --- Core Data Schemas (Payloads) ---
+    WorkflowExecuteRequest:
+      type: object
+      required: [workflow, action, data]
+      properties:
+        workflow: { type: string, minLength: 1, example: "profile-update", description: "Workflow name (e.g., profile-update)." }
+        action: { type: string, minLength: 1, example: "initiate", description: "Action/step name (e.g., initiate, verify_current_ownership)." }
+        data:
+          type: object
+          description: |
+            Action-specific data, validated dynamically against the workflow's registered
+            JSON schema. For delegation-create allow/deny actions this may include an
+            optional nested `allowedOperations` map: scope → dot-path → permitted
+            stringified values.
+          additionalProperties: true
+    WorkflowStatusRequest:
+      type: object
+      required: [workflowId]
+      properties:
+        workflowId: { type: string, minLength: 1, example: "profile-update-3f2504e0-4f89-41d3-9a0c-0305e82c3301", description: "The workflow instance ID." }
+    WorkflowCancelRequest:
+      type: object
+      required: [workflowId, workflowName]
+      properties:
+        workflowId: { type: string, minLength: 1, example: "profile-update-3f2504e0-4f89-41d3-9a0c-0305e82c3301", description: "The workflow instance ID." }
+        workflowName: { type: string, minLength: 1, example: "profile-update", description: "The workflow name (e.g., profile-update)." }
+
+    # --- Response payloads ---
+    WorkflowStartedResponse:
+      type: object
+      description: "Returned (202) when the action starts a new workflow instance."
+      properties:
+        workflowId: { type: string, example: "profile-update-3f2504e0-4f89-41d3-9a0c-0305e82c3301", description: "Generated as {workflowName}-{uuid}." }
+        status: { type: string, example: "accepted" }
+    WorkflowSignalResponse:
+      type: object
+      description: |
+        Returned (200) when the action signals an existing workflow. When the runtime
+        returns a body, that body is passed through verbatim (shape is workflow-defined);
+        otherwise this default object is returned. Modelled loosely — additional
+        properties are permitted.
+      additionalProperties: true
+      properties:
+        workflowId: { type: string, example: "profile-update-3f2504e0-4f89-41d3-9a0c-0305e82c3301" }
+        action: { type: string, example: "verify_current_ownership" }
+        status: { type: string, example: "signaled" }
+    WorkflowStatusResponse:
+      type: object
+      description: |
+        The raw status payload returned by the workflow runtime's getStatus query. Its
+        shape is workflow-defined; the fields shown are illustrative only.
+      additionalProperties: true
+    WorkflowCancelResponse:
+      type: object
+      description: "Returned (200) when a running workflow is cancelled."
+      properties:
+        workflowId: { type: string, example: "profile-update-3f2504e0-4f89-41d3-9a0c-0305e82c3301" }
+        status: { type: string, example: "cancelled" }
+
+  # -------------------- Responses --------------------
+  responses:
+    UnauthorizedError:
+      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "AUTHENTICATION_FAILED", message: "Token invalid or expired." } }
+            response: {}
+    ForbiddenError:
+      description: "Forbidden. Insufficient permissions (missing required scope) or consent not granted."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "PERMISSION_DENIED", message: "Insufficient permissions to perform this action." } }
+            response: {}
+    NotFoundError:
+      description: "Resource not found."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RESOURCE_NOT_FOUND", message: "The requested resource was not found." } }
+            response: {}
+    BadRequestError:
+      description: "Invalid request (e.g. schema validation failure, invalid workflow ID format, or invalid action for the workflow)."
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "Invalid request parameters." } }
+            response: {}
+    RateLimitedError:
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
+      headers:
+        Retry-After:
+          schema: { type: integer, description: "Seconds to wait before retrying." }
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+          example:
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
+            response: {}
+
+  # -------------------- Security --------------------
+  securitySchemes:
+    # This section is for documentation purposes.
+    # The server will check for the HTTP header first and fallbacks to context in case the headers are missing.
+
+    # 1. The Developer's Identity Token (Who they are)
+    developerToken:
+      type: http
+      scheme: bearer
+      bearerFormat: "JWT or Opaque"
+      description: |
+        A JWT or Opaque token that identifies the calling B2B developer/backend service.
+        This is passed in the standard `Authorization: Bearer <token>` header.
+        (This can also be passed in the `context.developerToken` as a fallback).
+
+    # 2. The Developer's Request Signature (What they're attesting to)
+    developerSignature:
+      type: apiKey
+      in: header
+      name: Signature
+      description: |
+        The IETF HTTP Signature (RFC 9421) used by B2B developers to ensure message
+        integrity and non-repudiation. This is passed in the `Signature` header.
+
+        Example Format:
+        Signature keyId="...",algorithm="...",created="...",expires="...",headers="...",signature="..."

--- a/api/workflows-interfaces.yaml
+++ b/api/workflows-interfaces.yaml
@@ -40,13 +40,10 @@ info:
 
     1.  **Platform-Level (Developer) Authentication:**
         * `context.developerToken`: The B2B Developer's API Key/Token.
-        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
 
     2.  **User-Level (End-User) Authorization:**
         * `context.authorization`: The end-user's JWT session token (for session-based calls).
         * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
-
-    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
 
     ### Per-endpoint authentication
 
@@ -103,7 +100,6 @@ paths:
         consent.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [workflows:create]
       requestBody:
         required: true
@@ -184,7 +180,6 @@ paths:
         Requires Developer auth and an end-user JWT (`context.authorization`).
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [workflows:view]
       requestBody:
         required: true
@@ -247,7 +242,6 @@ paths:
         consent.
       security:
         - developerToken: []
-        - developerSignature: []
       x-scopes: [workflows:manage]
       requestBody:
         required: true
@@ -313,8 +307,7 @@ components:
         ts: { type: string, format: date-time }
         msgId: { type: string, format: uuid }
         transactionId: { type: string, format: uuid, nullable: true, description: "ID for async operations" }
-        developerToken: { type: string, example: "fnt_...", nullable: true, description: "B2B Developer API Key/Token" }
-        developerSignature: { type: string, example: "t=...,v1=...", nullable: true, description: "B2B Developer Signature (e.g., HMAC)" }
+        developerToken: { type: string, example: "fnt_...", nullable: true, description: "Developer token identifying the calling application, sent in the request body." }
         authorization: { type: string, example: "Bearer eyJ...", nullable: true, description: "End-user's session token." }
     ResponseContext:
       type: object
@@ -495,17 +488,5 @@ components:
       type: http
       scheme: bearer
       bearerFormat: "JWT or Opaque"
-      description: |
-        A JWT or Opaque token that identifies the calling B2B developer/backend service.
-
+      description: "Developer token identifying the calling application, sent as `context.developerToken` in the request body."
     # 2. The Developer's Request Signature (What they're attesting to)
-    developerSignature:
-      type: apiKey
-      in: header
-      name: Signature
-      description: |
-        The IETF HTTP Signature (RFC 9421) used by B2B developers to ensure message
-        integrity and non-repudiation. This is passed in the `Signature` header.
-
-        Example Format:
-        Signature keyId="...",algorithm="...",created="...",expires="...",headers="...",signature="..."

--- a/api/workflows-interfaces.yaml
+++ b/api/workflows-interfaces.yaml
@@ -2,30 +2,61 @@ openapi: 3.0.4
 info:
   title: "Finternet API - Workflows"
   description: |
-    API specification for the Finternet Workflows service. These endpoints run
-    registered, multi-step workflow actions, query their status, and cancel running
-    instances.
+    The official API specification for the Finternet Workflows service. These
+    endpoints drive registered, multi-step workflow actions (started and signalled
+    through the Restate runtime), query their status, and cancel running instances.
 
-    ### Envelope
+    ### Protocol-Agnostic Envelope
+    All API interactions use a standard JSON envelope.
 
-    All endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
-    On failure `context.status` is `failed`, `context.error` carries a `code` and a
-    `message`, and `response` is empty.
+    **Request Envelope:**
+    ```json
+    {
+      "context": { ... },
+      "payload": { ... },
+      "signature": { ... } // Optional
+    }
+    ```
 
-    ### Authentication
+    **Response Envelope (Success):**
+    ```json
+    {
+      "context": { ..., "status": "successful" },
+      "response": { ... }
+    }
+    ```
 
-    * `context.developerToken`: the calling application's developer token. Required on
-      every endpoint.
-    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
-      `Signature` header.
-    * `context.authorization`: the end user's session token, required by the endpoints
-      that act on a signed-in user. Each operation states when it is needed.
+    **Response Envelope (Error):**
+    ```json
+    {
+      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." },
+      "response": {} // Empty on error
+    }
+    ```
+    (Error details are in the context.error object)
 
-    ### Per-endpoint requirements
+    ### Authentication and Authorization
+    This API uses a two-level authorization model contained within the `context`:
 
-    All three endpoints require a user session token. `/v1/workflows/execute` and
-    `/v1/workflows/cancel` additionally require the user to have accepted the current
-    Terms.
+    1.  **Platform-Level (Developer) Authentication:**
+        * `context.developerToken`: The B2B Developer's API Key/Token.
+        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
+
+    2.  **User-Level (End-User) Authorization:**
+        * `context.authorization`: The end-user's JWT session token (for session-based calls).
+        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
+
+    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
+
+    ### Per-endpoint authentication
+
+    All three endpoints require Developer auth **plus** an end-user JWT
+    (`context.authorization`). In addition:
+
+    * `POST /v1/workflows/execute`: requires an **active consent** (enforced by the
+      consent middleware) on top of the user JWT.
+    * `POST /v1/workflows/status`: user JWT only.
+    * `POST /v1/workflows/cancel`: requires an **active consent** on top of the user JWT.
 
     ### RBAC Scopes
 
@@ -35,13 +66,12 @@ info:
     | `POST /v1/workflows/status` | `workflows:view` |
     | `POST /v1/workflows/cancel` | `workflows:manage` |
 
-    Calls failing the scope check return `403`.
+    Calls failing the scope check return `403 FORBIDDEN`.
 
     ### Rate limiting
 
-    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
-    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
-    the tier assigned to the calling client.
+    All endpoints are protected by a scope-tier sliding-window rate limiter; on
+    breach the response is `429 Too Many Requests` with a `Retry-After` header.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -66,10 +96,11 @@ paths:
         Executes a registered workflow action. If the action is the first step of the
         workflow, a new workflow instance is started (**202 Accepted**, returning the
         generated `workflowId`). For subsequent steps, the existing workflow is signalled
-        (**200 OK**). The response body of a signalled step is defined by the workflow. The
-        `data` object is validated against the schema registered for that action.
+        (**200 OK**, returning the signal/handler response). The `data` object is validated
+        dynamically against the workflow's registered JSON schema for the given action.
 
-        Requires a user session token. The user must have accepted the current Terms.
+        Requires Developer auth, an end-user JWT (`context.authorization`), and an active
+        consent.
       security:
         - developerToken: []
         - developerSignature: []
@@ -95,7 +126,7 @@ paths:
                   name: "Alice Smith-Jones"
       responses:
         '200':
-          description: "Workflow action signalled (subsequent step). The response body is defined by the workflow."
+          description: "Workflow action signalled (subsequent step). Body is the handler/signal response, which is workflow-defined and may vary."
           content:
             application/json:
               schema:
@@ -150,7 +181,7 @@ paths:
         body is the raw status payload returned by the workflow runtime (`getStatus`
         query) and is therefore workflow-defined.
 
-        Requires a user session token.
+        Requires Developer auth and an end-user JWT (`context.authorization`).
       security:
         - developerToken: []
         - developerSignature: []
@@ -212,7 +243,8 @@ paths:
         Both the workflow instance ID and its workflow name are required (the name is
         used to resolve the runtime service).
 
-        Requires a user session token. The user must have accepted the current Terms.
+        Requires Developer auth, an end-user JWT (`context.authorization`), and an active
+        consent.
       security:
         - developerToken: []
         - developerSignature: []
@@ -383,9 +415,10 @@ components:
     WorkflowSignalResponse:
       type: object
       description: |
-        Returned (200) when the action signals an existing workflow. When the workflow
-        returns a body, it is passed through unchanged; otherwise this default object is
-        returned. Additional properties are permitted.
+        Returned (200) when the action signals an existing workflow. When the runtime
+        returns a body, that body is passed through verbatim (shape is workflow-defined);
+        otherwise this default object is returned. Modelled loosely; additional
+        properties are permitted.
       additionalProperties: true
       properties:
         workflowId: { type: string, example: "profile-update-3f2504e0-4f89-41d3-9a0c-0305e82c3301" }
@@ -407,7 +440,7 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
+      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -415,12 +448,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "The caller does not have the scope required by this endpoint, or the user has not accepted the current Terms."
+      description: "Forbidden. Insufficient permissions (missing required scope) or consent not granted."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -439,7 +472,9 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
-      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
+      description: |
+        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
+        response header indicates how long the caller should wait before retrying.
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }

--- a/api/workflows-interfaces.yaml
+++ b/api/workflows-interfaces.yaml
@@ -497,8 +497,6 @@ components:
       bearerFormat: "JWT or Opaque"
       description: |
         A JWT or Opaque token that identifies the calling B2B developer/backend service.
-        This is passed in the standard `Authorization: Bearer <token>` header.
-        (This can also be passed in the `context.developerToken` as a fallback).
 
     # 2. The Developer's Request Signature (What they're attesting to)
     developerSignature:

--- a/api/workflows-interfaces.yaml
+++ b/api/workflows-interfaces.yaml
@@ -66,7 +66,7 @@ info:
     | `POST /v1/workflows/status` | `workflows:view` |
     | `POST /v1/workflows/cancel` | `workflows:manage` |
 
-    Calls failing the scope check return `403 PERMISSION_DENIED`.
+    Calls failing the scope check return `403 FORBIDDEN`.
 
     ### Rate limiting
 
@@ -445,7 +445,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "AUTHENTICATION_FAILED", message: "Token invalid or expired." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
       description: "Forbidden. Insufficient permissions (missing required scope) or consent not granted."
@@ -453,7 +453,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "PERMISSION_DENIED", message: "Insufficient permissions to perform this action." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -469,7 +469,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_REQUEST", message: "Invalid request parameters." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
       description: |
@@ -482,7 +482,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "RATE_LIMITED", message: "Too many requests. Retry after 30s." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "TOO_MANY_REQUESTS", message: "Too many requests. Retry after 30s." } }
             response: {}
 
   # -------------------- Security --------------------

--- a/api/workflows-interfaces.yaml
+++ b/api/workflows-interfaces.yaml
@@ -2,61 +2,30 @@ openapi: 3.0.4
 info:
   title: "Finternet API - Workflows"
   description: |
-    The official API specification for the Finternet Workflows service. These
-    endpoints drive registered, multi-step workflow actions (started and signalled
-    through the Restate runtime), query their status, and cancel running instances.
+    API specification for the Finternet Workflows service. These endpoints run
+    registered, multi-step workflow actions, query their status, and cancel running
+    instances.
 
-    ### Protocol-Agnostic Envelope
-    All API interactions use a standard JSON envelope.
+    ### Envelope
 
-    **Request Envelope:**
-    ```json
-    {
-      "context": { ... },
-      "payload": { ... },
-      "signature": { ... } // Optional
-    }
-    ```
+    All endpoints use the standard envelope (`context`/`payload` → `context`/`response`).
+    On failure `context.status` is `failed`, `context.error` carries a `code` and a
+    `message`, and `response` is empty.
 
-    **Response Envelope (Success):**
-    ```json
-    {
-      "context": { ..., "status": "successful" },
-      "response": { ... }
-    }
-    ```
+    ### Authentication
 
-    **Response Envelope (Error):**
-    ```json
-    {
-      "context": { ..., "status": "failed", "error": {"code": "...", "message": "..." },
-      "response": {} // Empty on error
-    }
-    ```
-    (Error details are in the context.error object)
+    * `context.developerToken`: the calling application's developer token. Required on
+      every endpoint.
+    * `context.developerSignature`: optional request signature (RFC 9421), sent in the
+      `Signature` header.
+    * `context.authorization`: the end user's session token, required by the endpoints
+      that act on a signed-in user. Each operation states when it is needed.
 
-    ### Authentication and Authorization
-    This API uses a two-level authorization model contained within the `context`:
+    ### Per-endpoint requirements
 
-    1.  **Platform-Level (Developer) Authentication:**
-        * `context.developerToken`: The B2B Developer's API Key/Token.
-        * `context.developerSignature`: The B2B Developer's signature (e.g., RFC 9421) of the payload.
-
-    2.  **User-Level (End-User) Authorization:**
-        * `context.authorization`: The end-user's JWT session token (for session-based calls).
-        * `signature` (top-level): The end-user's JWS for critical, cryptographically-signed operations.
-
-    *Note for HTTP Clients:* As a convenience, the `developerToken` may be provided in the standard `Authorization: Bearer <token>` HTTP header, and the `developerSignature` in an `X-Finternet-Signature` header. The server will check the headers first, then fall back to the `context` object.
-
-    ### Per-endpoint authentication
-
-    All three endpoints require Developer auth **plus** an end-user JWT
-    (`context.authorization`). In addition:
-
-    * `POST /v1/workflows/execute` — requires an **active consent** (enforced by the
-      consent middleware) on top of the user JWT.
-    * `POST /v1/workflows/status` — user JWT only.
-    * `POST /v1/workflows/cancel` — requires an **active consent** on top of the user JWT.
+    All three endpoints require a user session token. `/v1/workflows/execute` and
+    `/v1/workflows/cancel` additionally require the user to have accepted the current
+    Terms.
 
     ### RBAC Scopes
 
@@ -66,12 +35,13 @@ info:
     | `POST /v1/workflows/status` | `workflows:view` |
     | `POST /v1/workflows/cancel` | `workflows:manage` |
 
-    Calls failing the scope check return `403 FORBIDDEN`.
+    Calls failing the scope check return `403`.
 
     ### Rate limiting
 
-    All endpoints are protected by a scope-tier sliding-window rate limiter; on
-    breach the response is `429 Too Many Requests` with a `Retry-After` header.
+    Every request is rate limited. Requests over the limit return `429 Too Many Requests`
+    with a `Retry-After` header giving the number of seconds to wait. The limit depends on
+    the tier assigned to the calling client.
   version: "1.0.0"
 servers:
   - url: "https://foundry.finternetlab.io"
@@ -96,11 +66,10 @@ paths:
         Executes a registered workflow action. If the action is the first step of the
         workflow, a new workflow instance is started (**202 Accepted**, returning the
         generated `workflowId`). For subsequent steps, the existing workflow is signalled
-        (**200 OK**, returning the signal/handler response). The `data` object is validated
-        dynamically against the workflow's registered JSON schema for the given action.
+        (**200 OK**). The response body of a signalled step is defined by the workflow. The
+        `data` object is validated against the schema registered for that action.
 
-        Requires Developer auth, an end-user JWT (`context.authorization`), and an active
-        consent.
+        Requires a user session token. The user must have accepted the current Terms.
       security:
         - developerToken: []
         - developerSignature: []
@@ -126,7 +95,7 @@ paths:
                   name: "Alice Smith-Jones"
       responses:
         '200':
-          description: "Workflow action signalled (subsequent step). Body is the handler/signal response, which is workflow-defined and may vary."
+          description: "Workflow action signalled (subsequent step). The response body is defined by the workflow."
           content:
             application/json:
               schema:
@@ -181,7 +150,7 @@ paths:
         body is the raw status payload returned by the workflow runtime (`getStatus`
         query) and is therefore workflow-defined.
 
-        Requires Developer auth and an end-user JWT (`context.authorization`).
+        Requires a user session token.
       security:
         - developerToken: []
         - developerSignature: []
@@ -243,8 +212,7 @@ paths:
         Both the workflow instance ID and its workflow name are required (the name is
         used to resolve the runtime service).
 
-        Requires Developer auth, an end-user JWT (`context.authorization`), and an active
-        consent.
+        Requires a user session token. The user must have accepted the current Terms.
       security:
         - developerToken: []
         - developerSignature: []
@@ -415,10 +383,9 @@ components:
     WorkflowSignalResponse:
       type: object
       description: |
-        Returned (200) when the action signals an existing workflow. When the runtime
-        returns a body, that body is passed through verbatim (shape is workflow-defined);
-        otherwise this default object is returned. Modelled loosely — additional
-        properties are permitted.
+        Returned (200) when the action signals an existing workflow. When the workflow
+        returns a body, it is passed through unchanged; otherwise this default object is
+        returned. Additional properties are permitted.
       additionalProperties: true
       properties:
         workflowId: { type: string, example: "profile-update-3f2504e0-4f89-41d3-9a0c-0305e82c3301" }
@@ -440,7 +407,7 @@ components:
   # -------------------- Responses --------------------
   responses:
     UnauthorizedError:
-      description: "Authentication failed. Can be invalid Developer Token OR invalid User JWT."
+      description: "Authentication failed. The developer token or the user session token is missing, invalid or expired."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
@@ -448,12 +415,12 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "UNAUTHORIZED", message: "Token invalid or expired." } }
             response: {}
     ForbiddenError:
-      description: "Forbidden. Insufficient permissions (missing required scope) or consent not granted."
+      description: "The caller does not have the scope required by this endpoint, or the user has not accepted the current Terms."
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ApiError' }
           example:
-            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "FORBIDDEN", message: "Insufficient permissions to perform this action." } }
+            context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "CLIENT_INSUFFICIENT_SCOPE", message: "service account does not have required scope" } }
             response: {}
     NotFoundError:
       description: "Resource not found."
@@ -472,9 +439,7 @@ components:
             context: { id: "...", ts: "...", msgId: "...", transactionId: "...", status: "failed", error: { code: "INVALID_INPUT", message: "Invalid request parameters." } }
             response: {}
     RateLimitedError:
-      description: |
-        Request exceeded the scope-tier sliding-window rate limit. The `Retry-After`
-        response header indicates how long the caller should wait before retrying.
+      description: "Too many requests. The `Retry-After` header gives the number of seconds to wait before retrying."
       headers:
         Retry-After:
           schema: { type: integer, description: "Seconds to wait before retrying." }


### PR DESCRIPTION
## What

Syncs the OpenAPI reference specs with the current `units-api` (developer-facing surface). These render the interactive API Reference on the docs site.

## Changes

- **Fixed key-management paths**: `/v1/keys/*` → `/v1/account/keys/create`, `/v1/account/sign`, `GET /v1/account/keys`, `/v1/account/keys/rotate`.
- **Added** account `otp/generate`/`otp/verify`/`pii/decrypt`; transaction proofs (`proof`, `proof/leaf`, `proof/verify`); the `/v1/adapter/*` registry; and new specs for **token-program, scopes, terms, workflows**.
- **Federation developer-facing surface**: transact `signed_lock_envelope`; real `transaction/status` fields; added `/v1/transactions/status` and `/v1/registry/lookup-address`.
- **Per-operation audit** against the request JSON schemas + Go response structs — removed fabricated fields and corrected names/types/required/status codes:
  - registry: invented chain `adapters[]` removed; `sort` → `sortBy`; response `identities`; `registry-chains`/`-wallets` scopes.
  - clients: invented `filters`/`pagination` removed; `label`/`expiresAt` → `name`/`expiresInDays`.
  - delegations: `operation`/`amount` → real `{filter}` and `{tokenId}`.
  - accounts: keys rewritten from a wrong DID model to `chainId`/`publicKey`/…; `update` `{name,mobile}` → `{action,data}`.
  - token: `token/add` fabricated `provider` fields → real schema; `transaction get/search` fabricated log → `TransactionResponse`; `tokenclasses` invented `chainDeployments` removed; transact `amount` → `value`.
- Envelope examples: developer-token prefix `fnt_`; signature `{key_id, jws}`.

All 12 specs validate (parse, `openapi`, paths, `$ref`s resolve).

## Notes for reviewer / follow-up

- **GitBook wiring**: the 4 **new** specs (token-program, scopes, terms, workflows) still need `api-reference/SUMMARY.md` nav entries in the docs repo **plus** a one-time GitBook registration of those spec names. The **edited** specs auto-update on merge.
- **`x-scopes`** annotations are sourced from the e2e seed (scopes are registry-authoritative at runtime). `lookup-address` and `transactions/status` have no seeded scope, so they're left un-annotated rather than guessed.
- **`/v1/account/keys/register`** appears in both `accounts` and `key-management` specs — this mirrors a real code-level route collision (two controllers register the same path). Worth a code fix.
- Peer/internal federation endpoints (`/v1/ulip/*`, `/v1/internal/*`) are intentionally excluded as not developer-facing.
